### PR TITLE
Show two countdowns for second deadline

### DIFF
--- a/eisbuk-admin/src/components/atoms/BookingsCountdown/BookingsCountdown.tsx
+++ b/eisbuk-admin/src/components/atoms/BookingsCountdown/BookingsCountdown.tsx
@@ -30,12 +30,18 @@ export interface BookingsCountdownProps {
   message: BookingCountdownMessage;
   deadline: DateTime | null;
   month: DateTime;
+  // we're lifting the state of locally finalized booking
+  // to be able to disable 'finalize' buttons on multiple instances of the component
+  isBookingFinalized?: boolean;
+  setIsBookingFinalized?: (isFinalized: boolean) => void;
 }
 
 const BookingsCountdown: React.FC<BookingsCountdownProps> = ({
   message,
   month,
   deadline,
+  isBookingFinalized,
+  setIsBookingFinalized = () => {},
 }) => {
   const { t } = useTranslation();
   const classes = useStyles();
@@ -59,7 +65,6 @@ const BookingsCountdown: React.FC<BookingsCountdownProps> = ({
 
   // finalize bookings flow
   const [finalizeBookings, setFinalizeBookings] = useState(false);
-  const [isBookingFinalized, setIsBookingFinalized] = useState(false);
 
   const handleFinalize = async () => {
     setIsBookingFinalized(true);

--- a/eisbuk-admin/src/pages/customer_area/CustomerSlots/CustomerSlots.tsx
+++ b/eisbuk-admin/src/pages/customer_area/CustomerSlots/CustomerSlots.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import { DateTime } from "luxon";
 import { useSelector } from "react-redux";
 
@@ -17,6 +17,7 @@ import { getCountdownProps } from "@/store/selectors/bookings";
 
 import { orderByWeekDay } from "./utils";
 import { getCalendarDay } from "@/store/selectors/app";
+import { BookingCountdownMessage } from "@/enums/translations";
 
 interface SlotsByDay {
   [dayISO: string]: {
@@ -69,11 +70,26 @@ const CustomerSlots: React.FC<Props> = ({
 
   // show countdown if booking deadline is close
   const currentDate = useSelector(getCalendarDay);
-  const countdownProps = useSelector(
+  const selectorCountdownProps = useSelector(
     // when we have a week (for book off-ice view), spaning over two months
     // we want to show countdown/bookings-locked message with respect to later date
     getCountdownProps(currentDate.endOf(paginateBy))
   );
+
+  // control local booking finalized to disable 'finalize' buttons on all instances of second countdown
+  const [isBookingFinalized, setIsBookingFinalized] = useState(false);
+
+  // all props passed down to BookingsCountdown:
+  // including countdown props from selector and 'finalize' button local state
+  const countdownProps = selectorCountdownProps
+    ? {
+        ...selectorCountdownProps,
+        isBookingFinalized,
+        setIsBookingFinalized,
+      }
+    : // fall back to `null` if `selectorFromCountdownProps` not defined
+      // and prevent showing of countdown messages
+      null;
 
   return (
     <DateNavigation jump={paginateBy} {...{ defaultDate }}>
@@ -111,6 +127,10 @@ const CustomerSlots: React.FC<Props> = ({
               </SlotsDayContainer>
             );
           })}
+          {countdownProps?.message ===
+            BookingCountdownMessage.SecondDeadline && (
+            <BookingsCountdown {...countdownProps} />
+          )}
         </>
       )}
     </DateNavigation>


### PR DESCRIPTION
Fixes #400 
This is a quick fix and doesn't include cypress test updates, as testing number of elements on screen (not being html elements) is a bit beyond me