### PR TITLE
Temp/igorice organization fallback

### DIFF
--- a/packages/client/src/__testSetup__/getTestEnv.ts
+++ b/packages/client/src/__testSetup__/getTestEnv.ts
@@ -9,7 +9,7 @@ import { Collection } from "@eisbuk/shared";
 
 import { defaultUser } from "@/__testSetup__/envData";
 
-import { __organization__ } from "@/lib/constants";
+import { getOrganization } from "@/lib/getters";
 
 export type TestEnvFirestore = ReturnType<RulesTestContext["firestore"]>;
 export type ExtendedTestEnvFirestore = TestEnvFirestore & {
@@ -48,7 +48,7 @@ export const getTestEnv: GetTestEnv = async ({
   // as organization's admin in firestore for a complete `isAdmin` functionality
   await testEnv.withSecurityRulesDisabled(async (context) => {
     const db = context.firestore();
-    await setDoc(doc(db, Collection.Organizations, __organization__), {
+    await setDoc(doc(db, Collection.Organizations, getOrganization()), {
       admins: [defaultUser.email],
     });
     // run setup function if any provided

--- a/packages/client/src/__testUtils__/firestore.ts
+++ b/packages/client/src/__testUtils__/firestore.ts
@@ -5,7 +5,7 @@ import { Collection, OrgSubCollection } from "@eisbuk/shared";
 
 import { adminDb } from "@/__testSetup__/firestoreSetup";
 
-import { __organization__ } from "@/lib/constants";
+import { getOrganization } from "@/lib/getters";
 
 import { LocalStore } from "@/types/store";
 
@@ -61,7 +61,7 @@ export const createTestStore = ({
 export const deleteAll = async (): Promise<void> => {
   const org = adminDb
     .collection(Collection.Organizations)
-    .doc(__organization__);
+    .doc(getOrganization());
 
   const operations: Promise<any>[] = [];
 
@@ -71,7 +71,7 @@ export const deleteAll = async (): Promise<void> => {
   // delete secrets
   const orgSecrets = adminDb
     .collection(Collection.Secrets)
-    .doc(__organization__);
+    .doc(getOrganization());
   operations.push(orgSecrets.delete());
 
   // remove `existingSecrets` from organization

--- a/packages/client/src/__tests__/customerDataTriggers.test.ts
+++ b/packages/client/src/__tests__/customerDataTriggers.test.ts
@@ -14,7 +14,7 @@ import {
 
 import { db } from "@/__testSetup__/firestoreSetup";
 
-import { __organization__ } from "@/lib/constants";
+import { getOrganization } from "@/lib/getters";
 
 import { deleteAll } from "@/__testUtils__/firestore";
 import { waitForCondition } from "@/__testUtils__/helpers";
@@ -24,8 +24,8 @@ import { loginDefaultUser } from "@/__testUtils__/auth";
 
 import { saul } from "@/__testData__/customers";
 
-const customersCollectionPath = `${Collection.Organizations}/${__organization__}/${OrgSubCollection.Customers}`;
-const bookingsCollectionPath = `${Collection.Organizations}/${__organization__}/${OrgSubCollection.Bookings}`;
+const customersCollectionPath = `${Collection.Organizations}/${getOrganization()}/${OrgSubCollection.Customers}`;
+const bookingsCollectionPath = `${Collection.Organizations}/${getOrganization()}/${OrgSubCollection.Bookings}`;
 
 describe("Customer triggers", () => {
   beforeEach(async () => {

--- a/packages/client/src/__tests__/dataTriggers.test.ts
+++ b/packages/client/src/__tests__/dataTriggers.test.ts
@@ -14,7 +14,7 @@ import {
 } from "@eisbuk/shared";
 
 import { adminDb } from "@/__testSetup__/firestoreSetup";
-import { __organization__ } from "@/lib/constants";
+import { getOrganization } from "@/lib/getters";
 
 import { getDocumentRef, waitForCondition } from "@/__testUtils__/helpers";
 import { testWithEmulator } from "@/__testUtils__/envUtils";
@@ -38,7 +38,7 @@ const customerBooking = getCustomerBase(saul);
 const testMonth = testDate.substring(0, 7);
 
 // document paths
-const orgPath = `${Collection.Organizations}/${__organization__}`;
+const orgPath = `${Collection.Organizations}/${getOrganization()}`;
 const slotsCollectionPath = `${orgPath}/${OrgSubCollection.Slots}`;
 const attendanceCollPath = `${orgPath}/${OrgSubCollection.Attendance}`;
 const bookingsCollectionPath = `${orgPath}/${OrgSubCollection.Bookings}`;
@@ -274,13 +274,13 @@ describe("Cloud functions -> Data triggers ->,", () => {
         // add new secret to trigger registering
         const orgSecretsRef = getDocumentRef(
           adminDb,
-          `${Collection.Secrets}/${__organization__}`
+          `${Collection.Secrets}/${getOrganization()}`
         );
         await orgSecretsRef.set({ testSecret: "abc123" });
         // check proper updates triggerd by write to secrets
         let existingSecrets = (
           (await waitForCondition({
-            documentPath: `${Collection.Organizations}/${__organization__}`,
+            documentPath: `${Collection.Organizations}/${getOrganization()}`,
             condition: (data) => Boolean(data?.existingSecrets.length),
           })) as OrganizationData
         ).existingSecrets;
@@ -290,7 +290,7 @@ describe("Cloud functions -> Data triggers ->,", () => {
         await orgSecretsRef.set({ anotherSecret: "abc234" }, { merge: true });
         existingSecrets = (
           (await waitForCondition({
-            documentPath: `${Collection.Organizations}/${__organization__}`,
+            documentPath: `${Collection.Organizations}/${getOrganization()}`,
             condition: (data) => data?.existingSecrets.length === 2,
           })) as OrganizationData
         ).existingSecrets;
@@ -300,7 +300,7 @@ describe("Cloud functions -> Data triggers ->,", () => {
         await orgSecretsRef.set({ anotherSecret: "abc234" });
         existingSecrets = (
           (await waitForCondition({
-            documentPath: `${Collection.Organizations}/${__organization__}`,
+            documentPath: `${Collection.Organizations}/${getOrganization()}`,
             condition: (data) => data?.existingSecrets.length === 1,
           })) as OrganizationData
         ).existingSecrets;

--- a/packages/client/src/__tests__/firestoreRules.test.ts
+++ b/packages/client/src/__tests__/firestoreRules.test.ts
@@ -18,7 +18,7 @@ import {
   getCustomerBase,
 } from "@eisbuk/shared";
 
-import { __organization__ } from "@/lib/constants";
+import { getOrganization } from "@/lib/getters";
 import { defaultCustomerFormValues } from "@/lib/data";
 
 import { getTestEnv } from "@/__testSetup__/getTestEnv";
@@ -34,7 +34,7 @@ describe("Firestore rules", () => {
       "should allow organziation admin read and write access to organization",
       async () => {
         const db = await getTestEnv({});
-        const orgRef = doc(db, Collection.Organizations, __organization__);
+        const orgRef = doc(db, Collection.Organizations, getOrganization());
         // check read access
         await assertSucceeds(getDoc(orgRef));
         // check write access
@@ -48,7 +48,7 @@ describe("Firestore rules", () => {
       "should not allow read nor write access to an unauth user",
       async () => {
         const db = await getTestEnv({ auth: false });
-        const orgRef = doc(db, Collection.Organizations, __organization__);
+        const orgRef = doc(db, Collection.Organizations, getOrganization());
         // check read access
         await assertFails(getDoc(orgRef));
         // check write access
@@ -89,7 +89,7 @@ describe("Firestore rules", () => {
      */
     const pathToSlots = [
       Collection.Organizations,
-      __organization__,
+      getOrganization(),
       OrgSubCollection.Slots,
     ].join("/");
     const pathToSlot = [pathToSlots, baseSlot.id].join("/");
@@ -221,14 +221,14 @@ describe("Firestore rules", () => {
     const monthStr = baseSlot.date.substring(0, 7);
     const pathToMonth = [
       Collection.Organizations,
-      __organization__,
+      getOrganization(),
       OrgSubCollection.SlotsByDay,
       monthStr,
     ].join("/");
 
     const pathToSlot = [
       Collection.Organizations,
-      __organization__,
+      getOrganization(),
       OrgSubCollection.Slots,
       baseSlot.id,
     ].join("/");
@@ -264,7 +264,7 @@ describe("Firestore rules", () => {
      */
     const saulBookingsPath = [
       Collection.Organizations,
-      __organization__,
+      getOrganization(),
       OrgSubCollection.Bookings,
       saul.secretKey,
     ].join("/");
@@ -323,7 +323,7 @@ describe("Firestore rules", () => {
      */
     const testSlotPath = [
       Collection.Organizations,
-      __organization__,
+      getOrganization(),
       OrgSubCollection.Slots,
       baseSlot.id,
     ].join("/");
@@ -450,7 +450,7 @@ describe("Firestore rules", () => {
   describe("Customers rules", () => {
     const saulPath = [
       Collection.Organizations,
-      __organization__,
+      getOrganization(),
       OrgSubCollection.Customers,
       saul.id,
     ].join("/");
@@ -677,7 +677,7 @@ describe("Firestore rules", () => {
      */
     const attendanceSlotPath = [
       Collection.Organizations,
-      __organization__,
+      getOrganization(),
       OrgSubCollection.Attendance,
       baseSlot.id,
     ].join("/");
@@ -742,7 +742,7 @@ describe("Firestore rules", () => {
               db,
               [
                 Collection.Organizations,
-                __organization__,
+                getOrganization(),
                 OrgSubCollection.Attendance,
                 "new-attendance",
               ].join("/")

--- a/packages/client/src/__tests__/smokeTest.test.ts
+++ b/packages/client/src/__tests__/smokeTest.test.ts
@@ -7,7 +7,7 @@ import { signInWithEmailAndPassword, signOut } from "@firebase/auth";
 
 import { Collection, OrgSubCollection } from "@eisbuk/shared";
 
-import { __organization__ } from "@/lib/constants";
+import { getOrganization } from "@/lib/getters";
 
 import i18n, { ActionButton } from "@eisbuk/translations";
 
@@ -36,7 +36,7 @@ describe("Smoke test", () => {
     testWithEmulator("should create a default organization", async () => {
       const testOrgRef = adminDb
         .collection(Collection.Organizations)
-        .doc(__organization__);
+        .doc(getOrganization());
       const testOrgCreated = (await testOrgRef.get()).exists;
       expect(testOrgCreated).toEqual(true);
     });
@@ -60,7 +60,7 @@ describe("Smoke test", () => {
       async () => {
         const saulDocRef = doc(
           db,
-          `${Collection.Organizations}/${__organization__}/${OrgSubCollection.Customers}/${saul.id}`
+          `${Collection.Organizations}/${getOrganization()}/${OrgSubCollection.Customers}/${saul.id}`
         );
 
         // should not allow access to customers before authentication

--- a/packages/client/src/lib/constants.ts
+++ b/packages/client/src/lib/constants.ts
@@ -24,7 +24,7 @@ export const __isTest__ = __buildEnv__ === "test";
 export const __organization__ = __isTest__
   ? // since we're importing organization string from this constant
     // to make our lives easier (so that we don't have to mock organization)
-    // the __organization__ in test environment will always have a value of __testOrganization__
+    // the getOrganization() in test environment will always have a value of __testOrganization__
     __testOrganization__
   : process.env.REACT_APP_EISBUK_SITE ||
     (window.location

--- a/packages/client/src/lib/getters.ts
+++ b/packages/client/src/lib/getters.ts
@@ -16,5 +16,11 @@ export const getOrganization = (): string => {
     //
   }
 
+  /**
+   * @TEMP replace `igoriceteam` with `igorice` in order to use the old organization entry (igorice)
+   * with new domain name (igoriceteam), until we migrate the organization entries to `igoriceteam`.
+   */
+  organization = organization.replace(/igoriceteam/i, "igorice");
+
   return organization;
 };

--- a/packages/client/src/react-redux-firebase/thunks/__testData__/slots.ts
+++ b/packages/client/src/react-redux-firebase/thunks/__testData__/slots.ts
@@ -3,7 +3,7 @@ import { DateTime } from "luxon";
 
 import { Collection, luxon2ISODate, OrgSubCollection } from "@eisbuk/shared";
 
-import { __organization__ } from "@/lib/constants";
+import { getOrganization } from "@/lib/getters";
 
 import { TestEnvSetup } from "../__testUtils__/utils";
 
@@ -35,7 +35,7 @@ export const createTestSlots: TestEnvSetup = async (db) => {
         doc(
           db,
           Collection.Organizations,
-          __organization__,
+          getOrganization(),
           OrgSubCollection.Slots,
           slot.id
         ),
@@ -47,6 +47,6 @@ export const createTestSlots: TestEnvSetup = async (db) => {
 
 export const slotsCollPath = [
   Collection.Organizations,
-  __organization__,
+  getOrganization(),
   OrgSubCollection.Slots,
 ].join("/");

--- a/packages/client/src/react-redux-firebase/thunks/__testUtils__/utils.ts
+++ b/packages/client/src/react-redux-firebase/thunks/__testUtils__/utils.ts
@@ -8,7 +8,7 @@ import { Collection } from "@eisbuk/shared";
 
 import { defaultUser } from "@/__testSetup__/envData";
 
-import { __organization__ } from "@/lib/constants";
+import { getOrganization } from "@/lib/getters";
 
 /** @TEMP replace this with central init test env function */
 export type TestEnvFirestore = ReturnType<RulesTestContext["firestore"]>;
@@ -27,7 +27,7 @@ export const getAuthTestEnv: GetTestEnv = async (setup = async () => {}) => {
   // as organization's admin in firestore for a complete `isAdmin` functionality
   await testEnv.withSecurityRulesDisabled(async (context) => {
     const db = context.firestore();
-    await setDoc(doc(db, Collection.Organizations, __organization__), {
+    await setDoc(doc(db, Collection.Organizations, getOrganization()), {
       admins: [defaultUser.email],
     });
     // run setup function if any provided

--- a/packages/client/src/react-redux-firebase/thunks/__tests__/onSnapshotHandlers.test.ts
+++ b/packages/client/src/react-redux-firebase/thunks/__tests__/onSnapshotHandlers.test.ts
@@ -2,7 +2,7 @@ import { collection, onSnapshot, setDoc, doc } from "@firebase/firestore";
 
 import { Collection, OrgSubCollection } from "@eisbuk/shared";
 
-import { __organization__ } from "@/lib/constants";
+import { getOrganization } from "@/lib/getters";
 
 import { getNewStore } from "@/store/createStore";
 
@@ -28,7 +28,7 @@ describe("Firestore subscriptions", () => {
         const customersRef = collection(
           db,
           Collection.Organizations,
-          __organization__,
+          getOrganization(),
           OrgSubCollection.Customers
         );
         onSnapshot(
@@ -60,7 +60,7 @@ describe("Firestore subscriptions", () => {
         const saulRef = doc(
           db,
           Collection.Organizations,
-          __organization__,
+          getOrganization(),
           OrgSubCollection.Customers,
           saul.id
         );

--- a/packages/client/src/react-redux-firebase/thunks/__tests__/rangeConstraintSubscriptions.test.ts
+++ b/packages/client/src/react-redux-firebase/thunks/__tests__/rangeConstraintSubscriptions.test.ts
@@ -17,7 +17,7 @@ import {
   testSlots,
   slotsCollPath,
 } from "../__testData__/slots";
-import { __organization__ } from "@/lib/constants";
+import { getOrganization } from "@/lib/getters";
 import { deleteDoc } from "firebase/firestore";
 
 describe("Firestore subscriptions", () => {
@@ -82,7 +82,7 @@ describe("Firestore subscriptions", () => {
         const slotRef = doc(
           db,
           Collection.Organizations,
-          __organization__,
+          getOrganization(),
           OrgSubCollection.Slots,
           testSlots[0].id
         );

--- a/packages/client/src/store/actions/__testUtils__/firestore.ts
+++ b/packages/client/src/store/actions/__testUtils__/firestore.ts
@@ -17,7 +17,7 @@ import {
 
 import { TestEnvFirestore } from "@/__testSetup__/getTestEnv";
 
-import { __organization__ } from "@/lib/constants";
+import { getOrganization } from "@/lib/getters";
 
 import { LocalStore } from "@/types/store";
 
@@ -31,7 +31,7 @@ import {
 /**
  * A stored path to test organization in firestore
  */
-const orgPath = [Collection.Organizations, __organization__].join("/");
+const orgPath = [Collection.Organizations, getOrganization()].join("/");
 /**
  * A path to `slots` collection in test organization
  */
@@ -135,7 +135,7 @@ export const setupTestBookings = async ({
   /** Path to customer's bookings */
   const customerBookingsPath = [
     Collection.Organizations,
-    __organization__,
+    getOrganization(),
     OrgSubCollection.Bookings,
     secretKey,
   ].join("/");

--- a/packages/client/src/store/actions/__tests__/attendanceOperations.test.ts
+++ b/packages/client/src/store/actions/__tests__/attendanceOperations.test.ts
@@ -6,7 +6,7 @@ import * as firestore from "@firebase/firestore";
 
 import { Collection, OrgSubCollection } from "@eisbuk/shared";
 
-import { __organization__ } from "@/lib/constants";
+import { getOrganization } from "@/lib/getters";
 
 import { markAbsence, markAttendance } from "../attendanceOperations";
 import { showErrSnackbar } from "../appActions";
@@ -28,7 +28,7 @@ const slotId = "slot-0";
 const bookedInterval = "11:00-12:00";
 const attendedInterval = "11:00-12:30";
 
-const attendaceCollectionPath = `${Collection.Organizations}/${__organization__}/${OrgSubCollection.Attendance}`;
+const attendaceCollectionPath = `${Collection.Organizations}/${getOrganization()}/${OrgSubCollection.Attendance}`;
 
 const getFirestoreSpy = jest.spyOn(firestore, "getFirestore");
 

--- a/packages/client/src/store/actions/organizationOperations.ts
+++ b/packages/client/src/store/actions/organizationOperations.ts
@@ -3,7 +3,7 @@ import { doc, getFirestore, setDoc } from "@firebase/firestore";
 import { Collection, OrganizationData } from "@eisbuk/shared";
 import i18n, { NotificationMessage } from "@eisbuk/translations";
 
-import { __organization__ } from "@/lib/constants";
+import { getOrganization } from "@/lib/getters";
 
 import { NotifVariant } from "@/enums/store";
 
@@ -12,7 +12,7 @@ import { FirestoreThunk } from "@/types/store";
 import { enqueueNotification, showErrSnackbar } from "./appActions";
 
 const getOrganizationCollPath = () =>
-  `${Collection.Organizations}/${__organization__}`;
+  `${Collection.Organizations}/${getOrganization()}`;
 
 export const updateOrganization =
   (


### PR DESCRIPTION
Made the `igoriceteam` organization (derived from domain name) fall back to `igorice`, until we migrate the organization in firestore from old to the new. 