### PR TITLE
Make production deploys possible if an unexpected function is found

### DIFF
--- a/eisbuk-admin/deploy-firebase.expect
+++ b/eisbuk-admin/deploy-firebase.expect
@@ -1,0 +1,24 @@
+#!/usr/bin/expect -f
+
+# We want to be able to deploy to firebase in non interactive mode
+# even if some cloud functions are present that were not expected
+# (we might want to do this to try out new functionalities in a preview channel
+# that depend on a cloud function being deployed).
+# When the interactive deployment asks if we want to delete the unexpected functions,
+# we need to type a single uppercase `N` to let the process continue.
+
+# Four minutes should be enough
+set timeout 240
+
+
+spawn npx firebase deploy --project eisbuk
+
+expect {
+    "*Would you like to proceed with deletion?*" {
+        # Some unexpected cloud functions are present. Tell firebase CLI not to delete them
+        send -- "N\r"
+    }
+    "*Deploy complete!*"
+}
+
+expect eof

--- a/eisbuk-admin/package.json
+++ b/eisbuk-admin/package.json
@@ -51,7 +51,7 @@
     "test:quicktest": "echo Running tests with no emulators support && yarn jest --watch --env=jest-environment-jsdom-sixteen src",
     "test": "echo 'Running all tests; using emulators.' && yarn test:emulators",
     "deploy:eisbuk": "firebase deploy --project eisbuk --only hosting:eisbuk",
-    "deploy:production": "firebase deploy --project eisbuk --only hosting:igorice; firebase deploy --project eisbuk --except hosting",
+    "deploy:production": "./deploy-firebase.expect",
     "deploy:preview": "firebase --project eisbuk hosting:channel:deploy",
     "lint": "eslint .",
     "lint:strict": "eslint . --max-warnings=0",


### PR DESCRIPTION
Currently `master` sports the red mark of shame of a failed CI run.
That's because the deployment failed. It failed because firebase found a function that was not defined in the code in `master`. In those cases firebase can run non-interactively and delete all unexpected functions, [if invoked with `--force`](https://firebase.google.com/docs/functions/manage-functions#delete_functions).

Unfortunately the firebase CLI does not provide a non-interactive way of ignoring unexpected functions.

This PR overcomes this limitation using an `expect` script to fake user interaction and aswer `N` to the question if we want to delete the unknown functions.