### PR TITLE
Invisible buttons

### DIFF
--- a/packages/client/src/components/atoms/AddToCalendar/AddToCalendar.tsx
+++ b/packages/client/src/components/atoms/AddToCalendar/AddToCalendar.tsx
@@ -111,6 +111,7 @@ const AddToCalendar: React.FC<Props> = ({ bookedSlots = {}, slots = {} }) => {
     <>
       <div className={classes.container}>
         <Button
+          className={classes.buttonPrimary}
           data-testid={__addToCalendarButtonId__}
           onClick={() => setEmailDialog(true)}
           variant="contained"
@@ -208,13 +209,16 @@ const getPreviousCalendarUids = (
 // #endregion helpers
 
 // #region styles
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   container: {
     padding: "0.5rem",
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
     justifyContent: "space-evenly",
+  },
+  buttonPrimary: {
+    backgroundColor: theme.palette.primary.main,
   },
 }));
 // #endregion styles

--- a/packages/client/src/components/atoms/BookingCard/BookingCard.tsx
+++ b/packages/client/src/components/atoms/BookingCard/BookingCard.tsx
@@ -133,7 +133,12 @@ const BookingCard: React.FC<Props> = ({
   const actionButton = (
     <Button
       disabled={disabled}
-      className={classes.actionButton}
+      className={[
+        classes.actionButton,
+        // The following is a workaround to not overrule the Mui base button styles
+        // by Tailwind's preflight reset
+        booked ? classes.buttonSecondary : classes.buttonPrimary,
+      ].join(" ")}
       onClick={handleClick}
       color={booked ? "secondary" : "primary"}
       variant="contained"
@@ -213,6 +218,12 @@ const useStyles = makeStyles((theme) =>
       bottom: 0,
       width: "52%",
       height: "2.25rem",
+    },
+    buttonPrimary: {
+      backgroundColor: theme.palette.primary.main,
+    },
+    buttonSecondary: {
+      backgroundColor: theme.palette.secondary.main,
     },
     fadeOverlay: {
       position: "absolute",

--- a/packages/client/src/components/atoms/CustomerCard/ActionButtons.tsx
+++ b/packages/client/src/components/atoms/CustomerCard/ActionButtons.tsx
@@ -162,6 +162,9 @@ const useStyles = makeStyles((theme) => ({
       width: "80%",
       margin: "0.5rem 10%",
     },
+    // The following is a workaround to not overrule the Mui base button styles
+    // by Tailwind's preflight reset
+    backgroundColor: theme.palette.primary.main,
   },
 }));
 

--- a/packages/client/src/components/atoms/CustomerCard/ExtendedDateField.tsx
+++ b/packages/client/src/components/atoms/CustomerCard/ExtendedDateField.tsx
@@ -51,6 +51,7 @@ const ExtendedDateField: React.FC<Props> = ({ customer, onClose }) => {
           {displayValue}
         </span>
         <Button
+          className={classes.buttonPrimary}
           color="primary"
           onClick={() => setOpenConfirmDialog(true)}
           variant="contained"
@@ -79,10 +80,15 @@ const ExtendedDateField: React.FC<Props> = ({ customer, onClose }) => {
   );
 };
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   field: { display: "flex", justifyContent: "space-between", flexWrap: "wrap" },
   bold: {
     fontWeight: "bold",
+  },
+  buttonPrimary: {
+    // The following is a workaround to not overrule the Mui base button styles
+    // by Tailwind's preflight reset
+    backgroundColor: theme.palette.primary.main,
   },
 }));
 

--- a/packages/client/src/components/atoms/DateSwitcher/DateSwitcher.tsx
+++ b/packages/client/src/components/atoms/DateSwitcher/DateSwitcher.tsx
@@ -8,6 +8,7 @@ import Badge from "@mui/material/Badge";
 import PickersDay, { PickersDayProps } from "@mui/lab/PickersDay";
 
 import { styled } from "@mui/material/styles";
