### PR TITLE
fix: snackbars unclickable and have no spaces in between

### DIFF
--- a/eisbuk-admin/src/App.tsx
+++ b/eisbuk-admin/src/App.tsx
@@ -18,14 +18,6 @@ import Notifier from "@/components/Notifier";
 import { currentTheme } from "@/themes";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 
-/**
- * The styles part is a, hopefully, temporary workaround to a
- * bug in notistack that causes snackbars to be unclickable.
- * Notistack v.1.0.10 fixes that bug however,
- * it doesn't work with materialUI v.5
- * The bug is caused by the root class not having the 'pointerEvents'
- * property set to 'all', 'root' class here overrides that.
- */
 const App: React.FC = () => {
   const classes = useStyles();
 
@@ -49,11 +41,19 @@ const App: React.FC = () => {
 };
 
 // ***** Region Styles ***** //
-type Theme = typeof currentTheme;
-
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     margin: theme.spacing(0.75, 0),
+
+    /**
+     * This is, hopefully, temporary workaround to a
+     * bug in notistack that causes snackbars to be unclickable.
+     * Notistack v.1.0.10 fixes that bug, however,
+     * it only works with materialUI v^5, which is in pre-release currently.
+     * The bug is caused by the root class not having the 'pointerEvents'
+     * property set to 'all', 'root' class here overrides that.
+     * @TODO upgade MUI, notistack and remove this when MUI v5 becomes the LTS
+     */
     pointerEvents: "all",
   },
 }));

--- a/eisbuk-admin/src/App.tsx
+++ b/eisbuk-admin/src/App.tsx
@@ -16,14 +16,17 @@ import AppContent from "@/AppContent";
 import Notifier from "@/components/Notifier";
 
 import { currentTheme } from "@/themes";
+import makeStyles from "@material-ui/core/styles/makeStyles";
 
 const App: React.FC = () => {
+  const classes = useStyles();
+
   return (
     <Provider store={store}>
       <ReactReduxFirebaseProvider {...rrfProps}>
         <ThemeProvider theme={currentTheme}>
           <MuiPickersUtilsProvider utils={LuxonUtils}>
-            <SnackbarProvider maxSnack={3}>
+            <SnackbarProvider className={classes.root} maxSnack={3}>
               <Notifier />
               <CssBaseline />
               <BrowserRouter>
@@ -37,4 +40,14 @@ const App: React.FC = () => {
   );
 };
 
+// ***** Region Styles ***** //
+type Theme = typeof currentTheme;
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    margin: theme.spacing(0.75, 0),
+    pointerEvents: "all",
+  },
+}));
+// ***** End Region Styles ***** //
 export default App;

--- a/eisbuk-admin/src/App.tsx
+++ b/eisbuk-admin/src/App.tsx
@@ -18,6 +18,14 @@ import Notifier from "@/components/Notifier";
 import { currentTheme } from "@/themes";
 import makeStyles from "@material-ui/core/styles/makeStyles";
 
+/**
+ * The styles part is a, hopefully, temporary workaround to a
+ * bug in notistack that causes snackbars to be unclickable.
+ * Notistack v.1.0.10 fixes that bug however,
+ * it doesn't work with materialUI v.5
+ * The bug is caused by the root class not having the 'pointerEvents'
+ * property set to 'all', 'root' class here overrides that.
+ */
 const App: React.FC = () => {
   const classes = useStyles();
 


### PR DESCRIPTION
Fixes: #153 
Turns out this is a bug in `Notistack` which is solved in version 1.0.10, however this update only works with MaterialUI version 5 which is currently unstable, so I fixed the bug overriding the MUI root class which is passed to the `SnackbarProvider` component.