### PR TITLE
Deploy preview via github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           # Run the `deploy:preview` script, passing the current git branch to be used for the name
           # of the preview channel
           yarn --cwd eisbuk-admin deploy:preview -- $(git branch --show-current) |
-            sed -E '/hosting:channel/s/^/::warning file=url,line=1,col=1::/'
+            sed -E '/hosting:channel/s/^(.*)$/\1\n::warning file=url,line=1,col=1::\1/'
           # and use a workflow command to make the deployed URLs more prominent
           # see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message
           # for all lines that contain hosting:channel (the `/hosting:channel/` part) replace the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           # of the preview channel
           yarn --cwd eisbuk-admin deploy:preview -- ${GITHUB_REF_SLUG_URL:-dev} | tee deploy.output
           # To pass the info to a later task, use the $GITHUB_ENV file
-          cat deploy.output | grep hosting:channel:[^d]|sed -e "s/\x1b\[[0-9;]*m//g;s|.*(||;s|)[^h]*|=|" >> $GITHUB_ENV
+          cat deploy.output | grep 'hosting:channel:.*https://'|sed -e "s/\x1b\[[0-9;]*m//g;s|.*(||;s|)[^h]*|=|" >> $GITHUB_ENV
           # documented here: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,11 @@ jobs:
           # Run the `deploy:preview` script, passing the current git branch to be used for the name
           # of the preview channel
           yarn --cwd eisbuk-admin deploy:preview -- $(git branch --show-current) |
-            sed -E '/hosting:channel/s/^/::debug::/'
+            sed -E '/hosting:channel/s/^/::warning file=url,line=1,col=1::/'
           # and use a workflow command to make the deployed URLs more prominent
-          # see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-debug-message
+          # see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message
           # for all lines that contain hosting:channel (the `/hosting:channel/` part) replace the
-          # beginning of the line (`^`) with the string `::debug::`.
+          # beginning of the line (`^`) with the string `::warning file=url,line=1,col=1::`.
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build and deploy preview
 
 on:
   - push
@@ -23,6 +23,10 @@ jobs:
         run: ./eisbuk-install.sh
       - name: Build app
         run: yarn --cwd eisbuk-admin build
+      - name: Deploy preview channel
+        run: yarn --cwd eisbuk-admin deploy:preview -- $(git branch --show-current)
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}
 
   test_v14:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,14 @@ jobs:
         run: ./eisbuk-install.sh
       - name: Build app
         run: yarn --cwd eisbuk-admin build
+        env:
+          REACT_APP_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          REACT_APP_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          REACT_APP_DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          REACT_APP_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
+          REACT_APP_FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
+          REACT_APP_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
+          REACT_APP_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
       - name: Deploy preview channel
         run: |
           # Run the `deploy:preview` script, passing the current git branch to be used for the name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,13 @@ jobs:
       - name: Build app
         run: yarn --cwd eisbuk-admin build
       - name: Deploy preview channel
-        run: yarn --cwd eisbuk-admin deploy:preview -- $(git branch --show-current)
+        run: |
+          # Run the `deploy:preview` script, passing the current git branch to be used for the name
+          # of the preview channel
+          yarn --cwd eisbuk-admin deploy:preview -- $(git branch --show-current) |
+            sed -E 's/^(...hosting:channel)/::debug::\1/'
+          # and use a workflow command to make the deployed URLs more prominent
+          # see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-debug-message
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,10 @@ jobs:
       - name: Deploy preview channel
         id: deploy
         run: |
+          set -e
           # Run the `deploy:preview` script, passing the current git branch to be used for the name
           # of the preview channel
-          yarn --cwd eisbuk-admin deploy:preview -- ${{ env.GITHUB_HEAD_REF_SLUG_URL }} |
+          yarn --cwd eisbuk-admin deploy:preview -- ${GITHUB_HEAD_REF_SLUG_URL:-dev} |
             sed -E '/hosting:channel/s|^(.*\(([^\)]+)\).*(https://[^ ]+).*)$|\1\n::set-output name=\2::\3|'
           # and use a workflow command to save the URLs for the next step to publish
           # see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
           set -e
           # Run the `deploy:preview` script, passing the current git branch to be used for the name
           # of the preview channel