+import makeStyles from "@mui/styles/makeStyles";
 
 import { changeCalendarDate } from "@/store/actions/appActions";
 import {
@@ -33,6 +34,8 @@ const DateSwitcher: React.FC<Props> = ({ currentDate, jump, ...MenuProps }) => {
   const end = currentDate.endOf("week");
   const calendarData = useSelector(getCalendarData(currentDate.toISO()));
 
+  const classes = useStyles();
+
   return (
     <>
       <Menu data-testid={__calendarMenuId__} {...MenuProps}>
@@ -42,6 +45,7 @@ const DateSwitcher: React.FC<Props> = ({ currentDate, jump, ...MenuProps }) => {
             dispatch(changeCalendarDate(currentDate!));
           }}
           renderDay={renderWeekPickerDay(
+            classes.bgPrimary,
             currentDate,
             start,
             end,
@@ -56,6 +60,10 @@ const DateSwitcher: React.FC<Props> = ({ currentDate, jump, ...MenuProps }) => {
 
 const renderWeekPickerDay =
   (
+    // A class name used to paint the background of active elements
+    // A workaround to not overrule the Mui base button styles
+    // by Tailwind's preflight reset
+    bgActive: string,
     currentDate: DateTime,
     start: DateTime,
     end: DateTime,
@@ -71,6 +79,10 @@ const renderWeekPickerDay =
     const isFirstDay = date.equals(start);
     const isLastDay = date.endOf("day").equals(end);
     const hasSlots = calendarData[date.toISO().substring(0, 10)];
+
+    // The following is a workaround to not overrule the Mui base button styles
+    // by Tailwind's preflight reset
+    const bgClass = dayIsBetween || isFirstDay || isLastDay ? bgActive : "";
 
     return (
       <Badge
@@ -99,6 +111,9 @@ const renderWeekPickerDay =
             data-testid={
               dayIsBetween || isFirstDay || isLastDay ? __pickedDay__ : ""
             }
+            // The following is a workaround to not overrule the Mui base button styles
+            // by Tailwind's preflight reset
+            className={bgClass}
           />
         )}
       </Badge>
@@ -133,4 +148,12 @@ const CustomPickersDay = styled(PickersDay, {
     borderBottomLeftRadius: "50%",
   }),
 })) as React.ComponentType<CustomPickerDayProps>;
+
+const useStyles = makeStyles((theme) => ({
+  bgPrimary: {
+    // The following is a workaround to not overrule the Mui base button styles
+    // by Tailwind's preflight reset
+    backgroundColor: theme.palette.primary.main,
+  },
+}));
 export default DateSwitcher;

--- a/packages/client/src/components/atoms/SlotForm/SlotForm.tsx
+++ b/packages/client/src/components/atoms/SlotForm/SlotForm.tsx
@@ -189,6 +189,7 @@ const SlotForm: React.FC<Props> = ({
                   Boolean(Object.keys(errors).length) &&
                   (isSubmitting || isValidating)
                 }
+                className={classes.buttonPrimary}
                 color="primary"
                 aria-label={
                   slotToEdit
@@ -238,6 +239,9 @@ const useStyles = makeStyles((theme) =>
         margin: theme.spacing(2),
       },
     },
+    // The following is a workaround to not overrule the Mui base button styles
+    // by Tailwind's preflight reset
+    buttonPrimary: { backgroundColor: theme.palette.primary.main },
   })
 );
 // #endregion styles

--- a/packages/client/src/components/atoms/SlotForm/SlotIntervals.tsx
+++ b/packages/client/src/components/atoms/SlotForm/SlotIntervals.tsx
@@ -71,6 +71,9 @@ const useStyles = makeStyles((theme) =>
     addInterval: {
       marginTop: theme.spacing(3),
       borderRadius: theme.spacing(100),
+      // The following is a workaround to not overrule the Mui base button styles
+      // by Tailwind's preflight reset
+      backgroundColor: theme.palette.primary.main,
     },
     buttonContainer: {
       display: "flex",

--- a/packages/client/src/components/auth/NotRegistered.tsx
+++ b/packages/client/src/components/auth/NotRegistered.tsx
@@ -7,6 +7,8 @@ import Button from "@mui/material/Button";
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 
+import makeStyles from "@mui/styles/makeStyles";
+
 import { useTranslation, AuthMessage } from "@eisbuk/translations";
 
 import { Routes } from "@/enums/routes";
@@ -80,6 +82,8 @@ const Unauthorized: React.FC<Props> = ({ backgroundIndex }) => {
     authString = userAuthData.phoneNumber;
   }
 
+  const classes = useStyles();
+
   return (
     <>
       {isAuthEmpty && <Redirect to={Routes.Login} />}
@@ -95,12 +99,22 @@ const Unauthorized: React.FC<Props> = ({ backgroundIndex }) => {
           })}
         </Typography>
 
-        <Button variant="contained" onClick={logOut}>
+        <Button
+          className={classes.buttonPrimary}
+          variant="contained"
+          onClick={logOut}
+        >
           {t(AuthMessage.TryAgain)}
         </Button>
       </Paper>
     </>
   );
 };
+
+const useStyles = makeStyles((theme) => ({
+  // The following is a workaround to not overrule the Mui base button styles
+  // by Tailwind's preflight reset
+  buttonPrimary: { backgroundColor: theme.palette.primary.main },
+}));
 
 export default Unauthorized;

