### PR TITLE
Fix/layout children

### DIFF
--- a/packages/ui/src/Layout/Layout.stories.tsx
+++ b/packages/ui/src/Layout/Layout.stories.tsx
@@ -37,6 +37,20 @@ const user = {
     "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80",
 };
 export const Default = (): JSX.Element => <Layout {...{ user }} />;
+
 export const CustomerArea = (): JSX.Element => (
-  <Layout {...{ additionalButtons, Notifications, user }} />
+  <Layout {...{ additionalButtons, Notifications, user }}>
+    <div className="content-container">
+      <div className="md:px-[44px]">
+        {Array(8)
+          .fill(null)
+          .map((_, i) => (
+            <div
+              key={i}
+              className="w-full h-40 my-4 bg-gray-100 border-2 border-gray-200 rounded-md md:h-80"
+            />
+          ))}
+      </div>
+    </div>
+  </Layout>
 );

--- a/packages/ui/src/Layout/Layout.stories.tsx
+++ b/packages/ui/src/Layout/Layout.stories.tsx
@@ -30,27 +30,34 @@ const Notifications: React.FC<{ className?: string }> = ({ className }) => (
   </NotificationToast>
 );
 
+const dummyContent = (
+  <div className="content-container">
+    <div className="md:px-[44px] pb-4">
+      <h1 className="mt-8 mb-10 text-2xl font-semibold">Dummy Content</h1>
+      {Array(8)
+        .fill(null)
+        .map((_, i) => (
+          <div
+            key={i}
+            className="w-full h-40 my-4 bg-gray-100 border-2 border-gray-200 rounded-md md:h-80"
+          />
+        ))}
+    </div>
+  </div>
+);
+
 const user = {
   name: "Salvo",
   surname: "Simonetti",
   avatar:
     "https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80",
 };
-export const Default = (): JSX.Element => <Layout {...{ user }} />;
+export const Default = (): JSX.Element => (
+  <Layout {...{ user }}>{dummyContent}</Layout>
+);
 
 export const CustomerArea = (): JSX.Element => (
   <Layout {...{ additionalButtons, Notifications, user }}>
-    <div className="content-container">
-      <div className="md:px-[44px]">
-        {Array(8)
-          .fill(null)
-          .map((_, i) => (
-            <div
-              key={i}
-              className="w-full h-40 my-4 bg-gray-100 border-2 border-gray-200 rounded-md md:h-80"
-            />
-          ))}
-      </div>
-    </div>
+    {dummyContent}
   </Layout>
 );

