### PR TITLE
Simplify dev config

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -13,19 +13,6 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: Create .env file with credentials
-        uses: SpicyPizza/create-envfile@v1
-        with:
-          envkey_REACT_APP_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
-          envkey_REACT_APP_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
-          envkey_REACT_APP_DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          envkey_REACT_APP_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
-          envkey_REACT_APP_FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
-          envkey_REACT_APP_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
-          envkey_REACT_APP_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
-          file_name: .env.production.local
-      - name: Move .env file to eisbuk-admin
-        run: mv .env.production.local eisbuk-admin
       - name: Install requirements
         run: yarn --cwd eisbuk-admin
       - name: build storybook and upload

--- a/eisbuk-admin/.env
+++ b/eisbuk-admin/.env
@@ -2,3 +2,10 @@ SKIP_PREFLIGHT_CHECK=true
 
 STORYBOOK_DATE=2021-01-18
 STORYBOOK_IS_STORYBOOK=true
+
+# App id specified in .firebaserc
+REACT_APP_FIREBASE_APP_ID=eisbuk-e6b2a
+# Any string will do against the emulators suite
+REACT_APP_FIREBASE_API_KEY=fake-key
+# Dummy value
+REACT_APP_FIREBASE_MESSAGING_SENDER_ID=1122334455

--- a/eisbuk-admin/src/store/index.ts
+++ b/eisbuk-admin/src/store/index.ts
@@ -59,10 +59,7 @@ const db = firebase.firestore();
 const functions = firebase.functions();
 
 if (__isDev__) {
-  db.settings({
-    host: __databaseURL__,
-    ssl: false,
-  });
+  db.useEmulator("localhost", 8080);
   firebase.auth().useEmulator("http://localhost:9099/");
   functions.useEmulator("localhost", 5001);
   console.warn("Using emulator for functions and authentication");

--- a/eisbuk-admin/yarn.lock
+++ b/eisbuk-admin/yarn.lock
@@ -5647,11 +5647,6 @@ babel-plugin-syntax-object-rest-spread@^6.8.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
   integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
 
-babel-plugin-transform-inline-environment-variables@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-0.4.3.tgz#a3b09883353be8b5e2336e3ff1ef8a5d93f9c489"
-  integrity sha1-o7CYgzU76LXiM24/8e+KXZP5xIk=
-
 babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"


### PR DESCRIPTION
This PR makes it possible to run the app in development without an additional `.env.development.local` file.
It also allows to run the storybook without additional configs.

There's an unrelated change that IMO is a small thing and didn't grant a separate PR: a package is removed from `yarn.lock`.