### PR TITLE
Apply some styling fixes on NotificationToast

### DIFF
--- a/packages/ui/src/NotificationToast/NotificationToast.stories.tsx
+++ b/packages/ui/src/NotificationToast/NotificationToast.stories.tsx
@@ -16,6 +16,9 @@ export const Variants = (): JSX.Element => (
       variant={NotificationToastVariant.Success}
       className="max-w-md mb-3"
     >{`April 13th 08:00 - 09:00, <strong>confirmed</strong>`}</NotificationToast>
+
+    <br />
+
     <NotificationToast
       variant={NotificationToastVariant.Error}
       className="max-w-md"

--- a/packages/ui/src/NotificationToast/NotificationToast.tsx
+++ b/packages/ui/src/NotificationToast/NotificationToast.tsx
@@ -36,7 +36,7 @@ const NotificationToast: React.FC<NotificationToastProps> = ({
       <button
         onClick={() => onClose()}
         key="close-button"
-        className="w-5 h-5 text-white/60"
+        className="w-5 h-5 absolute top-1/2 -translate-y-1/2 right-3 text-white/60"
       >
         <Close />
       </button>,
@@ -44,14 +44,16 @@ const NotificationToast: React.FC<NotificationToastProps> = ({
   );
 
 const baseClasses = [
-  "font-semibold",
-  "px-4",
-  "py-3",
+  "min-w-[360px]",
+  "inline-block",
+  "relative",
+  "pl-3",
+  "pr-10", // Offset for absolutely positioned 'x' button
+  "py-2",
   "rounded-lg",
+  "font-medium",
   "text-white",
-  "text-semibold",
   "select-none",
-  "flex",
   "justify-between",
   "items-center",
 ];


### PR DESCRIPTION
Fixes sizing of `NotificationToast` and uses `inline-block` + absolutely positioned button, rather than `flex`.