### PR TITLE
Change time slot duration calculation - fixes #371

### DIFF
--- a/eisbuk-admin/src/components/atoms/BookingCard/Duration.tsx
+++ b/eisbuk-admin/src/components/atoms/BookingCard/Duration.tsx
@@ -72,19 +72,16 @@ export const calculateIntervalDuration = (
   // exit early with catch all if duration greater than expected
   if (minutes > 120) return BookingDuration["2+h"];
 
-  const roundedMinutes = Math.round(minutes / 30) * 30;
-
-  switch (roundedMinutes) {
-    case 60:
-      return BookingDuration["1h"];
-    case 90:
-      return BookingDuration["1.5h"];
-    case 120:
-      return BookingDuration["2h"];
-    default:
-      // should not happen in production
-      return BookingDuration["0.5h"];
+  if (minutes < 40) {
+    return BookingDuration["0.5h"];
   }
+  if (minutes < 70) {
+    return BookingDuration["1h"];
+  }
+  if (minutes < 90) {
+    return BookingDuration["1.5h"];
+  }
+  return BookingDuration["2h"];
 };
 
 const useStyles = makeStyles(() => ({


### PR DESCRIPTION
In theory we should only have intervals with this durations:
* 30 minutes (half an hour)
* 50 minutes (one hour)
* 80 minutes (one and a half hour)
* 100 minutes (two hours)

but the code should not break when different intervals appear.

Hence the code in this PR applies these intervals:
* 0 < minutes < 40 → half an hour
* 40 < minutes < 70 → one hour
* 70 < minutes < 90 → one and a half hour
* 90 < minutes < 120 → two hours
* 120 < minutes → two hours+