### PR TITLE
Feature/login redirect

### DIFF
--- a/eisbuk-admin/cypress/integration/login_flow_spec.ts
+++ b/eisbuk-admin/cypress/integration/login_flow_spec.ts
@@ -298,7 +298,7 @@ describe("login", () => {
   });
 
   describe("Login redirect", () => {
-    it.only("Redirects to customer bookings page on customer (non-admin) login", () => {
+    it("Redirects to customer bookings page on customer (non-admin) login", () => {
       const password = "password";
       cy.addAuthUser({ email: saul.email, password });
       // log in saul, who is not an admin, but exists in customers collection
@@ -313,7 +313,7 @@ describe("login", () => {
       cy.contains(`${saul.name} ${saul.surname}`);
     });
 
-    it.only("redirects to unauth page if user not admin, nor a registered customer", () => {
+    it("redirects to unauth page if user not admin, nor a registered customer", () => {
       const email = "new-user@gmail.com";
       const password = "password";
       cy.addAuthUser({ email, password });
@@ -326,7 +326,8 @@ describe("login", () => {
       cy.clickButton(t(ActionButton.SignIn));
       // on successful login, should redirect to unauth page
       // the user is not admin and doesn't exist in customers collection
-      cy.contains(t(AuthMessage.NotAuthorized));
+      cy.contains(t(AuthMessage.NotRegistered));
+      cy.contains(t(AuthMessage.ContactAdminsForRegistration));
     });
   });
 });

--- a/eisbuk-admin/cypress/plugins/firebasePlugin/commands.ts
+++ b/eisbuk-admin/cypress/plugins/firebasePlugin/commands.ts
@@ -18,6 +18,8 @@ import {
 } from "@firebase/firestore";
 import { v4 as uuidv4 } from "uuid";
 
+import { CreateAuthUserPayload } from "eisbuk-shared";
+
 import { CloudFunction } from "@/enums/functions";
 
 import { defaultUser } from "@/__testSetup__/envData";
@@ -35,6 +37,10 @@ declare global {
        * @returns {Chainable<string>} a `PromiseLike` which yielding `string` a name of the current organization
        */
       initAdminApp: () => Chainable<string>;
+      /**
+       * Create a user in firebase auth and (optionally), if admin to firestore organization
+       */
+      addAuthUser: (payload: CreateAuthUserPayload) => Chainable<void>;
       /**
        * A sort of a proxy handler: passes organization and file names back to node environment
        * process (using `cy.task` API). The files get read and parsed (JSON)
@@ -114,6 +120,10 @@ const addFirebaseCommands = (): void => {
     )({ organization });
 
     return organization;
+  });
+
+  Cypress.Commands.add("addAuthUser", async (payload) => {
+    await httpsCallable(functions, CloudFunction.CreateUser)(payload);
   });
 
   Cypress.Commands.add(

--- a/eisbuk-admin/functions/src/auth.ts
+++ b/eisbuk-admin/functions/src/auth.ts
@@ -1,0 +1,53 @@
+import * as functions from "firebase-functions";
+import admin from "firebase-admin";
+
+import {
+  AuthStatus,
+  Collection,
+  OrganizationData,
+  OrgSubCollection,
+} from "eisbuk-shared";
+
+import { __functionsZone__ } from "./constants";
+import { checkRequiredFields } from "./utils";
+
+export const queryAuthStatus = functions
+  .region(__functionsZone__)
+  .https.onCall(async (payload) => {
+    // validate payload
+    checkRequiredFields(payload, ["organization", "authString"]);
+
+    const { organization, authString } = payload;
+
+    const authStatus: AuthStatus = {
+      isAdmin: false,
+    };
+
+    const orgRef = admin
+      .firestore()
+      .collection(Collection.Organizations)
+      .doc(organization);
+    const customersRef = orgRef.collection(OrgSubCollection.Customers);
+
+    const [org, customers] = await Promise.all([
+      orgRef.get(),
+      customersRef.get(),
+    ]);
+
+    // query admin status
+    const orgData = org.data() as OrganizationData;
+    if (orgData) {
+      authStatus.isAdmin = orgData.admins.includes(authString);
+    }
+
+    // query customer status
+    const authCustomer = customers.docs.find((customerDoc) => {
+      const data = customerDoc.data();
+      return data.email === authString || data.phone === authString;
+    });
+    if (authCustomer) {
+      authStatus.bookingsSecretKey = authCustomer.data().secretKey;
+    }
+
+    return authStatus;
+  });

--- a/eisbuk-admin/functions/src/auth.ts
+++ b/eisbuk-admin/functions/src/auth.ts
@@ -6,6 +6,7 @@ import {
   Collection,
   OrganizationData,
   OrgSubCollection,
+  QueryAuthStatusPayload,
 } from "eisbuk-shared";
 
 import { __functionsZone__ } from "./constants";
@@ -13,41 +14,43 @@ import { checkRequiredFields } from "./utils";
 
 export const queryAuthStatus = functions
   .region(__functionsZone__)
-  .https.onCall(async (payload) => {
-    // validate payload
-    checkRequiredFields(payload, ["organization", "authString"]);
+  .https.onCall(
+    async (payload: QueryAuthStatusPayload): Promise<AuthStatus> => {
+      // validate payload
+      checkRequiredFields(payload, ["organization", "authString"]);
 
-    const { organization, authString } = payload;
+      const { organization, authString } = payload;
 
-    const authStatus: AuthStatus = {
-      isAdmin: false,
-    };
+      const authStatus: AuthStatus = {
+        isAdmin: false,
+      };
 
-    const orgRef = admin
-      .firestore()
-      .collection(Collection.Organizations)
-      .doc(organization);
-    const customersRef = orgRef.collection(OrgSubCollection.Customers);
+      const orgRef = admin
+        .firestore()
+        .collection(Collection.Organizations)
+        .doc(organization);
+      const customersRef = orgRef.collection(OrgSubCollection.Customers);
 
-    const [org, customers] = await Promise.all([
-      orgRef.get(),
-      customersRef.get(),
-    ]);
+      const [org, customers] = await Promise.all([
+        orgRef.get(),
+        customersRef.get(),
+      ]);
 
-    // query admin status
-    const orgData = org.data() as OrganizationData;
-    if (orgData) {
-      authStatus.isAdmin = orgData.admins.includes(authString);
+      // query admin status
+      const orgData = org.data() as OrganizationData;
+      if (orgData) {
+        authStatus.isAdmin = orgData.admins.includes(authString);
+      }
+
+      // query customer status
+      const authCustomer = customers.docs.find((customerDoc) => {
+        const data = customerDoc.data();
+        return data.email === authString || data.phone === authString;
+      });
+      if (authCustomer) {
+        authStatus.bookingsSecretKey = authCustomer.data().secretKey;
+      }
+
+      return authStatus;
     }
-
-    // query customer status
-    const authCustomer = customers.docs.find((customerDoc) => {
-      const data = customerDoc.data();
-      return data.email === authString || data.phone === authString;
-    });
-    if (authCustomer) {
-      authStatus.bookingsSecretKey = authCustomer.data().secretKey;
-    }
-
-    return authStatus;
-  });
+  );

--- a/eisbuk-admin/functions/src/index.ts
+++ b/eisbuk-admin/functions/src/index.ts
@@ -7,3 +7,4 @@ export * from "./migrations";
 export * from "./testData";
 export * from "./testSlots";
 export * from "./https";
+export * from "./auth";

--- a/eisbuk-admin/src/__testUtils__/firestore.ts
+++ b/eisbuk-admin/src/__testUtils__/firestore.ts
@@ -91,16 +91,17 @@ export const deleteAllCollections = async (
     | FirebaseFirestore.DocumentReference<FirebaseFirestore.DocumentData>
     | FirebaseFirestore.Firestore,
   collections: string[]
-): Promise<void> => {
-  const toDelete: Promise<FirebaseFirestore.WriteResult>[] = [];
+): Promise<any> =>
+  Promise.all(collections.map((coll) => deleteCollection(db.collection(coll))));
 
-  for (const coll of collections) {
-    // eslint-disable-next-line no-await-in-loop
-    const existing = await db.collection(coll).get();
-    existing.forEach((el) => {
-      toDelete.push(el.ref.delete());
-    });
-  }
-
-  await Promise.all(toDelete);
+/**
+ * Deletes all documents in a collection
+ * @param collRef
+ * @returns
+ */
+export const deleteCollection = async (
+  collRef: FirebaseFirestore.CollectionReference<FirebaseFirestore.DocumentData>
+): Promise<FirebaseFirestore.WriteResult[]> => {
+  const docs = (await collRef.get()).docs;
+  return Promise.all(docs.map((doc) => doc.ref.delete()));
 };

--- a/eisbuk-admin/src/__tests__/auth.test.ts
+++ b/eisbuk-admin/src/__tests__/auth.test.ts
@@ -2,17 +2,39 @@
  * @jest-environment node
  */
 
-import { doc } from "@firebase/firestore";
+import { doc, getDoc } from "@firebase/firestore";
+import {
+  httpsCallable,
+  HttpsCallableResult,
+  FunctionsError,
+} from "@firebase/functions";
 
-import { Collection } from "eisbuk-shared";
+import {
+  Collection,
+  AuthStatus,
+  OrgSubCollection,
+  HTTPSErrors,
+} from "eisbuk-shared";
 
-import { adminDb, db } from "@/__testSetup__/firestoreSetup";
+import { adminDb, db, functions } from "@/__testSetup__/firestoreSetup";
+
+import { CloudFunction } from "@/enums/functions";
 
 import { testWithEmulator } from "@/__testUtils__/envUtils";
 import { loginWithEmail, loginWithPhone } from "@/__testUtils__/auth";
-import { getDoc } from "firebase/firestore";
+import { deleteCollection } from "@/__testUtils__/firestore";
+
+import { saul } from "@/__testData__/customers";
+
+const organization = "auth-test-organization";
+const orgRef = adminDb.collection(Collection.Organizations).doc(organization);
+const customersRef = orgRef.collection(OrgSubCollection.Customers);
 
 describe("Test authentication", () => {
+  afterEach(async () => {
+    await Promise.all([deleteCollection(customersRef), orgRef.delete()]);
+  });
+
   describe("Test organization data access", () => {
     testWithEmulator(
       "should only let admin access the organization data (by email)",
@@ -61,5 +83,67 @@ describe("Test authentication", () => {
       ).data();
       expect(org).toStrictEqual(orgDefinition);
     });
+  });
+
+  describe.only("Test queryAuthStatus", () => {
+    const queryAuthStatus = (authString: string) =>
+      httpsCallable(
+        functions,
+        CloudFunction.QueryAuthStatus
+      )({ organization, authString }) as Promise<
+        HttpsCallableResult<AuthStatus>
+      >;
+
+    testWithEmulator(
+      "should successfully query admin status using email",
+      async () => {
+        // set up test state with saul as admin
+        await orgRef.set({ admins: [saul.email] }, { merge: true });
+        const res = await queryAuthStatus(saul.email!);
+        const {
+          data: { isAdmin },
+        } = res;
+        expect(isAdmin).toEqual(true);
+      }
+    );
+
+    testWithEmulator(
+      "should successfully query customer status using email",
+      async () => {
+        // set up test state with saul as customer, but not an admin
+        await customersRef.doc(saul.id).set(saul);
+        const {
+          data: { isAdmin, bookingsSecretKey },
+        } = await queryAuthStatus(saul.email!);
+        expect(isAdmin).toEqual(false);
+        expect(bookingsSecretKey).toEqual(saul.secretKey);
+      }
+    );
+
+    testWithEmulator(
+      "should successfully query customer status using phone",
+      async () => {
+        // set up test state with saul as customer, but not an admin
+        await customersRef.doc(saul.id).set(saul);
+        const {
+          data: { isAdmin, bookingsSecretKey },
+        } = await queryAuthStatus(saul.phone!);
+        expect(isAdmin).toEqual(false);
+        expect(bookingsSecretKey).toEqual(saul.secretKey);
+      }
+    );
+
+    testWithEmulator(
+      "should reject if no 'organization' or 'authString' provided",
+      async () => {
+        try {
+          await httpsCallable(functions, CloudFunction.QueryAuthStatus)({});
+        } catch (error) {
+          expect((error as FunctionsError).message).toEqual(
+            `${HTTPSErrors.MissingParameter}: organization, authString`
+          );
+        }
+      }
+    );
   });
 });

--- a/eisbuk-admin/src/components/auth/LoginRoute.tsx
+++ b/eisbuk-admin/src/components/auth/LoginRoute.tsx
@@ -33,7 +33,7 @@ const LoginRoute: React.FC<RouteProps> = (props) => {
     case Boolean(secretKey):
       return <Redirect to={`${Routes.CustomerArea}/${secretKey}`} />;
     default:
-      return <Redirect to={Routes.Unauthorized} />;
+      return <Redirect to={Routes.NotRegistered} />;
   }
 };
 

--- a/eisbuk-admin/src/components/auth/LoginRoute.tsx
+++ b/eisbuk-admin/src/components/auth/LoginRoute.tsx
@@ -2,9 +2,14 @@ import React from "react";
 import { Route, Redirect, RouteProps } from "react-router-dom";
 import { useSelector } from "react-redux";
 
-import { PrivateRoutes } from "@/enums/routes";
+import { PrivateRoutes, Routes } from "@/enums/routes";
 
-import { getIsAuthEmpty, getIsAuthLoaded } from "@/store/selectors/auth";
+import {
+  getBookingsSecretKey,
+  getIsAdmin,
+  getIsAuthEmpty,
+  getIsAuthLoaded,
+} from "@/store/selectors/auth";
 
 /**
  * Login route, checks for auth, if auth not provided, renders passed route props (LoginComponent)
@@ -15,14 +20,20 @@ import { getIsAuthEmpty, getIsAuthLoaded } from "@/store/selectors/auth";
 const LoginRoute: React.FC<RouteProps> = (props) => {
   const isAuthEmpty = useSelector(getIsAuthEmpty);
   const isAuthLoaded = useSelector(getIsAuthLoaded);
+  const isAdmin = useSelector(getIsAdmin);
+  const secretKey = useSelector(getBookingsSecretKey);
 
   switch (true) {
-    case isAuthLoaded && isAuthEmpty:
-      return <Route {...props} />;
-    case isAuthLoaded && !isAuthEmpty:
-      return <Redirect to={PrivateRoutes.Root} />;
-    default:
+    case !isAuthLoaded:
       return null;
+    case isAuthEmpty:
+      return <Route {...props} />;
+    case isAdmin:
+      return <Redirect to={PrivateRoutes.Root} />;
+    case Boolean(secretKey):
+      return <Redirect to={`${Routes.CustomerArea}/${secretKey}`} />;
+    default:
+      return <Redirect to={Routes.Unauthorized} />;
   }
 };
 

--- a/eisbuk-admin/src/components/auth/NotRegistered.tsx
+++ b/eisbuk-admin/src/components/auth/NotRegistered.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { useDispatch, useSelector } from "react-redux";
+import _ from "lodash";
+import { useTranslation } from "react-i18next";
+
+import Button from "@mui/material/Button";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+
+import { signOut } from "@/store/actions/authOperations";
+
+import figureSkatingSilhouetteCouple from "@/assets/images/login/figure-skating-silhouette-couple.svg";
+import figureSkatingSilhouetteSkirt from "@/assets/images/login/figure-skating-silhouette-skirt.svg";
+import figureSkatingSilhouette from "@/assets/images/login/figure-skating-silhouette.svg";
+import girlIceSkating from "@/assets/images/login/girl-ice-skating-silhouette.svg";
+import iceSkatingSilhouette from "@/assets/images/login/ice-skating-silhouette.svg";
+
+import { getLocalAuth } from "@/store/selectors/auth";
+import { AuthMessage } from "@/enums/translations";
+
+// #region backgroundImages
+const backgrounds = [
+  figureSkatingSilhouetteCouple,
+  figureSkatingSilhouetteSkirt,
+  figureSkatingSilhouette,
+  girlIceSkating,
+  iceSkatingSilhouette,
+];
+// #endregion backgroundImages
+
+// #region styles
+/** @TODO refactor to use className instead of inline stlye */
+const baseStyle = {
+  backgroundRepeat: "no-repeat",
+  backgroundOpacity: "20%",
+  backgroundSize: "contain",
+  backgroundPosition: "center",
+  height: "100vh",
+};
+// #endregion styles
+
+interface Props {
+  backgroundIndex?: number;
+}
+
+/**
+ * Displays "unauthorized" message and logout button
+ * @param param0 {backgroundIndex: index of the background to show, if not provided, picks at random}
+ * @returns
+ */
+const Unauthorized: React.FC<Props> = ({ backgroundIndex }) => {
+  const dispatch = useDispatch();
+
+  // this is asserted as non-null as it shouldn't be render
+  // if user is not authentidated (user data doesn't exist)
+  // but only if user is authenticated and not admin
+  const userAuthData = useSelector(getLocalAuth)!;
+
+  const background = _.isNil(backgroundIndex)
+    ? _.sample(backgrounds)
+    : backgrounds[backgroundIndex % backgrounds.length];
+
+  const style = {
+    ...baseStyle,
+    backgroundImage: `url(${background})`,
+  };
+
+  const logOut = () => dispatch(signOut());
+  const { t } = useTranslation();
+
+  return (
+    <Paper style={style}>
+      <Typography component="h1" variant="h2">
+        {t(AuthMessage.NotRegistered)}
+      </Typography>
+      <Typography component="h2" variant="h4">
+        {t(AuthMessage.ContactAdminsForRegistration)}
+      </Typography>
+      <Typography component="h2" variant="h5">
+        {t(AuthMessage.LoggedInWith)}{" "}
+        <b>{userAuthData?.email || userAuthData?.phoneNumber || ""}</b>
+      </Typography>
+
+      <Button variant="contained" onClick={logOut}>
+        {t(AuthMessage.TryAgain)}
+      </Button>
+    </Paper>
+  );
+};
+
+export default Unauthorized;

--- a/eisbuk-admin/src/enums/functions.ts
+++ b/eisbuk-admin/src/enums/functions.ts
@@ -10,6 +10,7 @@ export enum CloudFunction {
   CreateTestData = "createTestData",
   CreateOrganization = "createOrganization",
   CreateDefaultUser = "createDefaultUser",
+  CreateUser = "createUser",
   CreateTestSlots = "createTestSlots",
 
   PruneSlotsByDay = "pruneSlotsByDay",

--- a/eisbuk-admin/src/enums/functions.ts
+++ b/eisbuk-admin/src/enums/functions.ts
@@ -3,6 +3,8 @@ export enum CloudFunction {
   SendEmail = "sendEmail",
   SendSMS = "sendSMS",
 
+  QueryAuthStatus = "queryAuthStatus",
+
   FinalizeBookings = "finalizeBookings",
 
   CreateTestData = "createTestData",

--- a/eisbuk-admin/src/enums/routes.ts
+++ b/eisbuk-admin/src/enums/routes.ts
@@ -1,6 +1,7 @@
 export enum Routes {
   Login = "/login",
   Unauthorized = "/unautorized",
+  NotRegistered = "/not_registered",
   CustomerArea = "/customer_area",
   AttendancePrintable = "/attendance_printable",
   Debug = "/debug",

--- a/eisbuk-admin/src/enums/translations.ts
+++ b/eisbuk-admin/src/enums/translations.ts
@@ -16,7 +16,9 @@ export enum CustomerNavigationLabel {
 // #region auth
 export enum AuthMessage {
   NotAuthorized = "Authorization.NotAuthorized",
+  NotRegistered = "Authorization.NotRegistered",
   AdminsOnly = "Authorization.AdminsOnly",
+  ContactAdminsForRegistration = "Authorization.ContactAdminsForRegistration",
   LoggedInWith = "Authorization.LoggedInWith",
   TryAgain = "Authorization.TryAgain",
 

--- a/eisbuk-admin/src/react-redux-firebase/hooks/useConnectAuthToStore.ts
+++ b/eisbuk-admin/src/react-redux-firebase/hooks/useConnectAuthToStore.ts
@@ -6,10 +6,8 @@ import { isEmpty } from "lodash";
 
 import { LocalStore } from "@/types/store";
 
-import {
-  revalidateAdminStatus,
-  updateAuthUser,
-} from "@/store/actions/authOperations";
+import { updateAuthUser } from "@/store/actions/authOperations";
+import { getLocalAuth } from "@/store/selectors/auth";
 
 /**
  * A hook used to subscribe to firebase auth state changes and
@@ -33,7 +31,8 @@ export default (auth: Auth, store: Store<LocalStore, any>): void => {
   // as we're using organization data to check if user is admin of given organization
   useEffect(() => {
     if (organizations && !isEmpty(organizations)) {
-      dispatch(revalidateAdminStatus);
+      const authUser = getLocalAuth(store.getState());
+      dispatch(updateAuthUser(authUser));
     }
   }, [organizations]);
 

--- a/eisbuk-admin/src/store/actions/__tests__/authOperations.test.ts
+++ b/eisbuk-admin/src/store/actions/__tests__/authOperations.test.ts
@@ -4,131 +4,86 @@
 
 import { User } from "@firebase/auth";
 
-import { Collection, OrganizationData } from "eisbuk-shared";
-
 import { defaultUser } from "@/__testSetup__/envData";
 
-import { __organization__ } from "@/lib/constants";
-
-import { Action } from "@/enums/store";
-
-import { revalidateAdminStatus, updateAuthUser } from "../authOperations";
-import { updateLocalDocuments } from "@/react-redux-firebase/actions";
+import { updateAuthUser } from "../authOperations";
 
 import { getNewStore } from "@/store/createStore";
 
 // a minimalist dummy entry for a user
 const testUser: User = { uid: "some uuid", email: defaultUser.email } as User;
 
-/**
- * A store we'll be using throughout the tests,
- * gets restarted before each test
- */
-let testStore = getNewStore();
+const mockQueryAuthStatus = jest.fn();
+// mock the entire functions package as we're only using `httpsCallable`
+jest.mock("@firebase/functions", () => ({
+  getFunctions: jest.fn(),
+  // httpsCallable will always return mockQueryAuthStatus as `queryAuthStatus`
+  // is the only usage of `httpsCallable` in `authOperations` package
+  httpsCallable: () => mockQueryAuthStatus,
+}));
 
 describe("Auth operations", () => {
-  beforeEach(() => {
-    // restart the store to default state,
-    // with test organization added to the store
-    testStore = getNewStore();
-    const { dispatch } = testStore;
-    dispatch(
-      updateLocalDocuments(Collection.Organizations, {
-        [__organization__]: {
-          admins: [defaultUser.email],
-        } as OrganizationData,
-      })
-    );
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   describe("test updating auth state on user changed", () => {
-    test("should update user to local store", async () => {
-      const { dispatch, getState } = testStore;
+    test("should update user auth state to local store", async () => {
+      const { dispatch, getState } = getNewStore();
       const testThunk = updateAuthUser(testUser);
+      // try with user authenticated, but not admin nor customer
+      mockQueryAuthStatus.mockResolvedValueOnce({
+        data: {
+          isAdmin: false,
+        },
+      });
       await testThunk(dispatch, getState);
-      const { userData, isLoaded } = getState().auth;
-      expect(userData).toEqual(testUser);
-      expect(isLoaded).toEqual(true);
-    });
-
-    test("should update isAdmin flag if user is an admin of current organization", async () => {
-      const { dispatch, getState } = testStore;
-      const testThunk = updateAuthUser(testUser);
+      expect(getState().auth).toEqual({
+        isAdmin: false,
+        isEmpty: false,
+        isLoaded: true,
+        userData: testUser,
+      });
+      // try with customer user
+      mockQueryAuthStatus.mockResolvedValueOnce({
+        data: {
+          isAdmin: false,
+          bookingsSecretKey: "secret-key",
+        },
+      });
       await testThunk(dispatch, getState);
-      const { isAdmin, isEmpty, isLoaded } = getState().auth;
-      expect(isAdmin).toEqual(true);
-      expect(isEmpty).toEqual(false);
-      expect(isLoaded).toEqual(true);
+      expect(getState().auth).toEqual({
+        isAdmin: false,
+        isEmpty: false,
+        isLoaded: true,
+        userData: testUser,
+        bookingsSecretKey: "secret-key",
+      });
+      // try with admin user
+      mockQueryAuthStatus.mockResolvedValueOnce({ data: { isAdmin: true } });
+      await testThunk(dispatch, getState);
+      expect(getState().auth).toEqual({
+        userData: testUser,
+        isAdmin: true,
+        isEmpty: false,
+        isLoaded: true,
+      });
     });
 
     test("should reset the state (perform local logout) if no user is received", async () => {
-      const { dispatch, getState } = testStore;
+      // set up tests with authenticated admin
+      const { dispatch, getState } = getNewStore();
+      mockQueryAuthStatus.mockResolvedValueOnce({ data: { isAdmin: true } });
       await updateAuthUser(testUser)(dispatch, getState);
       // run the thunk
       const testThunk = updateAuthUser(null);
       await testThunk(dispatch, getState);
-      const auth = getState().auth;
-      expect(auth).toEqual({
+      expect(getState().auth).toEqual({
         userData: null,
         isAdmin: false,
         isEmpty: true,
         isLoaded: true,
       });
-    });
-
-    test("should update 'userData' and set 'isEmpty' to false if user is registered in firebase auth, but not an admin of current organization", async () => {
-      const { dispatch, getState } = testStore;
-      const testThunk = updateAuthUser({
-        ...testUser,
-        email: "not-admmin@gmail.com",
-      });
-      await testThunk(dispatch, getState);
-      const { isAdmin, isEmpty, isLoaded } = getState().auth;
-      expect(isAdmin).toEqual(false);
-      expect(isEmpty).toEqual(false);
-      expect(isLoaded).toEqual(true);
-    });
-  });
-
-  describe("test updating isAdmin on revalidation", () => {
-    test("should get 'userData' and organizations data from store and update 'auth.isAdmin' if needed", async () => {
-      const { dispatch, getState } = testStore;
-      dispatch({
-        type: Action.UpdateAuthInfo,
-        payload: {
-          userData: testUser,
-          // remember here that the test user should be admin
-          // because of `beforeEach`. Here we're explicitly setting it
-          // to `false` to test manual revalidation
-          isAdmin: false,
-          isEmpty: false,
-          isLoaded: true,
-        },
-      });
-      await revalidateAdminStatus(dispatch, getState);
-      const { isAdmin } = getState().auth;
-      expect(isAdmin).toEqual(true);
-    });
-
-    test("should not dispatch enything if 'isAdmin' is as it should be", async () => {
-      const { dispatch, getState } = testStore;
-      dispatch({
-        type: Action.UpdateAuthInfo,
-        payload: {
-          userData: testUser,
-          // remember here that the test user should be admin
-          // because of `beforeEach`. Here we're explicitly setting it
-          // to `false` to test manual revalidation
-          isAdmin: true,
-          isEmpty: false,
-          isLoaded: true,
-        },
-      });
-      const mockDispatch = jest.fn();
-      await revalidateAdminStatus(mockDispatch, getState);
-      // is admin is already true (as it should be)
-      // so mockDispatch shouldn't be called
-      expect(mockDispatch).not.toHaveBeenCalled();
     });
   });
 });

--- a/eisbuk-admin/src/store/actions/authOperations.ts
+++ b/eisbuk-admin/src/store/actions/authOperations.ts
@@ -1,22 +1,18 @@
 // import { CollectionReference, getFirestore } from "@firebase/firestore";
 import { getAuth, User } from "@firebase/auth";
+import { httpsCallable, getFunctions } from "@firebase/functions";
 import i18n from "i18next";
 
+import { AuthStatus, QueryAuthStatusPayload } from "eisbuk-shared";
+
 import { getOrganization } from "@/lib/getters";
-import { Collection } from "eisbuk-shared";
 
 import { Action, NotifVariant } from "@/enums/store";
+import { CloudFunction } from "@/enums/functions";
 
-import {
-  FirestoreData,
-  AuthReducerAction,
-  FirestoreThunk,
-} from "@/types/store";
+import { AuthReducerAction, FirestoreThunk } from "@/types/store";
 
-import {
-  enqueueNotification,
-  // showErrSnackbar,
-} from "@/store/actions/appActions";
+import { enqueueNotification } from "@/store/actions/appActions";
 
 /**
  * Creates firestore async thunk:
@@ -53,106 +49,55 @@ export const signOut = (): FirestoreThunk => async (dispatch) => {
 };
 
 /**
- * Creates firestore async thunk:
- * - sends a query to firestore regarding admin status of the user
- * - on success updates admin status in local store
- * - on error enqueues error snackbar
- * @returns async thunk
- */
-// export const queryOrganizationStatus = (): FirestoreThunk => async (
-//   dispatch,
-//   getState
-// ) => {
-//   try {
-//     const db = getFirestore();
-
-//     const orgRef = doc(db, `${Collection.Organizations}/${__organization__}`);
-//     const res = await getDoc(orgRef);
-//     const admins: string[] = res.data()?.admins ?? [];
-//     const { uid } = (getState() as any).firebase.auth; /** @TODO_AUTH */
-
-//     if (uid) {
-//       dispatch(updateOrganizationStatus(uid, admins));
-//     }
-//   } catch (err) {
-//     /** @TODO inform the user that the login was successful, but */
-//     // they don't have permission to access
-//     dispatch(showErrSnackbar);
-//   }
-// };
-
-/**
  * Checks admin status locally (against organization in local store)
  * @param authString email or phone for which to check against organization's admins
  * @param orgsInStore organizations in local store against which to check
  * @returns isAdmin
  */
-export const checkAdminStatus = (
-  authString: string,
-  orgsInStore?: FirestoreData[Collection.Organizations]
-): boolean => {
+export const checkAuthStatus = async (
+  authString: string
+): Promise<AuthStatus> => {
   const organization = getOrganization();
-  if (!authString || !orgsInStore) {
-    // At least one of authString or orgsInStore is missing
-    // hence the current user is not an admin
-    return false;
+
+  // fail early if no auth string
+  if (!authString) {
+    return { isAdmin: false };
   }
-  if (!orgsInStore[organization]) {
-    // The current organization is not in the local store
-    return false;
-  }
-  return orgsInStore[organization].admins.includes(authString);
+
+  const res = await httpsCallable<QueryAuthStatusPayload, AuthStatus>(
+    getFunctions(),
+    CloudFunction.QueryAuthStatus
+  )({ organization, authString });
+
+  return res.data;
 };
 /**
  * An update user callback, called by firestore's `onAuthStateChanged`.
- * Get's passed a new user, determines the `isAuthenticated` and `isAdmin` state,
+ * Gets passed a new user, determines the `isAuthenticated` and `isAdmin` state,
  * dispatches the updates to store.
  * @param user new user (if authenticated) or null if not authenticated as a user in our firebase auth record
  * @returns a firestore thunk dispatching appropriate updates to the store
  */
 export const updateAuthUser =
   (user: User | null): FirestoreThunk =>
-  async (dispatch, getState) => {
-    // stop early (and log out) if not user recieved
+  async (dispatch) => {
+    // stop early (and log out) if no user recieved
     if (!user) {
       dispatch({ type: Action.Logout });
       return;
     }
 
-    const orgsInStore = getState().firestore.data.organizations;
     const { email, phoneNumber } = user;
 
-    const isAdmin = checkAdminStatus(email || phoneNumber || "", orgsInStore);
+    const authStatus = await checkAuthStatus(email || phoneNumber || "");
 
     dispatch({
       type: Action.UpdateAuthInfo,
-      payload: { userData: user, isAdmin, isEmpty: false, isLoaded: true },
+      payload: {
+        ...authStatus,
+        userData: user,
+        isEmpty: false,
+        isLoaded: true,
+      },
     } as AuthReducerAction<Action.UpdateAuthInfo>);
   };
-
-/**
- * A thunk ran when the organization status is updated, reads the store state internally
- * and revalidates the auth user's admin status against updated organization.
- */
-export const revalidateAdminStatus: FirestoreThunk = async (
-  dispatch,
-  getState
-) => {
-  const { organizations } = getState().firestore.data;
-  const { userData, isAdmin: isAdminInStore } = getState().auth;
-
-  // the user is authenticated if user data recieved
-  // (even if they're not an admin for a current organization)
-  const isAdmin = checkAdminStatus(
-    userData?.email || userData?.phoneNumber || "",
-    organizations
-  );
-
-  // update store only if needed
-  if (isAdmin !== isAdminInStore) {
-    dispatch({
-      type: Action.UpdateAdminStatus,
-      payload: isAdmin,
-    } as AuthReducerAction<Action.UpdateAdminStatus>);
-  }
-};

--- a/eisbuk-admin/src/store/actions/authOperations.ts
+++ b/eisbuk-admin/src/store/actions/authOperations.ts
@@ -1,9 +1,8 @@
 // import { CollectionReference, getFirestore } from "@firebase/firestore";
 import { getAuth, User } from "@firebase/auth";
-import { httpsCallable, getFunctions } from "@firebase/functions";
 import i18n from "i18next";
 
-import { AuthStatus, QueryAuthStatusPayload } from "eisbuk-shared";
+import { AuthStatus } from "eisbuk-shared";
 
 import { getOrganization } from "@/lib/getters";
 
@@ -13,6 +12,7 @@ import { CloudFunction } from "@/enums/functions";
 import { AuthReducerAction, FirestoreThunk } from "@/types/store";
 
 import { enqueueNotification } from "@/store/actions/appActions";
+import { createCloudFunctionCaller } from "@/utils/firebase";
 
 /**
  * Creates firestore async thunk:
@@ -64,10 +64,10 @@ export const checkAuthStatus = async (
     return { isAdmin: false };
   }
 
-  const res = await httpsCallable<QueryAuthStatusPayload, AuthStatus>(
-    getFunctions(),
-    CloudFunction.QueryAuthStatus
-  )({ organization, authString });
+  const res = await createCloudFunctionCaller(CloudFunction.QueryAuthStatus, {
+    organization,
+    authString,
+  })();
 
   return res.data;
 };

--- a/eisbuk-admin/src/store/selectors/auth.ts
+++ b/eisbuk-admin/src/store/selectors/auth.ts
@@ -31,6 +31,14 @@ export const getIsAuthEmpty = (state: LocalStore): boolean =>
 export const getIsAdmin = (state: LocalStore): boolean => state.auth.isAdmin;
 
 /**
+ * Get secretKey for customer's bookings from store (if any)
+ * @param state Local Redux Store
+ * @returns secretKey if it exists, undefined if it doesn't
+ */
+export const getBookingsSecretKey = (state: LocalStore): string | undefined =>
+  state.auth.bookingsSecretKey;
+
+/**
  * Get boolean representing auth load state (set to true when initial auth is loaded)
  * @param state Local Redux Store
  * @returns true is current user is admin (boolean)

--- a/eisbuk-admin/src/translations/en.json
+++ b/eisbuk-admin/src/translations/en.json
@@ -11,8 +11,10 @@
   },
 
   "Authorization": {
-    "NotAuthorized": "You are not authorized to login",
+    "NotAuthorized": "Access not authorized",
+    "NotRegistered": "You are not registered yet",
     "AdminsOnly": "This space is reserved for administrators",
+    "ContactAdminsForRegistration": "Contact the organization admin(s) to get registered as a customer",
     "LoggedInWith": "You are logged in with:",
     "TryAgain": "Log out and try again with a different user",
 

--- a/eisbuk-admin/src/translations/it.json
+++ b/eisbuk-admin/src/translations/it.json
@@ -12,7 +12,9 @@
 
   "Authorization": {
     "NotAuthorized": "Non sei autorizzato ad accedere.",
+    "NotRegistered": "You are not registered yet",
     "AdminsOnly": "Questo spazio è riservato agli amministratori",
+    "ContactAdminsForRegistration": "Contact the organization admin(s) to get registered as a customer",
     "LoggedInWith": "Hai effettuato l'accesso con:",
     "TryAgain": "Esci e riprova con un altro utente",
 

--- a/eisbuk-admin/src/types/store.ts
+++ b/eisbuk-admin/src/types/store.ts
@@ -7,6 +7,7 @@ import { Unsubscribe } from "@firebase/firestore";
 import { User } from "@firebase/auth";
 
 import {
+  AuthStatus,
   BookingSubCollection,
   Collection,
   Customer,
@@ -98,9 +99,8 @@ export type AuthReducerAction<A extends AuthAction> =
 /**
  * `authInfoEisbuuk` portion of the local store
  */
-export interface AuthState {
+export interface AuthState extends AuthStatus {
   userData: User | null;
-  isAdmin: boolean;
   isEmpty: boolean;
   isLoaded: boolean;
 }

--- a/eisbuk-admin/src/utils/firebase.ts
+++ b/eisbuk-admin/src/utils/firebase.ts
@@ -15,9 +15,8 @@ const functions = getFunctions(app, "europe-west6");
  */
 export const createCloudFunctionCaller =
   (functionName: CloudFunction, payload?: Record<string, any>) =>
-  async (): Promise<void> => {
-    await httpsCallable(
+  async (): Promise<any> =>
+    httpsCallable(
       functions,
       functionName
     )({ ...payload, organization: getOrganization() });
-  };

--- a/eisbuk-shared/src/types/cloudFunctions.ts
+++ b/eisbuk-shared/src/types/cloudFunctions.ts
@@ -9,6 +9,17 @@ export interface SendSMSPayload extends SMSMessage {
   organization: string;
 }
 
+/**
+ * Payload passed to `createUser` cloud function (for testing)
+ */
+export type CreateAuthUserPayload = Partial<{
+  email: string;
+  phoneNumber: string;
+  password: string;
+  organization: string;
+  isAdmin: boolean;
+}>;
+
 // #region queryAuthStatus
 /**
  * Payload of `queryAuthStatus` cloud function

--- a/eisbuk-shared/src/types/cloudFunctions.ts
+++ b/eisbuk-shared/src/types/cloudFunctions.ts
@@ -8,3 +8,22 @@ export interface SendMailPayload extends EmailMessage {
 export interface SendSMSPayload extends SMSMessage {
   organization: string;
 }
+
+/**
+ * Auth status of an authenticated user. Returned by
+ * `queryAuthStatus` cloud function and stored to `auth`
+ * state of redux on client app
+ */
+export interface AuthStatus {
+  /**
+   * Is user admin of current organization
+   */
+  isAdmin: boolean;
+  /**
+   * If user is not admin of current organization,
+   * but is a registered customer, this is their
+   * secret key used to access bookings.
+   * `undefined` if user is not a customer of an organization
+   */
+  bookingsSecretKey?: string;
+}

--- a/eisbuk-shared/src/types/cloudFunctions.ts
+++ b/eisbuk-shared/src/types/cloudFunctions.ts
@@ -9,6 +9,17 @@ export interface SendSMSPayload extends SMSMessage {
   organization: string;
 }
 
+// #region queryAuthStatus
+/**
+ * Payload of `queryAuthStatus` cloud function
+ */
+export interface QueryAuthStatusPayload {
+  /** Current organization */
+  organization: string;
+  /** String used to authenticate user, either email or phone */
+  authString: string;
+}
+
 /**
  * Auth status of an authenticated user. Returned by
  * `queryAuthStatus` cloud function and stored to `auth`
@@ -27,3 +38,4 @@ export interface AuthStatus {
    */
   bookingsSecretKey?: string;
 }
+// #endregion queryAuthStatus


### PR DESCRIPTION
After signing in, the user gets redirected to appropriate route:
- attendance route for admins
- customer_area for registered customers (but not admins)
- not_registered route for non-registered customers

There are some additional points to take into account:
(1) we're allowing anybody to register using email - this should either be forbidden (auth users can be created on customer creation) 