### PR TITLE
Fix the predeploy script

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,7 +6,7 @@
   "functions": {
     "predeploy": [
       "yarn --cwd \"$RESOURCE_DIR\" build",
-      "sed -i '/@eisbuk\\/shared/d' \"$RESOURCE_DIR/package.json\""
+      "sed -i '/\"@eisbuk\\/shared/d\"' \"$RESOURCE_DIR/package.json\""
     ],
     "postdeploy": [
       "sed -i -e \\'s/  .dependencies.: {/  \"dependencies\": {\\n    \"@eisbuk\\/shared\": \"1.0.0\",/\\' \"$RESOURCE_DIR/package.json\""


### PR DESCRIPTION
A small fix with updated predeploy/post deploy scripts (`@eisbuk/shared` being part of the whole `sed` contraption)