### PR TITLE
Add min height to SlotsDayContainer to make empty days clearer

### DIFF
--- a/eisbuk-admin/src/components/atoms/SlotsDayContainer/SlotsDayContainer.tsx
+++ b/eisbuk-admin/src/components/atoms/SlotsDayContainer/SlotsDayContainer.tsx
@@ -97,6 +97,7 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
   },
   slotListContainer: {
+    minHeight: "10rem",
     paddingBottom: theme.spacing(2),
     marginBottom: theme.spacing(0.5),
     borderBottomStyle: "solid",


### PR DESCRIPTION
I've added a simple update suggestion to make the empty days appear empty (by having minHeight) to look as empty calendar slots...idk I think it's prettier, let me know what you both think