--- a/packages/client/src/components/auth/Unauthorized.tsx
+++ b/packages/client/src/components/auth/Unauthorized.tsx
@@ -6,6 +6,8 @@ import Button from "@mui/material/Button";
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 
+import makeStyles from "@mui/styles/makeStyles";
+
 import { useTranslation, AuthMessage } from "@eisbuk/translations";
 
 import { signOut } from "@/store/actions/authOperations";
@@ -68,6 +70,8 @@ const Unauthorized: React.FC<Props> = ({ backgroundIndex }) => {
   const logOut = () => dispatch(signOut());
   const { t } = useTranslation();
 
+  const classes = useStyles();
+
   return (
     <Paper style={style}>
       <Typography component="h1" variant="h2">
@@ -81,11 +85,21 @@ const Unauthorized: React.FC<Props> = ({ backgroundIndex }) => {
         <b>{userAuthData?.email || userAuthData?.phoneNumber || ""}</b>
       </Typography>
 
-      <Button variant="contained" onClick={logOut}>
+      <Button
+        className={classes.buttonPrimary}
+        variant="contained"
+        onClick={logOut}
+      >
         {t(AuthMessage.TryAgain)}
       </Button>
     </Paper>
   );
 };
+
+const useStyles = makeStyles((theme) => ({
+  // The following is a workaround to not overrule the Mui base button styles
+  // by Tailwind's preflight reset
+  buttonPrimary: { backgroundColor: theme.palette.primary.main },
+}));
 
 export default Unauthorized;

--- a/packages/client/src/components/customers/CustomerForm/CustomerForm.tsx
+++ b/packages/client/src/components/customers/CustomerForm/CustomerForm.tsx
@@ -201,6 +201,7 @@ const CustomerForm: React.FC<Props> = ({
                 disabled={isSubmitting}
                 variant="contained"
                 color="primary"
+                className={classes.buttonPrimary}
               >
                 {t(ActionButton.Save)}
               </Button>
@@ -265,6 +266,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: theme.spacing(1.5),
     marginBottom: theme.spacing(1.5),
   },
+  // The following is a workaround to not overrule the Mui base button styles
+  // by Tailwind's preflight reset
+  buttonPrimary: { backgroundColor: theme.palette.primary.main },
 }));
 // #endregion styles
 

--- a/packages/client/src/components/global/ConfirmDialog.tsx
+++ b/packages/client/src/components/global/ConfirmDialog.tsx
@@ -10,6 +10,7 @@ import {
   __confirmDialogYesId__,
   __confirmDialogNoId__,
 } from "@/__testData__/testIds";
