### PR TITLE
Fix sizing of an icon in EmptySpace to conform to mockup

### DIFF
--- a/packages/ui/src/EmptySpace/EmptySpace.tsx
+++ b/packages/ui/src/EmptySpace/EmptySpace.tsx
@@ -21,7 +21,7 @@ const EmptySpace: React.FC<EmptySpaceProps> = ({
       className: [...baseClasses, className].join(" "),
     },
     [
-      <span key="exclamation-circle" className="w-8 h-8 mb-2 md:mb-0 md:mr-2">
+      <span key="exclamation-circle" className="w-6 h-6 mb-2 md:mb-0 md:mr-2">
         <ExclamationCircle />
       </span>,
       <span


### PR DESCRIPTION
Small sizing (width/height) fix-up of `EmptySpace` icon from 32px to 24px