-          yarn --cwd eisbuk-admin deploy:preview -- ${GITHUB_HEAD_REF_SLUG_URL:-dev} | tee deploy.output
+          yarn --cwd eisbuk-admin deploy:preview -- ${GITHUB_REF_SLUG_URL:-dev} | tee deploy.output
           # To pass the info to a later task, use the $GITHUB_ENV file
           cat deploy.output | grep hosting:channel:[^d]|sed -e "s/\x1b\[[0-9;]*m//g;s|.*(||;s|)[^h]*|=|" >> $GITHUB_ENV
           # documented here: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,19 +37,11 @@ jobs:
         id: deploy
         run: |
           set -e
-          echo ::set-output name=eisbuk::Not set
-          echo ::set-output name=igorice::Not set
-          echo ::save-state name=urls::This is a state
           # Run the `deploy:preview` script, passing the current git branch to be used for the name
           # of the preview channel
           yarn --cwd eisbuk-admin deploy:preview -- ${GITHUB_HEAD_REF_SLUG_URL:-dev} | tee deploy.output
-          cat deploy.output | grep hosting:channel:[^d] |
-            sed -E 's|^(.*\(([^\)]+)\).*(https://[^ ]+).*)$|\1\n::set-output name=\2::\3|'
-          # and use a workflow command to save the URLs for the next step to publish
-          # see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message
-
-          # Ok, the above doesn't seem to work. I'm trying other ways, like this:
-          cat deploy.output | grep hosting:channel:[^d]|sed -e "s/\x1b\[[0-9;]*m//g;s|.*(||;s|)[^h]*|='|;s/$/'/" >> $GITHUB_ENV
+          # To pass the info to a later task, use the $GITHUB_ENV file
+          cat deploy.output | grep hosting:channel:[^d]|sed -e "s/\x1b\[[0-9;]*m//g;s|.*(||;s|)[^h]*|=|" >> $GITHUB_ENV
           # documented here: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}
