### PR TITLE
Fix production deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,21 +24,16 @@ jobs:
           key: ${{ runner.os }}-modules-v12-${{ hashFiles('**/yarn.lock') }}
       - name: Install and link packages
         run: yarn
-      - name: Create .env file with credentials
-        uses: SpicyPizza/create-envfile@v1
-        with:
-          envkey_REACT_APP_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
-          envkey_REACT_APP_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
-          envkey_REACT_APP_DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          envkey_REACT_APP_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
-          envkey_REACT_APP_FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
-          envkey_REACT_APP_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
-          envkey_REACT_APP_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
-          file_name: .env.production.local
-      - name: Move .env file to eisbuk-admin
-        run: mv .env.production.local eisbuk-admin
       - name: Build app
         run: yarn --cwd eisbuk-admin build
+        env:
+          REACT_APP_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          REACT_APP_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          REACT_APP_DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          REACT_APP_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
+          REACT_APP_FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
+          REACT_APP_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
+          REACT_APP_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
       - name: Deploy to firebase
         run: yarn --cwd eisbuk-admin deploy:production
         env: # Or as an environment variable

--- a/eisbuk-admin/.gitignore
+++ b/eisbuk-admin/.gitignore
@@ -35,8 +35,12 @@ yarn-error.log*
 build-storybook.log*
 
 # IDE specific
-.vscode\
+.vscode
 
 # Test result files
 junit.xml
 coverage
+
+# Built app
+/dist
+/build

--- a/eisbuk-admin/src/lib/constants.ts
+++ b/eisbuk-admin/src/lib/constants.ts
@@ -14,7 +14,7 @@ export const __isStorybook__ = Boolean(process.env.STORYBOOK_IS_STORYBOOK);
 // env info variable
 // this will return true if env is "test" as well or if the `BUILD_ENV` variable has a value
 export const __isDev__ =
-  process.env.NODE_ENV !== "production" || process.env.BUILD_ENV;
+  process.env.NODE_ENV !== "production" || Boolean(process.env.BUILD_ENV);
 
 // check for explicit "test" environment
 export const __isTest__ = process.env.NODE_ENV === "test";

--- a/eisbuk-admin/src/lib/constants.ts
+++ b/eisbuk-admin/src/lib/constants.ts
@@ -14,7 +14,7 @@ export const __isStorybook__ = Boolean(process.env.STORYBOOK_IS_STORYBOOK);
 // env info variable
 // this will return true if env is "test" as well or if the `BUILD_ENV` variable has a value
 export const __isDev__ =
-  process.env.NODE_ENV !== "production" || process.env.BUILD_ENV !== "";
+  process.env.NODE_ENV !== "production" || process.env.BUILD_ENV;
 
 // check for explicit "test" environment
 export const __isTest__ = process.env.NODE_ENV === "test";


### PR DESCRIPTION
Production was broken. It had the `__isDev__` flag set to `true`.
The reason for this was the condition inspecting the `BUILD_ENV`
variable did a strict comparison against the empty string:
it should be a dev build if and only if the `BUILD_ENV` variable
is different from the empty string.

But since we don't provide a value to the `BUILD_ENV` variable in the CI
job that does the deployment, `process.env.BUILD_ENV` ended up
having the value `undefined`, and a dev build was being pushed to production.

This PR changes the condition to check if the variable has a truthy value.
This should be what we want in this case: a non empty string will yield a
`true` while an `undefined` or an empty string will yield a `false`.
See https://developer.mozilla.org/en-US/docs/Glossary/Truthy

I also sneaked in a simplification: we can pass environment variables to the build step instead of stuffing them in a `.env` file, saving a couple of steps in the job.
