### PR TITLE
Dispatch a single action to update multiple records

### DIFF
--- a/eisbuk-admin/src/enums/store.ts
+++ b/eisbuk-admin/src/enums/store.ts
@@ -22,9 +22,8 @@ export enum Action {
   Logout = "@@Eisbuk/LOGOUT",
 
   UpdateFirestoreListener = "@@Eisbuk/UPDATE_FIRESTORE_LISTENER",
-  UpdateLocalCollection = "@@Eisbuk/UPDATE_LOCAL_COLLECTION",
-  UpdateLocalDocument = "@@Eisbuk/UPDATE_LOCAL_DOCUMENT",
-  DeleteLocalDocument = "@@Eisbuk/DELETE_LOCAL_DOCUMENT",
+  UpdateLocalDocuments = "@@Eisbuk/UPDATE_LOCAL_DOCUMENTS",
+  DeleteLocalDocuments = "@@Eisbuk/DELETE_LOCAL_DOCUMENTS",
   DeleteFirestoreListener = "@@Eisbuk/DELETE_FIRESTORE_LISTENER",
 }
 /**

--- a/eisbuk-admin/src/react-redux-firebase/actions/index.ts
+++ b/eisbuk-admin/src/react-redux-firebase/actions/index.ts
@@ -10,10 +10,7 @@ import {
 } from "@/types/store";
 
 interface UpdateFirestoreData<
-  A extends
-    | Action.UpdateLocalCollection
-    | Action.UpdateLocalDocument
-    | Action.DeleteLocalDocument
+  A extends Action.UpdateLocalDocuments | Action.DeleteLocalDocuments
 > {
   <C extends CollectionSubscription | BookingSubCollection.BookedSlots>(
     payload: UpdateFirestoreDataPayload<C>[A]
@@ -24,41 +21,28 @@ interface UpdateFirestoreData<
 }
 
 /**
- * An action creator used to dispatch updates for given collection in local store's `firestore.data`
- * @param collection to update
- * @param data updated data entry
- * @param merge if true leaves the rest of the collection entry intact and updates only the provided data (non-recursive)
- * @returns Redux action
- */
-export const updateLocalColl: UpdateFirestoreData<Action.UpdateLocalCollection> =
-  ({ collection, data, merge }) => ({
-    type: Action.UpdateLocalCollection,
-    payload: { collection, data, merge },
-  });
-
-/**
- * An action creator used to dispatch updates for given document in a collection in local store's `firestore.data`
+ * An action creator used to dispatch updates for the given set of documents in a collection in local store's `firestore.data`
  * @param collection of the document to update
  * @param id document `id` of corresponding firestore document, `key` for local store entry
  * @param data updated data entry
  * @returns Redux action
  */