@@ -70,11 +62,9 @@ jobs:
           comment-id: ${{ steps.findcomment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Deployed URLs: (`STATE_urls`: ${{ env.STATE_urls }})
-              * Igorice: ${{ steps.deploy.outputs.igorice }}
-              * Eisbuk: ${{ steps.deploy.outputs.eisbuk }}
-              * Igorice (from env): ${{ env.igorice }}
-              * Eisbuk (from env): ${{ env.eisbuk }}
+            Deployed URLs:
+              * Igorice: ${{ env.igorice }}
+              * Eisbuk: ${{ env.eisbuk }}
           reaction-type: 'rocket'
           edit-mode: replace
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,12 +37,20 @@ jobs:
         id: deploy
         run: |
           set -e
+          echo ::set-output name=eisbuk::Not set
+          echo ::set-output name=igorice::Not set
+          echo ::save-state name=urls::This is a state
           # Run the `deploy:preview` script, passing the current git branch to be used for the name
           # of the preview channel
-          yarn --cwd eisbuk-admin deploy:preview -- ${GITHUB_HEAD_REF_SLUG_URL:-dev} |
-            sed -E '/hosting:channel/s|^(.*\(([^\)]+)\).*(https://[^ ]+).*)$|\1\n::set-output name=\2::\3|'
+          yarn --cwd eisbuk-admin deploy:preview -- ${GITHUB_HEAD_REF_SLUG_URL:-dev} | tee deploy.output
+          cat deploy.output | grep hosting:channel:[^d] |
+            sed -E 's|^(.*\(([^\)]+)\).*(https://[^ ]+).*)$|\1\n::set-output name=\2::\3|'
           # and use a workflow command to save the URLs for the next step to publish
           # see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message
+
+          # Ok, the above doesn't seem to work. I'm trying other ways, like this:
+          cat deploy.output | grep hosting:channel:[^d]|sed -e "s/\x1b\[[0-9;]*m//g;s|.*(||;s|)[^h]*|='|;s/$/'/" >> $GITHUB_ENV
+          # documented here: https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}
       - name: Find Comment
@@ -62,9 +70,11 @@ jobs:
           comment-id: ${{ steps.findcomment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Deployed URLs:
+            Deployed URLs: (`STATE_urls`: ${{ env.STATE_urls }})
               * Igorice: ${{ steps.deploy.outputs.igorice }}
               * Eisbuk: ${{ steps.deploy.outputs.eisbuk }}
+              * Igorice (from env): ${{ env.igorice }}
+              * Eisbuk (from env): ${{ env.eisbuk }}
           reaction-type: 'rocket'
           edit-mode: replace
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,18 +44,27 @@ jobs:
           # see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: findcomment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Build output
+
       - name: Add preview channel URL to comment on PR
         uses: peter-evans/create-or-update-comment@v1
         if: ${{ github.event.pull_request.number }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          comment-id: ${{ steps.findcomment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ```
-            Igorice: ${{ steps.deploy.outputs.igorice }}
-            Eisbuk: ${{ steps.deploy.outputs.eisbuk }}
-            ```
+            Deployed URLs:
+              * Igorice: ${{ steps.deploy.outputs.igorice }}
+              * Eisbuk: ${{ steps.deploy.outputs.eisbuk }}
           reaction-type: 'rocket'
+          edit-mode: replace
 
   test_v14:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,13 @@ jobs:
           REACT_APP_FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
           REACT_APP_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
           REACT_APP_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v3.x
       - name: Deploy preview channel
         run: |
           # Run the `deploy:preview` script, passing the current git branch to be used for the name
           # of the preview channel
-          yarn --cwd eisbuk-admin deploy:preview -- $(git branch --show-current) |
+          yarn --cwd eisbuk-admin deploy:preview -- ${{ env.GITHUB_HEAD_REF_SLUG_URL }} |
             sed -E '/hosting:channel/s/^(.*)$/\1\n::warning file=url,line=1,col=1::\1/'
           # and use a workflow command to make the deployed URLs more prominent
           # see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,11 @@ jobs:
       - name: Install and link packages
         run: ./eisbuk-install.sh
       - name: Build app
-        run: yarn --cwd eisbuk-admin build
+        run: |
+          yarn --cwd eisbuk-admin build | tee build.output
+          echo "BUILD_STATS<<EOF" >> $GITHUB_ENV
+          cat build.output|grep File\ sizes -A5 >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
         env:
           REACT_APP_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           REACT_APP_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
@@ -65,6 +69,9 @@ jobs:
             Deployed URLs:
               * Igorice: ${{ env.igorice }}
               * Eisbuk: ${{ env.eisbuk }}
+            ```
+            ${{ env.BUILD_STATS }}
+            ```
           reaction-type: 'rocket'
           edit-mode: replace
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,7 @@ jobs:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}
       - name: Add preview channel URL to comment on PR
         uses: peter-evans/create-or-update-comment@v1
+        if: ${{ github.event.pull_request.number }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,11 @@ jobs:
           # Run the `deploy:preview` script, passing the current git branch to be used for the name
           # of the preview channel
           yarn --cwd eisbuk-admin deploy:preview -- $(git branch --show-current) |
-            sed -E 's/^(...hosting:channel)/::debug::\1/'
+            sed -E '/hosting:channel/s/^/::debug::/'
           # and use a workflow command to make the deployed URLs more prominent
           # see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-debug-message
+          # for all lines that contain hosting:channel (the `/hosting:channel/` part) replace the
+          # beginning of the line (`^`) with the string `::debug::`.
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: Build output
+          body-includes: Deployed URLs
 
       - name: Add preview channel URL to comment on PR
         uses: peter-evans/create-or-update-comment@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
             ```
             ${{ env.BUILD_STATS }}
             ```
-          reaction-type: 'rocket'
+          reactions: heart, hooray, laugh, rocket
           edit-mode: replace
 
   test_v14:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}
       - name: Find Comment
         uses: peter-evans/find-comment@v1
+        if: ${{ github.event.pull_request.number }}
         id: findcomment
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,17 +34,27 @@ jobs:
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v3.x
       - name: Deploy preview channel
+        id: deploy
         run: |
           # Run the `deploy:preview` script, passing the current git branch to be used for the name
           # of the preview channel
           yarn --cwd eisbuk-admin deploy:preview -- ${{ env.GITHUB_HEAD_REF_SLUG_URL }} |
-            sed -E '/hosting:channel/s/^(.*)$/\1\n::warning file=url,line=1,col=1::\1/'
-          # and use a workflow command to make the deployed URLs more prominent
+            sed -E '/hosting:channel/s|^(.*\(([^\)]+)\).*(https://[^ ]+).*)$|\1\n::set-output name=\2::\3|'
+          # and use a workflow command to save the URLs for the next step to publish
           # see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message
-          # for all lines that contain hosting:channel (the `/hosting:channel/` part) replace the
-          # beginning of the line (`^`) with the string `::warning file=url,line=1,col=1::`.
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}
+      - name: Add preview channel URL to comment on PR
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ```
+            Igorice: ${{ steps.deploy.outputs.igorice }}
+            Eisbuk: ${{ steps.deploy.outputs.eisbuk }}
+            ```
+          reaction-type: 'rocket'
 
   test_v14:
     runs-on: ubuntu-latest

--- a/eisbuk-admin/package.json
+++ b/eisbuk-admin/package.json
@@ -50,6 +50,7 @@
     "test:ci": "npm --prefix \"./functions\" run build && firebase -c firebase-testing.json  emulators:exec --project eisbuk -- 'yarn run jest --forceExit --runInBand'",
     "deploy:eisbuk": "firebase deploy --project eisbuk --only hosting:eisbuk",
     "deploy:production": "firebase deploy --project eisbuk --only hosting:igorice; firebase deploy --project eisbuk --except hosting",
+    "deploy:preview": "firebase --project eisbuk hosting:channel:deploy",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public",

--- a/eisbuk-admin/src/config/envInfo.ts
+++ b/eisbuk-admin/src/config/envInfo.ts
@@ -5,6 +5,20 @@ let isDev: boolean;
 let functionsZone: string | undefined;
 let ORGANIZATION: string;
 
+/**
+ * @param  {string} location (for instance website.web.app)
+ * @returns string
+
+Firebase hosting has a concept of "preview channels":
+https://firebase.google.com/docs/hosting/test-preview-deploy
+When deployed this way, apps will be served on a URL derived from the main
+hosting URL. For instance, for appname.web.app, a preview channel named new-feature
+can be published at https://appname--new-feature-randomhash.web.app/
+*/
+function getOrgFromLocation(location: string): string {
+  return location.replace(/--[^.]+/, "");
+}
+
 if (!__eisbukSite__) {
   isDev =
     window.location.port !== "" &&
@@ -13,7 +27,7 @@ if (!__eisbukSite__) {
 
   functionsZone = isDev ? undefined : "europe-west6";
 
-  ORGANIZATION = window.location.hostname;
+  ORGANIZATION = getOrgFromLocation(window.location.hostname);
 } else {
   isDev = false;
   functionsZone = "europe-west6";
@@ -23,4 +37,4 @@ if (!__eisbukSite__) {
   );
 }
 
-export { isDev, functionsZone, ORGANIZATION };
+export { isDev, functionsZone, getOrgFromLocation, ORGANIZATION };

--- a/eisbuk-admin/src/tests/envInfo.test.tsx
+++ b/eisbuk-admin/src/tests/envInfo.test.tsx
@@ -1,0 +1,13 @@
+import { getOrgFromLocation } from "@/config/envInfo";
+
+it("splits on the first double dash and returns the first part", async () => {
+  expect(getOrgFromLocation("no-double-dashes.web.app")).toEqual(
+    "no-double-dashes.web.app"
+  );
+  expect(getOrgFromLocation("one--double-dash-randomhash.web.app")).toEqual(
+    "one.web.app"
+  );
+  expect(getOrgFromLocation("two--double--dashes-randomhash.web.app")).toEqual(
+    "two.web.app"
+  );
+});


### PR DESCRIPTION
Firebase hosting [supports deploying temporary builds](https://firebase.google.com/docs/hosting/test-preview-deploy).

This PR automates the process, deploying a temporary build on every push, named after the branch.
If there is a standing PR for the current branch a comment will be created or updated there, including the URLs of the deployed preview channels and stats about the build size.