### PR TITLE
Fix week logic in slot view and copy/paste slot week

### DIFF
--- a/eisbuk-admin/src/pages/slots/index.tsx
+++ b/eisbuk-admin/src/pages/slots/index.tsx
@@ -35,7 +35,8 @@ import useFirestoreSubscribe from "@/react-redux-firebase/hooks/useFirestoreSubs
 const SlotsPage: React.FC = () => {
   const dispatch = useDispatch();
 
-  const date = useSelector(getCalendarDay);
+  const currentDate = useSelector(getCalendarDay);
+  const date = currentDate.startOf("week");
 
   useFirestoreSubscribe([OrgSubCollection.SlotsByDay]);
 
@@ -57,7 +58,7 @@ const SlotsPage: React.FC = () => {
     </SlotOperationButtons>
   );
 
-  const canClick = Boolean(weekToPaste);
+  const canClick = weekToPaste && (weekToPaste.weekStart.toMillis() === date.toMillis());
   const handleSlotClick =
     ({ slot, selected }: { slot: SlotInterface; selected: boolean }) =>
     () => {

--- a/eisbuk-admin/src/store/actions/copyPaste.ts
+++ b/eisbuk-admin/src/store/actions/copyPaste.ts
@@ -120,7 +120,7 @@ export const copySlotsWeek = (): FirestoreThunk => async (
   const state = getState();
 
   // get week start and date keys
-  const weekStart = state.app.calendarDay;
+  const weekStart = state.app.calendarDay.startOf("week");
   const weekStartISO = luxon2ISODate(weekStart);
   const monthStr = weekStartISO.substr(0, 7);
 

--- a/eisbuk-admin/src/store/selectors/__tests__/slots.test.ts
+++ b/eisbuk-admin/src/store/selectors/__tests__/slots.test.ts
@@ -44,6 +44,19 @@ describe("Slot selectors > ", () => {
       const res = selector(testStore as LocalStore);
       expect(res).toEqual(expectedWeekCustomer);
     });
+
+    test("should get slots for a week even if passed non-week-start-date", () => {
+      const testDate = DateTime.fromISO(currentWeekStartDate).plus({ days: 1 });
+      // create a selector curried with `timeframe` and `date` params (like we will be doing within the component)
+      const selector = getSlotsForCustomer(
+        Category.Competitive,
+        "week",
+        testDate
+      );
+      // test created selector against test store state
+      const res = selector(testStore as LocalStore);
+      expect(res).toEqual(expectedWeekCustomer);
+    });
   });
 
   describe("Test 'getAdminSlots' selector", () => {
@@ -55,6 +68,17 @@ describe("Slot selectors > ", () => {
     test("should return empty days if no slots in store ('slotsByDay' = null)", () => {
       const slotsForWeek = getAdminSlots(noSlotsStore);
       expect(slotsForWeek).toEqual(emptyWeek);
+    });
+
+    test("should get all slots for given week even if passed a non-week-start date", () => {
+      const slotsForWeek = getAdminSlots({
+        ...testStore,
+        app: {
+          ...testStore.app,
+          calendarDay: testStore.app.calendarDay.plus({ days: 1 }),
+        },
+      });
+      expect(slotsForWeek).toEqual(expectedWeekAdmin);
     });
   });
 });

--- a/eisbuk-admin/src/store/selectors/slots.ts
+++ b/eisbuk-admin/src/store/selectors/slots.ts
@@ -104,11 +104,12 @@ export const getAdminSlots = (state: LocalStore): SlotsByDay => {
   // (as opposed to creating fallback dates and filling them with slots later)
   const slotsByDay = allSlotsInStore ?? {};
 
+  const startCalendarDay = calendarDay.startOf("week");
   // create all dates for a week
   return Array(7)
     .fill(null)
     .reduce((acc, _, i) => {
-      const date = calendarDay.plus({ days: i });
+      const date = startCalendarDay.plus({ days: i });
       const dateISO = luxon2ISODate(date);
       const monthString = dateISO.substr(0, 7);
 


### PR DESCRIPTION
This fixes #324
Also fixes #323 which was wrongly described. The issue there is not with the copy (that does indeed copy from Monday to Sunday) but with the week display for slots: it was starting at the currently set day instead of a Monday.