### PR TITLE
import ui css file so that it can be purged with main.css

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -99,6 +99,7 @@ importers:
       nyc: ^15.1.0
       p-retry: ^4.6.1
       postcss: ~8.4.13
+      postcss-import: ~14.1.0
       prop-types: ^15.8.1
       react: ^16.13.1
       react-dom: ^16.13.1
@@ -231,6 +232,7 @@ importers:
       nyc: 15.1.0
       p-retry: 4.6.2
       postcss: 8.4.14
+      postcss-import: 14.1.0_postcss@8.4.14
       prop-types: 15.8.1
       redux-devtools-extension: 2.13.9_redux@4.2.0
       reselect: 4.1.6
@@ -17488,6 +17490,18 @@ packages:
       postcss: 7.0.39
     dev: true
 
+  /postcss-import/14.1.0_postcss@8.4.14:
+    resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss: 8.4.14
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.1
+    dev: true
+
   /postcss-js/4.0.0_postcss@8.4.14:
     resolution: {integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==}
     engines: {node: ^12 || ^14 || >= 16}
@@ -18307,6 +18321,12 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.8.1
+
+  /read-cache/1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+    dependencies:
+      pify: 2.3.0
+    dev: true
 
   /read-pkg-up/1.0.1:
     resolution: {integrity: sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "68f3797fa118f1fe0ebe691acc4730508db8a30f",
+  "pnpmShrinkwrapHash": "4e2d55d46c6a990fd0fff4fdbc573be7c70431a6",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/client/.storybook/preview.js
+++ b/packages/client/.storybook/preview.js
@@ -6,8 +6,6 @@ import { Provider } from "react-redux";
 // Import stylesheet importing tailwind to allow
 // for tailwind styles creation for stories
 import "../src/main.css";
-// Import styles from ui package
-import "@eisbuk/ui/dist/style.css";
 
 import { available as availableThemes } from "@/themes";
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -153,6 +153,7 @@
     "vite-plugin-environment": "^1.1.0",
     "vite-plugin-svgr": "~2.1.0",
     "webpack": "^5.72.0",
-    "@babel/plugin-proposal-private-methods": "~7.17.12"
+    "@babel/plugin-proposal-private-methods": "~7.17.12",
+    "postcss-import": "~14.1.0"
   }
 }

--- a/packages/client/postcss.config.js
+++ b/packages/client/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: {
+    "postcss-import": {},
     tailwindcss: {},
     autoprefixer: {},
   },

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -5,9 +5,6 @@ import "./main.css";
 import React from "react";
 import ReactDOM from "react-dom";
 
-// import "@eisbuk/translations";
-import "@eisbuk/ui/dist/style.css";
-
 import * as Sentry from "@sentry/react";
 import { Integrations } from "@sentry/tracing";
 

--- a/packages/client/src/main.css
+++ b/packages/client/src/main.css
@@ -1,6 +1,9 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss/base";
+
+@import "tailwindcss/components";
+
+@import "tailwindcss/utilities";
+@import "../../ui/dist/style.css";
 
 .center-absolute {
   @apply absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2;


### PR DESCRIPTION
Fixes #581 

The ideal solution would be to split `ui` package CSS bundle into (purged) Tailwind layers and then import all layers in a template CSS file in `client`. Like so:
```css
@import "tailwindcss/base"
@import "../../ui/dist/base.css"

@import "tailwindcss/components"
@import "../../ui/dist/components.css"

@import "tailwindcss/utilities"
@import "../../ui/dist/utilities.css"
```

However, I didn't find a straight forward way of doing this so this solution has to do: The entire bundle is imported after "tailwindcss/utilities", in template `main.css`, rather than `index.tsx`. This is done using `postcss-import` plugin and allows the input to get purged as well (avoiding duplicate classes).

The result is reduction of CSS bundle from ~65KB to ~56KB, which doesn't seem like much, but is a difference, especially on a bundle for an app this size (very little different styles used)