-export const updateLocalDocument: UpdateFirestoreData<Action.UpdateLocalDocument> =
-  ({ collection, id, data }) => ({
-    type: Action.UpdateLocalDocument,
-    payload: { collection, data, id },
+export const updateLocalDocuments: UpdateFirestoreData<Action.UpdateLocalDocuments> =
+  ({ collection, records }) => ({
+    type: Action.UpdateLocalDocuments,
+    payload: { collection, records },
   });
 
 /**
- * An action creator used to delete given firestore document from corresponding collection in local store's `firestore.data`
+ * An action creator used to delete given set of firestore documents from corresponding collection in local store's `firestore.data`
  * @param collection to update
  * @param id document id of the document to delete
  * @returns Redux action
  */
-export const deleteLocalDocument: UpdateFirestoreData<Action.DeleteLocalDocument> =
-  ({ collection, id }) => ({
-    type: Action.DeleteLocalDocument,
-    payload: { collection, id },
+export const deleteLocalDocuments: UpdateFirestoreData<Action.DeleteLocalDocuments> =
+  ({ collection, ids }) => ({
+    type: Action.DeleteLocalDocuments,
+    payload: { collection, ids },
   });
 
 /**

--- a/eisbuk-admin/src/react-redux-firebase/reducer/__tests__/firestoreReducer.test.ts
+++ b/eisbuk-admin/src/react-redux-firebase/reducer/__tests__/firestoreReducer.test.ts
@@ -5,11 +5,10 @@ import { LocalStore } from "@/types/store";
 import firestoreReducer from "../";
 
 import {
-  updateLocalColl,
   deleteFirestoreListener,
   updateFirestoreListener,
-  updateLocalDocument,
-  deleteLocalDocument,
+  updateLocalDocuments,
+  deleteLocalDocuments,
 } from "@/react-redux-firebase/actions";
 
 import { baseAttendance } from "@/__testData__/dataTriggers";
@@ -73,71 +72,8 @@ describe("Firestore reducer", () => {
     });
   });
 
-  describe("Test Action.UpdateLocalCollection", () => {
-    /**
-     * Base attendance with different date (used to test updates to the store)
-     */
-    const updatedAttendance = {
-      [slotId]: {
-        ...baseAttendance,
-        date: "1550-11-11",
-      },
-    };
-
-    test("should overwrite updated collection in store by default", () => {
-      // set up test state
-      const initialState: LocalStore["firestore"] = {
-        data: {
-          attendance: {
-            ["dummy-slot"]: baseAttendance,
-            [slotId]: baseAttendance,
-          },
-        },
-        listeners: {},
-      };
-      // update attendance
-      const updateAction = updateLocalColl({
-        collection: OrgSubCollection.Attendance,
-        data: updatedAttendance,
-      });
-      const updatedState = firestoreReducer(initialState, updateAction);
-      // since the `merge` param is falsy (undefined), should overwrite the `attendance` entirely
-      expect(updatedState).toEqual({
-        listeners: {},
-        data: { attendance: updatedAttendance },
-      });
-    });
-
-    test("should update only the provided entries, without overwriting the entire state, if 'merge=true'", () => {
-      // set up test state
-      const initialState: LocalStore["firestore"] = {
-        data: {
-          attendance: {
-            ["dummy-slot"]: baseAttendance,
-            [slotId]: baseAttendance,
-          },
-        },
-        listeners: {},
-      };
-      // update attendance
-      const updateAction = updateLocalColl({
-        collection: OrgSubCollection.Attendance,
-        data: updatedAttendance,
-        merge: true,
-      });
-      const updatedState = firestoreReducer(initialState, updateAction);
-      // since the `merge` param is true, should only update the attendance entry keyed by `slotId` (according to test data)
-      expect(updatedState).toEqual({
-        listeners: {},
-        data: {
-          attendance: { ["dummy-slot"]: baseAttendance, ...updatedAttendance },
-        },
-      });
-    });
-  });
-
-  describe("Test Action.UpdateLocalDocument", () => {
-    test("should update the firestore document entry in local store without meddling with the rest of the collection", () => {
+  describe("Test Action.UpdateLocalDocuments", () => {
+    test("should update the firestore documsent entry in local store without meddling with the rest of the collection", () => {
       // set up test state
       const initialState: LocalStore["firestore"] = {
         data: {
@@ -150,10 +86,14 @@ describe("Firestore reducer", () => {
       };
       // update attendance
       const updatedSaul = { ...saul, name: "not-saul" };
-      const updateAction = updateLocalDocument({
+      const updateAction = updateLocalDocuments({
         collection: OrgSubCollection.Customers,
-        id: saul.id,
-        data: updatedSaul,
+        records: [
+          {
+            id: saul.id,
+            data: updatedSaul,
+          },
+        ],
       });
       const updatedState = firestoreReducer(initialState, updateAction);
       // since the `merge` param is falsy (undefined), should overwrite the `attendance` entirely
@@ -169,7 +109,7 @@ describe("Firestore reducer", () => {
     });
   });
 
-  describe("Test Action.DeleteLocalDocument", () => {
+  describe("Test Action.DeleteLocalDocuments", () => {
     test("should delete the firestore document entry in local store without meddling with the rest of the collection", () => {
       // set up test state
       const initialState: LocalStore["firestore"] = {
@@ -182,12 +122,13 @@ describe("Firestore reducer", () => {
         listeners: {},
       };
       // update attendance
-      const updateAction = deleteLocalDocument({
+      const updateAction = deleteLocalDocuments({
         collection: OrgSubCollection.Customers,
-        id: saul.id,
+        ids: [saul.id],
       });
       const updatedState = firestoreReducer(initialState, updateAction);
       // since the `merge` param is falsy (undefined), should overwrite the `attendance` entirely
+      console.log(updatedState);
       expect(updatedState).toEqual({
         data: {
           customers: {

--- a/eisbuk-admin/src/react-redux-firebase/reducer/index.ts
+++ b/eisbuk-admin/src/react-redux-firebase/reducer/index.ts
@@ -39,54 +39,39 @@ export default (
       // return state with listener for collection and the correspoding data removed
       return { data, listeners };
 
-    case Action.UpdateLocalCollection:
-      const {
-        collection: collectionToUpdate1,
-        data: updatedCollection1,
-        merge,
-      } = action.payload as FirestoreReducerAction<Action.UpdateLocalCollection>["payload"];
+    case Action.UpdateLocalDocuments: {
+      const { collection: collectionToUpdate, records: records } =
+        action.payload as FirestoreReducerAction<Action.UpdateLocalDocuments>["payload"];
+      const recordsToAddOrEdit = {};
+      records.forEach(({ id, data }) => {
+        recordsToAddOrEdit[id] = data;
+      });
       return {
         data: {
           ...state.data,
-          [collectionToUpdate1]: merge
-            ? { ...state.data[collectionToUpdate1], ...updatedCollection1 }
-            : updatedCollection1,
-        },
-        listeners: state.listeners,
-      };
-
-    case Action.UpdateLocalDocument:
-      const {
-        collection: collectionToUpdate2,
-        data: updatedDocument,
-        id: documentToUpdate,
-      } = action.payload as FirestoreReducerAction<Action.UpdateLocalDocument>["payload"];
-      return {
-        data: {
-          ...state.data,
-          [collectionToUpdate2]: {
-            ...state.data[collectionToUpdate2],
-            [documentToUpdate]: updatedDocument,
+          [collectionToUpdate]: {
+            ...state.data[collectionToUpdate],
+            ...recordsToAddOrEdit,
           },
         },
         listeners: state.listeners,
       };
-
-    case Action.DeleteLocalDocument:
-      const { collection: collectionToUpdate3, id: documentToDelete } =
-        action.payload as FirestoreReducerAction<Action.DeleteLocalDocument>["payload"];
-      // copy the collection without the deleted document
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { [documentToDelete]: deletedDocument, ...updatedCollection3 } =
-        state.data[collectionToUpdate3] || {};
-      // update state without the deleted document
+    }
+    case Action.DeleteLocalDocuments: {
+      const { collection: collectionToUpdate, ids: documentsToDelete } =
+        action.payload as FirestoreReducerAction<Action.DeleteLocalDocuments>["payload"];
+      // Create a copy of the collection
+      const { ...updatedCollection } = state.data[collectionToUpdate] || {};
+      // Remove deleted documents
+      documentsToDelete.forEach((key) => delete updatedCollection[key]);
       return {
         data: {
           ...state.data,
-          [collectionToUpdate3]: updatedCollection3,
+          [collectionToUpdate]: updatedCollection,
         },
         listeners: state.listeners,
       };
+    }
     default:
       return state;
   }

--- a/eisbuk-admin/src/react-redux-firebase/thunks/__tests__/onSnapshotHandlers.test.ts
+++ b/eisbuk-admin/src/react-redux-firebase/thunks/__tests__/onSnapshotHandlers.test.ts
@@ -49,7 +49,7 @@ describe("Firestore subscriptions", () => {
     );
   });
 
-  describe("createCollSnapshotHandler", () => {
+  describe("createDocSnapshotHandler", () => {
     testWithEmulator(
       "should update the local store on update to subscribed firestore collection",
       async () => {

--- a/eisbuk-admin/src/store/actions/__tests__/authOperations.test.ts
+++ b/eisbuk-admin/src/store/actions/__tests__/authOperations.test.ts
@@ -9,7 +9,7 @@ import { __organization__ } from "@/lib/constants";
 import { Action } from "@/enums/store";
 
 import { revalidateAdminStatus, updateAuthUser } from "../authOperations";
-import { updateLocalColl } from "@/react-redux-firebase/actions";
+import { updateLocalDocuments } from "@/react-redux-firebase/actions";
 
 import { getNewStore } from "@/store/createStore";
 
@@ -29,13 +29,16 @@ describe("Auth operations", () => {
     testStore = getNewStore();
     const { dispatch } = testStore;
     dispatch(
-      updateLocalColl({
+      updateLocalDocuments({
         collection: Collection.Organizations,
-        data: {
-          [__organization__]: {
-            admins: [defaultUser.email],
-          } as OrganizationData,
-        },
+        records: [
+          {
+            id: __organization__,
+            data: {
+              admins: [defaultUser.email],
+            } as OrganizationData,
+          },
+        ],
       })
     );
   });

--- a/eisbuk-admin/src/types/store.ts
+++ b/eisbuk-admin/src/types/store.ts
@@ -218,28 +218,24 @@ export type CollectionSubscription =
 export type FirestoreAction =
   | Action.UpdateFirestoreListener
   | Action.DeleteFirestoreListener
-  | Action.UpdateLocalCollection
-  | Action.UpdateLocalDocument
-  | Action.DeleteLocalDocument;
+  | Action.UpdateLocalDocuments
+  | Action.DeleteLocalDocuments;
 /**
  * A generic used to type the payload we'll recieve from UpdateLocalCollection action
  */
 export interface UpdateFirestoreDataPayload<
   C extends CollectionSubscription | BookingSubCollection.BookedSlots
 > {
-  [Action.UpdateLocalCollection]: {
+  [Action.UpdateLocalDocuments]: {
     collection: C;
-    data: FirestoreData[C];
-    merge?: boolean;
+    records: {
+      data: FirestoreData[C][keyof FirestoreData[C]];
+      id: string;
+    }[];
   };
-  [Action.UpdateLocalDocument]: {
+  [Action.DeleteLocalDocuments]: {
     collection: C;
-    data: FirestoreData[C][keyof FirestoreData[C]];
-    id: string;
-  };
-  [Action.DeleteLocalDocument]: {
-    collection: C;
-    id: string;
+    ids: string[];
   };
 }
 
@@ -247,9 +243,8 @@ export interface UpdateFirestoreDataPayload<
  * Record of payloads for each of the firestore reducer actions
  */
 interface FirestorReducerPayload {
-  [Action.UpdateLocalCollection]: UpdateFirestoreDataPayload<CollectionSubscription>[Action.UpdateLocalCollection];
-  [Action.UpdateLocalDocument]: UpdateFirestoreDataPayload<CollectionSubscription>[Action.UpdateLocalDocument];
-  [Action.DeleteLocalDocument]: UpdateFirestoreDataPayload<CollectionSubscription>[Action.DeleteLocalDocument];
+  [Action.UpdateLocalDocuments]: UpdateFirestoreDataPayload<CollectionSubscription>[Action.UpdateLocalDocuments];
+  [Action.DeleteLocalDocuments]: UpdateFirestoreDataPayload<CollectionSubscription>[Action.DeleteLocalDocuments];
   [Action.UpdateFirestoreListener]: {
     collection: CollectionSubscription;
     listener: Partial<FirestoreListener>;


### PR DESCRIPTION
The linting fails with

```
src/react-redux-firebase/reducer/__tests__/firestoreReducer.test.ts:98:59 - error TS2345: Argument of type '{ type: Action.UpdateLocalDocuments; payload: { collection: OrgSubCollection.Customers; records: { data: Customer; id: string; }[]; }; }' is not assignable to parameter of type 'FirestoreReducerAction<FirestoreAction>'.
  Types of property 'payload' are incompatible.
    Type '{ collection: OrgSubCollection.Customers; records: { data: Customer; id: string; }[]; }' is not assignable to type 'CollectionSubscription | { collection: CollectionSubscription; records: { data: never; id: string; }[]; } | { collection: CollectionSubscription; ids: string[]; } | { ...; }'.
      Type '{ collection: OrgSubCollection.Customers; records: { data: Customer; id: string; }[]; }' is not assignable to type '{ collection: CollectionSubscription; records: { data: never; id: string; }[]; }'.
        Types of property 'records' are incompatible.
          Type '{ data: Customer; id: string; }[]' is not assignable to type '{ data: never; id: string; }[]'.
            Type '{ data: Customer; id: string; }' is not assignable to type '{ data: never; id: string; }'.
              Types of property 'data' are incompatible.
                Type 'Customer' is not assignable to type 'never'.

98       const updatedState = firestoreReducer(initialState, updateAction);
```

@ikusteu Can you have a look at that? I believe it should be a very quick one for you, and I didn't investigate the `never` type (as I understand it's a temporary solution I didn't put much effort into looking into it).