### PR TITLE
Feature/interval card group

### DIFF
--- a/packages/ui/src/IntervalCard/IntervalCard.stories.tsx
+++ b/packages/ui/src/IntervalCard/IntervalCard.stories.tsx
@@ -113,9 +113,6 @@ export const States = (): JSX.Element => (
       <StorybookItem height={160} label="Active">
         <IntervalCard {...baseSlot} state={IntervalCardState.Active} />
       </StorybookItem>
-      <StorybookItem height={160} label="Faded">
-        <IntervalCard {...baseSlot} state={IntervalCardState.Faded} />
-      </StorybookItem>
       <StorybookItem height={160} label="Disabled">
         <IntervalCard {...baseSlot} state={IntervalCardState.Disabled} />
       </StorybookItem>
@@ -133,13 +130,6 @@ export const States = (): JSX.Element => (
         <IntervalCard
           {...baseSlot}
           state={IntervalCardState.Active}
-          type={SlotType.OffIce}
-        />
-      </StorybookItem>
-      <StorybookItem height={160} label="Faded">
-        <IntervalCard
-          {...baseSlot}
-          state={IntervalCardState.Faded}
           type={SlotType.OffIce}
         />
       </StorybookItem>

--- a/packages/ui/src/IntervalCard/IntervalCard.tsx
+++ b/packages/ui/src/IntervalCard/IntervalCard.tsx
@@ -70,7 +70,7 @@ const IntervalCard: React.FC<IntervalCardProps> = ({
 
       {variant !== IntervalCardVariant.Simple && (
         <BookingButton
-          className="absolute right-2 bottom-2"
+          className="absolute right-2 bottom-2 min-w-[85px]"
           {...{ type, variant, state, duration }}
           onClick={handleBookingClick}
         />

--- a/packages/ui/src/IntervalCard/IntervalCard.tsx
+++ b/packages/ui/src/IntervalCard/IntervalCard.tsx
@@ -56,7 +56,7 @@ const IntervalCard: React.FC<IntervalCardProps> = ({
     <IntervalCardContainer
       {...{ ...containerProps, state, duration, type, variant }}
     >
-      <div className="relative h-full w-full">
+      <div className="relative h-full w-full cursor-default select-none">
         {variant !== IntervalCardVariant.Booking && dateString}
 
         {timestring}

--- a/packages/ui/src/IntervalCard/IntervalCardContainer.tsx
+++ b/packages/ui/src/IntervalCard/IntervalCardContainer.tsx
@@ -86,18 +86,18 @@ const getBackgroundColor = (
   variant: IntervalCardVariant,
   state: IntervalCardState
 ) => {
-  const isActive =
-    variant === IntervalCardVariant.Booking &&
-    state === IntervalCardState.Active;
-  const isFaded =
-    variant === IntervalCardVariant.Booking &&
-    state === IntervalCardState.Faded;
+  const isActive = state === IntervalCardState.Active;
 
-  return isActive
+  // Disabled cards and all non-booking variants have white background without hover
+  const isWhite =
+    state === IntervalCardState.Disabled ||
+    variant !== IntervalCardVariant.Booking;
+
+  return isWhite
+    ? "bg-white"
+    : isActive
     ? backgroundColorLookup[type]
-    : isFaded
-    ? "bg-gray-100"
-    : "bg-white";
+    : "bg-white hover:bg-gray-100";
 };
 
 const backgroundColorLookup = {
@@ -130,7 +130,6 @@ const outlineColorLookup = {
   [SlotType.Ice]: {
     [IntervalCardState.Default]: "outline-ice-300",
     [IntervalCardState.Active]: "outline-cyan-500",
-    [IntervalCardState.Faded]: "outline-ice-300",
   },
   [SlotType.OffIce]: {
     [IntervalCardState.Active]: "outline-yellow-600",

--- a/packages/ui/src/IntervalCard/__tests__/IntervalCard.test.tsx
+++ b/packages/ui/src/IntervalCard/__tests__/IntervalCard.test.tsx
@@ -67,12 +67,6 @@ describe("IntervalCard", () => {
     },
     {
       variant: IntervalCardVariant.Booking,
-      state: IntervalCardState.Faded,
-      onBook: true,
-      onCancel: false,
-    },
-    {
-      variant: IntervalCardVariant.Booking,
       state: IntervalCardState.Disabled,
       onBook: false,
       onCancel: false,
@@ -88,12 +82,6 @@ describe("IntervalCard", () => {
     {
       variant: IntervalCardVariant.Calendar,
       state: IntervalCardState.Active,
-      onBook: false,
-      onCancel: true,
-    },
-    {
-      variant: IntervalCardVariant.Calendar,
-      state: IntervalCardState.Faded,
       onBook: false,
       onCancel: true,
     },

--- a/packages/ui/src/IntervalCard/types.ts
+++ b/packages/ui/src/IntervalCard/types.ts
@@ -3,7 +3,6 @@ import { SlotInterface, SlotInterval } from "@eisbuk/shared";
 export enum IntervalCardState {
   Default = "default",
   Active = "active",
-  Faded = "faded",
   Disabled = "disabled",
 }
 

--- a/packages/ui/src/IntervalCardGroup/IntervalCardGroup.stories.tsx
+++ b/packages/ui/src/IntervalCardGroup/IntervalCardGroup.stories.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+import { ComponentMeta } from "@storybook/react";
+
+import { Category, SlotInterface, SlotType } from "@eisbuk/shared";
+
+import IntervalCardGroup from "./IntervalCardGroup";
+
+export default {
+  title: "Interval Card Group",
+  component: IntervalCardGroup,
+} as ComponentMeta<typeof IntervalCardGroup>;
+
+const dummySlot: SlotInterface = {
+  id: "ice-slot",
+  type: SlotType.Ice,
+  categories: [Category.Competitive],
+  date: "2022-01-01",
+  intervals: {
+    "09:00-11:00": {
+      startTime: "09:00",
+      endTime: "11:00",
+    },
+    "09:00-10:30": {
+      startTime: "09:00",
+      endTime: "10:30",
+    },
+    "09:00-10:00": {
+      startTime: "09:00",
+      endTime: "10:00",
+    },
+  },
+  notes: "Rink 1",
+};
+
+export const Interactive = (): JSX.Element => {
+  const [bookedInterval, setBookedInterval] = useState<string | null>(
+    "09:00-11:00"
+  );
+
+  return (
+    <IntervalCardGroup
+      {...{ ...dummySlot, bookedInterval }}
+      onBook={(interval) => setBookedInterval(interval)}
+      onCancel={() => setBookedInterval(null)}
+    />
+  );
+};

--- a/packages/ui/src/IntervalCardGroup/IntervalCardGroup.stories.tsx
+++ b/packages/ui/src/IntervalCardGroup/IntervalCardGroup.stories.tsx
@@ -38,10 +38,18 @@ export const Interactive = (): JSX.Element => {
   );
 
   return (
-    <IntervalCardGroup
-      {...{ ...dummySlot, bookedInterval }}
-      onBook={(interval) => setBookedInterval(interval)}
-      onCancel={() => setBookedInterval(null)}
-    />
+    <div className="flex flex-wrap gap-4 items-end">
+      <IntervalCardGroup
+        {...{ ...dummySlot, bookedInterval }}
+        onBook={(interval) => setBookedInterval(interval)}
+        onCancel={() => setBookedInterval(null)}
+      />
+    </div>
   );
 };
+
+export const Disabled = (): JSX.Element => (
+  <div className="flex flex-wrap gap-4 items-end">
+    <IntervalCardGroup disabled {...{ ...dummySlot }} />
+  </div>
+);

--- a/packages/ui/src/IntervalCardGroup/IntervalCardGroup.tsx
+++ b/packages/ui/src/IntervalCardGroup/IntervalCardGroup.tsx
@@ -50,15 +50,11 @@ const BookingCardGroup: React.FC<BookingCardGroupProps> = ({
         const interval = intervals[intervalKey];
 
         const isActive = intervalKey === bookedInterval;
-        // Display fadded if booked interval exists, but is not this interval (some other card is booked)
-        const isFadded = bookedInterval && intervalKey !== bookedInterval;
 
         const state = isDisabled
           ? IntervalCardState.Disabled
           : isActive
           ? IntervalCardState.Active
-          : isFadded
-          ? IntervalCardState.Faded
           : IntervalCardState.Default;
 
         return (

--- a/packages/ui/src/IntervalCardGroup/IntervalCardGroup.tsx
+++ b/packages/ui/src/IntervalCardGroup/IntervalCardGroup.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import { SlotInterface } from "@eisbuk/shared";
+
+interface BookingCardGroupProps extends SlotInterface {
+  /**
+   * Booked interval for a slot, used to control the rendering
+   */
+  bookedInterval: string | null;
+  /**
+   * Disable all `IntervalCard`s rendered by this instance
+   */
+  disabled?: boolean;
+  /**
+   * We're not dispatching directly to the store,
+   * but rather calling an `onBook` function (for easier testing/storybook previews).
+   * The parent component can then be in charge of providing the booking handler.
+   */
+  onBook?: (interval: string) => void;
+  /**
+   * We're not dispatching directly to the store,
+   * but rather calling an `onCancel` function (for easier testing/storybook previews).
+   * The parent component can then be in charge of providing the cancel handler.
+   */
+  onCancel?: () => void;
+}
+
+/**
+ * A component used to render all of the intervals for a slot. It uses `IntervalCard` to render each interval
+ * and controlls the variant/styles/disabling of the intervals with respect to `disabled` prop, and `bookedInterval`.
+ *
+ * The booking/canceling is controlled through `onBook` and `onCancel` handlers.
+ */
+const BookingCardGroup: React.FC<BookingCardGroupProps> = () => null;
+
+export default BookingCardGroup;

--- a/packages/ui/src/IntervalCardGroup/IntervalCardGroup.tsx
+++ b/packages/ui/src/IntervalCardGroup/IntervalCardGroup.tsx
@@ -2,11 +2,13 @@ import React from "react";
 
 import { SlotInterface } from "@eisbuk/shared";
 
+import IntervalCard, { IntervalCardState } from "../IntervalCard";
+
 interface BookingCardGroupProps extends SlotInterface {
   /**
    * Booked interval for a slot, used to control the rendering
    */
-  bookedInterval: string | null;
+  bookedInterval?: string | null;
   /**
    * Disable all `IntervalCard`s rendered by this instance
    */
@@ -31,6 +33,36 @@ interface BookingCardGroupProps extends SlotInterface {
  *
  * The booking/canceling is controlled through `onBook` and `onCancel` handlers.
  */
-const BookingCardGroup: React.FC<BookingCardGroupProps> = () => null;
+const BookingCardGroup: React.FC<BookingCardGroupProps> = ({
+  bookedInterval = null,
+  intervals,
+  onBook = () => {},
+  onCancel = () => {},
+  ...slot
+}) => {
+  const intervalsToRender = Object.keys(intervals || {});
+
+  return (
+    <>
+      {intervalsToRender.map((intervalKey) => {
+        // Get `startTime` and `endTime`
+        const interval = intervals[intervalKey];
+
+        const isActive = intervalKey === bookedInterval;
+
+        return (
+          <IntervalCard
+            key={intervalKey}
+            state={
+              isActive ? IntervalCardState.Active : IntervalCardState.Default
+            }
+            {...{ ...slot, interval, onCancel }}
+            onBook={() => onBook(intervalKey)}
+          />
+        );
+      })}
+    </>
+  );
+};
 
 export default BookingCardGroup;

--- a/packages/ui/src/IntervalCardGroup/IntervalCardGroup.tsx
+++ b/packages/ui/src/IntervalCardGroup/IntervalCardGroup.tsx
@@ -38,6 +38,7 @@ const BookingCardGroup: React.FC<BookingCardGroupProps> = ({
   intervals,
   onBook = () => {},
   onCancel = () => {},
+  disabled: isDisabled,
   ...slot
 }) => {
   const intervalsToRender = Object.keys(intervals || {});
@@ -49,14 +50,21 @@ const BookingCardGroup: React.FC<BookingCardGroupProps> = ({
         const interval = intervals[intervalKey];
 
         const isActive = intervalKey === bookedInterval;
+        // Display fadded if booked interval exists, but is not this interval (some other card is booked)
+        const isFadded = bookedInterval && intervalKey !== bookedInterval;
+
+        const state = isDisabled
+          ? IntervalCardState.Disabled
+          : isActive
+          ? IntervalCardState.Active
+          : isFadded
+          ? IntervalCardState.Faded
+          : IntervalCardState.Default;
 
         return (
           <IntervalCard
             key={intervalKey}
-            state={
-              isActive ? IntervalCardState.Active : IntervalCardState.Default
-            }
-            {...{ ...slot, interval, onCancel }}
+            {...{ ...slot, interval, onCancel, state }}
             onBook={() => onBook(intervalKey)}
           />
         );

--- a/packages/ui/src/IntervalCardGroup/__tests__/IntervalCardGroup.test.tsx
+++ b/packages/ui/src/IntervalCardGroup/__tests__/IntervalCardGroup.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { Category, SlotType } from "@eisbuk/shared";
+
+import IntervalCardGroup from "../IntervalCardGroup";
+
+const dummySlot = {
+  id: "ice-slot",
+  type: SlotType.Ice,
+  categories: [Category.Competitive],
+  date: "2022-01-01",
+  intervals: {
+    "09:00-11:00": {
+      startTime: "09:00",
+      endTime: "11:00",
+    },
+    "09:00-10:30": {
+      startTime: "09:00",
+      endTime: "10:30",
+    },
+    "09:00-10:00": {
+      startTime: "09:00",
+      endTime: "10:00",
+    },
+  },
+};
+
+describe("IntervalCardGroup", () => {
+  afterEach(() => {
+    cleanup;
+    jest.clearAllMocks();
+  });
+
+  test("should call 'onBook' with appropriate interval", () => {
+    const mockOnBook = jest.fn();
+    render(<IntervalCardGroup {...dummySlot} onBook={mockOnBook} />);
+    const [firstIntervalButton, , lastIntervalButton] =
+      screen.getAllByRole("button");
+
+    // Book first interval
+    firstIntervalButton.click();
+    expect(mockOnBook).toHaveBeenCalledWith("09:00-11:00");
+
+    // Book last (third) interval
+    lastIntervalButton.click();
+    expect(mockOnBook).toHaveBeenCalledWith("09:00-10:00");
+  });
+
+  test("should call 'onCancel' when 'Cancel' button is clicked on a booked IntervalCard", () => {
+    const mockOnCancel = jest.fn();
+    render(
+      <IntervalCardGroup
+        {...dummySlot}
+        bookedInterval={"09:00-11:00"}
+        onCancel={mockOnCancel}
+      />
+    );
+    const [firstIntervalButton] = screen.getAllByRole("button");
+
+    // First interval is booked, therefore, its button should be used to cancel
+    firstIntervalButton.click();
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/IntervalCardGroup/index.ts
+++ b/packages/ui/src/IntervalCardGroup/index.ts
@@ -1,0 +1,3 @@
+import IntervalCardGroup from "./IntervalCardGroup";
+
+export default IntervalCardGroup;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,6 +12,7 @@ import CalendarNav from "./CalendarNav";
 import Layout from "./Layout";
 import IntervalCard from "./IntervalCard";
 import ActionDialog from "./ActionDialog";
+import IntervalCardGroup from "./IntervalCardGroup";
 
 export * from "./UserAvatar";
 export * from "./NotificationToast";
@@ -29,4 +30,5 @@ export {
   SlotTypeIcon,
   IntervalCard,
   ActionDialog,
+  IntervalCardGroup,
 };


### PR DESCRIPTION
A feature without a ticket. IntervalCardGroup component is here instead of BookingCardGroup in previous setup. It's used to render all intervals for a provided slot and act as a wrapper around onBook and onCancel logic, passing it further up to the parent component (most likely the `customer_area` page).

Additionally, I've removed the faded logic from `IntervalCard` and use previously faded styles as hover for the default state, which is, I assume, the way Alex envisioned it.