--- a/packages/ui/src/Layout/Layout.tsx
+++ b/packages/ui/src/Layout/Layout.tsx
@@ -9,6 +9,7 @@ interface LayoutProps {
   user?: UserAvatarProps;
   additionalButtons?: JSX.Element;
   Notifications?: React.FC<{ className?: string }>;
+  children?: React.ReactNode[] | React.ReactNode;
 }
 
 const Layout: React.FC<LayoutProps> = ({
@@ -16,29 +17,34 @@ const Layout: React.FC<LayoutProps> = ({
   additionalButtons,
   user,
   Notifications,
+  children,
 }) => {
   const rowClasses = "flex justify-between items-center w-full min-h-[70px]";
 
   return (
-    <div className="bg-gray-800">
-      <div className="content-container">
-        <div className={rowClasses}>
-          <div className="h-5 w-[86px] text-white">{<Logo />}</div>
+    <div>
+      <header className="bg-gray-800">
+        <div className="content-container">
+          <div className={rowClasses}>
+            <div className="h-5 w-[86px] text-white">{<Logo />}</div>
 
-          {user && <UserAvatar {...user} />}
-        </div>
-
-        <div className="w-full h-[2px] bg-gray-700" />
-
-        <div className={[rowClasses, "py-[15px]"].join(" ")}>
-          <div className="w-full flex justify-center gap-4 md:gap-3 md:justify-start md:max-w-1/2">
-            {additionalButtons}
+            {user && <UserAvatar {...user} />}
           </div>
-          <div className="fixed bottom-[27px] left-4 right-4 md:static">
-            {Notifications && <Notifications className="w-full md:w-auto" />}
+
+          <div className="w-full h-[2px] bg-gray-700" />
+
+          <div className={[rowClasses, "py-[15px]"].join(" ")}>
+            <div className="w-full flex justify-center gap-4 md:gap-3 md:justify-start md:max-w-1/2">
+              {additionalButtons}
+            </div>
+            <div className="fixed bottom-[27px] left-4 right-4 md:static">
+              {Notifications && <Notifications className="w-full md:w-auto" />}
+            </div>
           </div>
         </div>
-      </div>
+      </header>
+
+      <main>{children}</main>
     </div>
   );
 };

--- a/packages/ui/src/Layout/Layout.tsx
+++ b/packages/ui/src/Layout/Layout.tsx
@@ -19,13 +19,11 @@ const Layout: React.FC<LayoutProps> = ({
   Notifications,
   children,
 }) => {
-  const rowClasses = "flex justify-between items-center w-full min-h-[70px]";
-
   return (
     <div>
       <header className="bg-gray-800">
         <div className="content-container">
-          <div className={rowClasses}>
+          <div className={getHeaderRowClasses("top")}>
             <div className="h-5 w-[86px] text-white">{<Logo />}</div>
 
             {user && <UserAvatar {...user} />}
@@ -33,8 +31,13 @@ const Layout: React.FC<LayoutProps> = ({
 
           <div className="w-full h-[2px] bg-gray-700" />
 
-          <div className={[rowClasses, "py-[15px]"].join(" ")}>
-            <div className="w-full flex justify-center gap-4 md:gap-3 md:justify-start md:max-w-1/2">
+          <div
+            className={getHeaderRowClasses(
+              "bottom",
+              Boolean(additionalButtons)
+            )}
+          >
+            <div className="w-full flex justify-center items-center gap-4 md:gap-3 md:justify-start md:max-w-1/2">
               {additionalButtons}
             </div>
             <div className="fixed bottom-[27px] left-4 right-4 md:static">
@@ -47,6 +50,29 @@ const Layout: React.FC<LayoutProps> = ({
       <main>{children}</main>
     </div>
   );
+};
+
+/** Get styles for top / botton row of the header */
+const getHeaderRowClasses = (
+  row: "top" | "bottom",
+  hasAdditionalButtons?: boolean
+) => {
+  // Hide bottom row on mobile if it doesn't have 'additionalButtons'
+  const displayClasses =
+    row === "top" || hasAdditionalButtons ? ["flex"] : ["hidden", "md:flex"];
+
+  // Styles used across both rows
+  const baseClasses = [
+    "w-full",
+    "min-h-[70px]",
+    "justify-between",
+    "items-center",
+  ];
+
+  // Additional classes per row
+  const additionalClasses = row === "top" ? [] : ["py-[15px]"];
+
+  return [...displayClasses, ...baseClasses, ...additionalClasses].join(" ");
 };
 
 export default Layout;

--- a/packages/ui/src/Layout/Layout.tsx
+++ b/packages/ui/src/Layout/Layout.tsx
@@ -20,7 +20,7 @@ const Layout: React.FC<LayoutProps> = ({
   children,
 }) => {
   return (
-    <div>
+    <div className="absolute top-0 right-0 bottom-0 left-0 flex flex-col overflow-hidden">
       <header className="bg-gray-800">
         <div className="content-container">
           <div className={getHeaderRowClasses("top")}>
@@ -40,14 +40,14 @@ const Layout: React.FC<LayoutProps> = ({
             <div className="w-full flex justify-center items-center gap-4 md:gap-3 md:justify-start md:max-w-1/2">
               {additionalButtons}
             </div>
-            <div className="fixed bottom-[27px] left-4 right-4 md:static">
+            <div className="fixed z-100 bottom-[27px] left-4 right-4 md:static">
               {Notifications && <Notifications className="w-full md:w-auto" />}
             </div>
           </div>
         </div>
       </header>
 
-      <main>{children}</main>
+      <main className="flex overflow-y-scroll">{children}</main>
     </div>
   );
 };


### PR DESCRIPTION
Adds `children` as a prop to the `Layout` component and fixes the Layout to the screen (no overflowing) and scrolls the overflowing content (keeping the Header in view)