### PR TITLE
Fix/slots mobile overflow

### DIFF
--- a/packages/client/src/components/atoms/SlotCard/SlotCard.stories.tsx
+++ b/packages/client/src/components/atoms/SlotCard/SlotCard.stories.tsx
@@ -5,14 +5,14 @@ import { SlotInterface } from "@eisbuk/shared";
 
 import SlotCard from "./SlotCard";
 
-import { baseSlot } from "@/__testData__/slots";
+import { baseSlot, createIntervals } from "@/__testData__/slots";
 
 /**
  * Decorator used to prevent slots diaplayed from stratching to full width
  */
 const decorators: ComponentMeta<typeof SlotCard>["decorators"] = [
   (Story) => (
-    <div style={{ width: 500 }}>
+    <div style={{ maxWidth: 500 }}>
       <Story />
     </div>
   ),
@@ -24,17 +24,22 @@ export default {
   decorators,
 } as ComponentMeta<typeof SlotCard>;
 
-const baseProps: SlotInterface = {
-  ...baseSlot,
-};
-
 export const Default = (): JSX.Element => (
-  <SlotCard {...baseProps} notes="Pista 1" />
+  <SlotCard {...baseSlot} notes="Pista 1" />
 );
 
 const adminViewWithActionButtonsProps = { enableEdit: true };
 export const AdminViewWithActionButtons = (): JSX.Element => (
-  <SlotCard {...baseProps} {...adminViewWithActionButtonsProps} />
+  <SlotCard {...baseSlot} {...adminViewWithActionButtonsProps} />
+);
+
+const aBunchOfIntervals: SlotInterface = {
+  ...baseSlot,
+  intervals: { ...baseSlot.intervals, ...createIntervals(11) },
+};
+
+export const ABunchOfIntervalsWithActionButtons = (): JSX.Element => (
+  <SlotCard {...aBunchOfIntervals} {...adminViewWithActionButtonsProps} />
 );
 
 export const Selected = (): JSX.Element => {
@@ -42,7 +47,7 @@ export const Selected = (): JSX.Element => {
   const [selected, setSelected] = useState(true);
   return (
     <SlotCard
-      {...baseProps}
+      {...baseSlot}
       enableEdit
       selected={selected}
       onClick={() => setSelected(!selected)}

--- a/packages/client/src/components/atoms/SlotCard/SlotCard.tsx
+++ b/packages/client/src/components/atoms/SlotCard/SlotCard.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import clsx from "clsx";
 
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
@@ -85,18 +84,36 @@ const SlotCard: React.FC<SlotCardProps> = ({
     intervalValues[0] || { startTime: "00:00", endTime: "00:00" }
   );
 
+  const backgroundColor = selected ? classes.bgSelected : classes.bgBasic;
+
+  // Set up container styles
+  const containerClasses = [
+    classes.container,
+    backgroundColor,
+    ...(canClick ? [classes.cursorPointer] : []),
+  ].join(" ");
+
+  // Set up slot type label styles
+  const slotTypeLabelClasses = [classes.typeLabel, backgroundColor].join(" ");
+
+  // Set up interval styles
+  const overlayShadow = selected ? classes.insetSelected : classes.insetBasic;
+  const intervalsOverlayClasses = [classes.overlay, overlayShadow].join(" ");
+
+  // Set up action button styles
+  const actionButtonClasses = [classes.actionButtons, backgroundColor].join(
+    " "
+  );
+
   return (
     <>
       <Card
-        className={clsx(classes.root, {
-          [classes.selected]: selected,
-          [classes.cursorPointer]: canClick,
-        })}
+        className={containerClasses}
         variant="outlined"
         data-testid={__slotId__}
         onClick={onClick}
       >
-        <CardContent className={classes.wrapper}>
+        <CardContent className={classes.contentTop}>
           <SlotTime backgroundColor={typeColor} {...{ startTime, endTime }} />
           <Box
             display="flex"
@@ -123,27 +140,31 @@ const SlotCard: React.FC<SlotCardProps> = ({
             </Box>
           </Box>
         </CardContent>
-        <Box className={classes.actionsContainer} flexGrow={1}>
-          <SlotTypeIcon className={classes.typeLabel} type={slotData.type} />
-          <Box display="flex" justifyContent="space-evenly">
-            {intervalStrings.map((interval) => (
-              <Typography
-                style={{ backgroundColor: typeColor }}
-                key={interval}
-                component="span"
-                variant="body2"
-                className={classes.intervalTag}
-              >
-                {interval.split("-").join(" - ")}
-              </Typography>
-            ))}
+
+        <Box className={classes.contentBottom} flexGrow={1}>
+          <SlotTypeIcon className={slotTypeLabelClasses} type={slotData.type} />
+          <Box className={classes.intervalsContainer}>
+            <>
+              <div className={intervalsOverlayClasses} />
+              {intervalStrings.map((interval) => (
+                <Typography
+                  style={{ backgroundColor: typeColor }}
+                  key={interval}
+                  component="span"
+                  variant="body2"
+                  className={classes.intervalTag}
+                >
+                  {interval.split("-").join(" - ")}
+                </Typography>
+              ))}
+            </>
           </Box>
           {enableEdit && (
             <SlotOperationButtons
               contextType={ButtonContextType.Slot}
               slot={slotData}
               iconSize="small"
-              className={classes.buttons}
+              className={actionButtonClasses}
             >
               <EditSlotButton />
               <DeleteButton
@@ -213,7 +234,8 @@ const createDeleteConfirmDialog = ({
 // #region styles
 const useStyles = makeStyles((theme) =>
   createStyles({
-    root: {
+    // Blocks top
+    container: {
       border: "1px solid",
       borderColor: theme.palette.divider,
       position: "relative",
@@ -223,7 +245,7 @@ const useStyles = makeStyles((theme) =>
         borderColor: theme.palette.primary.light,
       },
     },
-    wrapper: {
+    contentTop: {
       display: "flex",
       padding: 0,
       "&:last-child": {
@@ -234,9 +256,6 @@ const useStyles = makeStyles((theme) =>
       padding: 4,
       display: "flex",
       flexWrap: "wrap",
-    },
-    typeLabel: {
-      padding: `0 ${theme.spacing(1)}`,
     },
     category: {
       textTransform: "uppercase",
@@ -251,8 +270,11 @@ const useStyles = makeStyles((theme) =>
     notes: {
       fontWeight: theme.typography.fontWeightBold,
     },
-    actionsContainer: {
+
+    // Blocks bottom
+    contentBottom: {
       display: "flex",
+      flexWrap: "nowrap",
       justifyContent: "start",
       alignItems: "center",
       height: "2.25rem",
@@ -261,23 +283,60 @@ const useStyles = makeStyles((theme) =>
       borderTopColor: theme.palette.divider,
       padding: "0 0.5rem",
     },
+    typeLabel: {
+      height: "100%",
+      backgroundColor: "inherit",
+      padding: `0 ${theme.spacing(1)}`,
+    },
+    intervalsContainer: {
+      position: "relative",
+      height: "100%",
+      overflow: "hidden",
+      padding: ".5rem",
+      boxSizing: "border-box",
+    },
     intervalTag: {
-      margin: "0.25rem",
+      margin: "0 0.25rem",
       padding: "0.25rem 0.5rem",
       borderRadius: "0.5rem",
       overflow: "hidden",
       color: theme.palette.primary.contrastText,
       fontWeight: "bold",
       fontSize: "0.75rem",
+      whiteSpace: "nowrap",
     },
-    buttons: {
+    actionButtons: {
+      height: "100%",
       marginLeft: "auto",
+      backgroundColor: "inherit",
     },
-    selected: {
+
+    // Color
+    bgSelected: {
       backgroundColor: theme.palette.warning.light,
     },
+    bgBasic: {
+      backgroundColor: "#FFFFFF",
+    },
+    insetSelected: {
+      boxShadow: `inset 12px 0 6px -6px ${theme.palette.warning.light}, inset -12px 0 6px -6px ${theme.palette.warning.light}`,
+    },
+    insetBasic: {
+      boxShadow:
+        "inset 12px 0 6px -6px #FFFFFF, inset -12px 0 6px -6px #FFFFFF",
+    },
+
+    // Misc utils
     cursorPointer: {
       cursor: "pointer",
+    },
+    overlay: {
+      position: "absolute",
+      left: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      zIndex: 1000,
     },
   })
 );

--- a/packages/client/src/components/atoms/SlotCard/SlotCard.tsx
+++ b/packages/client/src/components/atoms/SlotCard/SlotCard.tsx
@@ -93,17 +93,15 @@ const SlotCard: React.FC<SlotCardProps> = ({
     ...(canClick ? [classes.cursorPointer] : []),
   ].join(" ");
 
-  // Set up slot type label styles
-  const slotTypeLabelClasses = [classes.typeLabel, backgroundColor].join(" ");
-
-  // Set up interval styles
-  const overlayShadow = selected ? classes.insetSelected : classes.insetBasic;
-  const intervalsOverlayClasses = [classes.overlay, overlayShadow].join(" ");
-
-  // Set up action button styles
-  const actionButtonClasses = [classes.actionButtons, backgroundColor].join(
-    " "
-  );
+  // Set up interval tag fades styles
+  const fadeLeftClasses = [
+    classes.leftOverlay,
+    selected ? classes.fadeSelectedLeft : classes.fadeWhiteLeft,
+  ].join(" ");
+  const fadeRightClasses = [
+    classes.rightOverlay,
+    selected ? classes.fadeSelectedRight : classes.fadeWhiteRight,
+  ].join(" ");
 
   return (
     <>
@@ -142,21 +140,24 @@ const SlotCard: React.FC<SlotCardProps> = ({
         </CardContent>
 
         <Box className={classes.contentBottom} flexGrow={1}>
-          <SlotTypeIcon className={slotTypeLabelClasses} type={slotData.type} />
+          <SlotTypeIcon className={classes.typeLabel} type={slotData.type} />
           <Box className={classes.intervalsContainer}>
             <>
-              <div className={intervalsOverlayClasses} />
-              {intervalStrings.map((interval) => (
-                <Typography
-                  style={{ backgroundColor: typeColor }}
-                  key={interval}
-                  component="span"
-                  variant="body2"
-                  className={classes.intervalTag}
-                >
-                  {interval.split("-").join(" - ")}
-                </Typography>
-              ))}
+              <div className={fadeLeftClasses} />
+              <div className={classes.intervals}>
+                {intervalStrings.map((interval) => (
+                  <Typography
+                    style={{ backgroundColor: typeColor }}
+                    key={interval}
+                    component="span"
+                    variant="body2"
+                    className={classes.intervalTag}
+                  >
+                    {interval.split("-").join(" - ")}
+                  </Typography>
+                ))}
+              </div>
+              <div className={fadeRightClasses} />
             </>
           </Box>
           {enableEdit && (
@@ -164,7 +165,7 @@ const SlotCard: React.FC<SlotCardProps> = ({
               contextType={ButtonContextType.Slot}
               slot={slotData}
               iconSize="small"
-              className={actionButtonClasses}
+              className={classes.actionButtons}
             >
               <EditSlotButton />
               <DeleteButton
@@ -292,8 +293,21 @@ const useStyles = makeStyles((theme) =>
       position: "relative",
       height: "100%",
       overflow: "hidden",
+      boxSizing: "border-box",
+    },
+    intervals: {
+      height: "100%",
+      width: "100%",
+      overflowY: "hidden",
+      overflowX: "auto",
+      scrollPadding: 0,
+      ["&::-webkit-scrollbar"]: {
+        height: 0,
+        background: "none",
+      },
       padding: ".5rem",
       boxSizing: "border-box",
+      cursor: "normal",
     },
     intervalTag: {
       margin: "0 0.25rem",
@@ -304,6 +318,7 @@ const useStyles = makeStyles((theme) =>
       fontWeight: "bold",
       fontSize: "0.75rem",
       whiteSpace: "nowrap",
+      userSelect: "none",
     },
     actionButtons: {
       height: "100%",
@@ -318,21 +333,34 @@ const useStyles = makeStyles((theme) =>
     bgBasic: {
       backgroundColor: "#FFFFFF",
     },
-    insetSelected: {
-      boxShadow: `inset 12px 0 6px -6px ${theme.palette.warning.light}, inset -12px 0 6px -6px ${theme.palette.warning.light}`,
+    fadeSelectedLeft: {
+      boxShadow: `inset 12px 0 6px -6px ${theme.palette.warning.light}`,
     },
-    insetBasic: {
-      boxShadow:
-        "inset 12px 0 6px -6px #FFFFFF, inset -12px 0 6px -6px #FFFFFF",
+    fadeSelectedRight: {
+      boxShadow: `inset -12px 0 6px -6px ${theme.palette.warning.light}`,
+    },
+    fadeWhiteLeft: {
+      boxShadow: "inset 12px 0 6px -6px #FFFFFF",
+    },
+    fadeWhiteRight: {
+      boxShadow: "inset -12px 0 6px -6px #FFFFFF",
     },
 
     // Misc utils
     cursorPointer: {
       cursor: "pointer",
     },
-    overlay: {
+    leftOverlay: {
       position: "absolute",
+      width: "1rem",
       left: 0,
+      top: 0,
+      bottom: 0,
+      zIndex: 1000,
+    },
+    rightOverlay: {
+      position: "absolute",
+      width: "1rem",
       top: 0,
       right: 0,
       bottom: 0,

--- a/packages/client/src/components/atoms/SlotCard/SlotCard.tsx
+++ b/packages/client/src/components/atoms/SlotCard/SlotCard.tsx
@@ -301,6 +301,7 @@ const useStyles = makeStyles((theme) =>
       overflowY: "hidden",
       overflowX: "auto",
       scrollPadding: 0,
+      scrollbarWidth: "none",
       ["&::-webkit-scrollbar"]: {
         height: 0,
         background: "none",


### PR DESCRIPTION
Fixes #466 
Additionally, user can scroll through intervals on `SlotCard` if using mobile or touchpad horizontal scroll. Neither scroll snap not slider implemented as that would require additional work, but can be implemented as an enhancement: if needed and if the style will remain such after Alex's mockup.