### PR TITLE
Make slot operation buttons clickable even on selected slot

### DIFF
--- a/eisbuk-admin/src/components/atoms/SlotOperationButtons/CopyButton.tsx
+++ b/eisbuk-admin/src/components/atoms/SlotOperationButtons/CopyButton.tsx
@@ -69,7 +69,10 @@ export const CopyButton: React.FC<SlotButtonProps> = ({ size }) => {
   // pick the right action creator with respect to `contextType`
   const copyActionCreator =
     contextType === ButtonContextType.Day ? copySlotsDay : copySlotsWeek;
-  const onCopy = () => dispatch(copyActionCreator(date));
+  const onCopy = (e: React.SyntheticEvent) => {
+    e.stopPropagation();
+    dispatch(copyActionCreator(date));
+  };
 
   // check if there are slots in clipboard for given `contextType`
   const displayBadge = slotsToCopy && slotsToCopy[contextType!];

--- a/eisbuk-admin/src/components/atoms/SlotOperationButtons/DeleteButton.tsx
+++ b/eisbuk-admin/src/components/atoms/SlotOperationButtons/DeleteButton.tsx
@@ -108,7 +108,8 @@ export const DeleteButton: React.FC<Props> = ({ size, confirmDialog }) => {
    * - If `confirmDialog` prop provided, prompts for confirmation
    * - If no `confirmDialog` prop provided, executes delete immediately
    */
-  const handleClick = () => {
+  const handleClick = (e: React.SyntheticEvent) => {
+    e.stopPropagation();
     if (confirmDialog) {
       setOpenConfirmDialog(true);
     } else {

--- a/eisbuk-admin/src/components/atoms/SlotOperationButtons/EditSlotButton.tsx
+++ b/eisbuk-admin/src/components/atoms/SlotOperationButtons/EditSlotButton.tsx
@@ -33,7 +33,10 @@ export const EditSlotButton: React.FC<SlotButtonProps> = ({ size }) => {
 
   const [openForm, setOpenForm] = useState(false);
 
-  const showForm = () => setOpenForm(true);
+  const showForm = (e: React.SyntheticEvent) => {
+    e.stopPropagation();
+    setOpenForm(true);
+  };
   const closeForm = () => setOpenForm(false);
 
   // prevent component from rendering and log error to console (but don't throw)


### PR DESCRIPTION
Fixes #245 
A quick fix. Took a *tad* longer than expected it was `e.stopPropagation()` rather than `e.preventDefault()`