### PR TITLE
Remove unnecessary click invocation

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   },
   build: {
     sourcemap: true,
+    chunkSizeWarningLimit: 2000,
   },
   plugins: [
     react(),

--- a/packages/e2e/integration/copy_button_spec.ts
+++ b/packages/e2e/integration/copy_button_spec.ts
@@ -27,8 +27,7 @@ describe("Copy Button", () => {
       "aria-label",
       `${i18n.t(AdminAria.CopySlots)} ${traslatedDate}`
     )
-      .click() // We really need two click statements here - I'm not sure why
-      .click({ force: true })
+      .click()
       .blur();
 
     cy.getAttrWith(

--- a/packages/e2e/integration/login_flow_spec.ts
+++ b/packages/e2e/integration/login_flow_spec.ts
@@ -183,6 +183,10 @@ describe("login", () => {
 
   describe("Phone login", () => {
     beforeEach(() => {
+      // This test was failing from time to time: Cypress would enter the test
+      // with an already logged in user
+      cy.clearCookies();
+      cy.visit(PrivateRoutes.Root);
       // start email auth flow
       cy.clickButton(t(AuthTitle.SignInWithPhone));
     });
@@ -261,6 +265,10 @@ describe("login", () => {
 
   describe("Email link login", () => {
     beforeEach(() => {
+      // This test was failing from time to time: Cypress would enter the test
+      // with an already logged in user
+      cy.clearCookies();
+      cy.visit(PrivateRoutes.Root);
       cy.clickButton(t(AuthTitle.SignInWithEmailLink));
     });
 


### PR DESCRIPTION
This PR removes a non necessary `click` invocation in cypress tests.

It also amends two tests that for some reason were sometimes failing. They now clear all cookies once more, to make sure the state is clean before each test. This unfortunately makes them slower, but it's an acceptable trade-off, since having them fail from time to time ends up wasting a lot of developer time.