+import makeStyles from "@mui/styles/makeStyles";
 
 interface Props {
   title: string;
@@ -39,6 +40,8 @@ const ConfirmDialog: React.FC<Props> = ({
     setOpen(false);
   };
 
+  const classes = useStyles();
+
   return (
     <Dialog open={open} onClose={() => setOpen(false)}>
       <DialogTitle>{title}</DialogTitle>
@@ -49,6 +52,7 @@ const ConfirmDialog: React.FC<Props> = ({
           onClick={handleReject}
           color="secondary"
           data-testid={__confirmDialogNoId__}
+          className={classes.buttonSecondary}
         >
           No
         </Button>
@@ -57,6 +61,7 @@ const ConfirmDialog: React.FC<Props> = ({
           onClick={handleConfirm}
           color="primary"
           data-testid={__confirmDialogYesId__}
+          className={classes.buttonPrimary}
         >
           Yes
         </Button>
@@ -64,5 +69,14 @@ const ConfirmDialog: React.FC<Props> = ({
     </Dialog>
   );
 };
+
+const useStyles = makeStyles((theme) => ({
+  buttonPrimary: {
+    backgroundColor: theme.palette.primary.main,
+  },
+  buttonSecondary: {
+    backgroundColor: theme.palette.secondary.main,
+  },
+}));
 
 export default ConfirmDialog;

--- a/packages/client/src/components/layout/DebugMenu.tsx
+++ b/packages/client/src/components/layout/DebugMenu.tsx
@@ -17,6 +17,7 @@ import {
   __debugButtonId__,
   __create100Athletes__,
 } from "@/__testData__/testIds";
+import makeStyles from "@mui/styles/makeStyles";
 
 const app = getApp();
 const functions = getFunctions(app, __functionsZone__);
@@ -48,10 +49,13 @@ const DebugMenu: React.FC = () => {
       }
     };
 
+  const classes = useStyles();
+
   return (
     <>
       <Button
         color="secondary"
+        className={classes.buttonSecondary}
         variant="contained"
         startIcon={<BugReportIcon />}
         onClick={handleClick}
@@ -85,5 +89,11 @@ const DebugMenu: React.FC = () => {
     </>
   );
 };
+
+const useStyles = makeStyles((theme) => ({
+  buttonSecondary: {
+    backgroundColor: theme.palette.secondary.main,
+  },
+}));
 
 export default DebugMenu;

--- a/packages/client/src/pages/customer_area_archive/CustomerNavigation/CustomerNavigation.tsx
+++ b/packages/client/src/pages/customer_area_archive/CustomerNavigation/CustomerNavigation.tsx
@@ -85,6 +85,7 @@ const CustomerNavigation: React.FC = () => {
           onChange={handleChange}
         >
           <LinkTab
+            // classes={{ selected: classes.buttonPrimary }}
             customerRoute={CustomerRoute.BookIce}
             icon={<EventNoteIcon />}
             disabled={customerRouteInPathname === CustomerRoute.BookIce}
@@ -138,6 +139,9 @@ const useStyles = makeStyles((theme) => ({
   customerNav: {
     backgroundColor: theme.palette.secondary.main,
   },
+  // The following is a workaround to not overrule the Mui base button styles
+  // by Tailwind's preflight reset
+  buttonPrimary: { backgroundColor: theme.palette.primary.main },
 }));
 // #endregion styles
 

--- a/packages/client/src/pages/debug/index.tsx
+++ b/packages/client/src/pages/debug/index.tsx
@@ -16,6 +16,7 @@ import AppbarAdmin from "@/components/layout/AppbarAdmin";
 import useTitle from "@/hooks/useTitle";
 
 import { createCloudFunctionCaller } from "@/utils/firebase";
+import makeStyles from "@mui/styles/makeStyles";
 
 const auth = getAuth();
 
@@ -35,7 +36,10 @@ export const createAdminTestUsers = async (): Promise<void> => {
 };
 
 const DebugPage: React.FC = () => {
+  const classes = useStyles();
+
   useTitle("Debug");
+
   return (
     <Container maxWidth="sm">
       <AppbarAdmin />
@@ -43,6 +47,7 @@ const DebugPage: React.FC = () => {
         <Button
           onClick={createAdminTestUsers}
           color="secondary"
+          className={classes.buttonSecondary}
           variant="contained"
         >
           Create admin test users
@@ -54,6 +59,7 @@ const DebugPage: React.FC = () => {
             numUsers: 10,
           })}
           color="primary"
+          className={classes.buttonPrimary}
           variant="contained"
         >
           Create test users
@@ -63,6 +69,7 @@ const DebugPage: React.FC = () => {
         <Button
           onClick={createCloudFunctionCaller(CloudFunction.CreateTestSlots)}
           color="primary"
+          className={classes.buttonPrimary}
           variant="contained"
         >
           Create test slots
@@ -72,6 +79,7 @@ const DebugPage: React.FC = () => {
         <Button
           onClick={createCloudFunctionCaller(CloudFunction.PruneSlotsByDay)}
           color="primary"
+          className={classes.buttonPrimary}
           variant="contained"
         >
           Prune slots by day
@@ -83,6 +91,7 @@ const DebugPage: React.FC = () => {
             CloudFunction.DeleteOrphanedBookings
           )}
           color="primary"
+          className={classes.buttonPrimary}
           variant="contained"
         >
           Delete orphaned bookings
@@ -94,6 +103,7 @@ const DebugPage: React.FC = () => {
             CloudFunction.MigrateCategoriesToExplicitMinors
           )}
           color="primary"
+          className={classes.buttonPrimary}
           variant="contained"
         >
           Migrate categories to explicit minors
@@ -102,4 +112,13 @@ const DebugPage: React.FC = () => {
     </Container>
   );
 };
+
+const useStyles = makeStyles((theme) => ({
+  buttonPrimary: {
+    background: theme.palette.primary.main,
+  },
+  buttonSecondary: {
+    background: theme.palette.secondary.main,
+  },
+}));
 export default DebugPage;


### PR DESCRIPTION
Fixes #555 
Add a workaround to fix "invisible" buttons due to Tailwind and Mui clashing:
- Tailwind features a preflight reset css file removing background colour on buttons
- PostCSS, for some reason loads generated CSS files (including the preflight) as latest - highest priority
- button background for primary button gets overwritten by reset

- A "quick" fix - assign colour to buttons explicitly through class names: classes created with `useStyles` are created in the browser so they have the highest priority (are loaded latest)

Not ideal, but we're moving to Tailwind bit by bit anyhow and it's good enough to make it work at the moment.