### PR TITLE
Fix/small fixes 1

### DIFF
--- a/packages/client/src/components/atoms/AttendanceSheet/AttendanceSheetSlot.tsx
+++ b/packages/client/src/components/atoms/AttendanceSheet/AttendanceSheetSlot.tsx
@@ -42,6 +42,7 @@ const AttendanceSheetSlot: React.FC<Props> = ({ customers, type, notes }) => {
 
         return (
           <TableRow
+            key={customer.id}
             style={{ backgroundColor: typeColor }}
             className={classes.tableCell}
           >
@@ -88,7 +89,7 @@ const AttendanceSheetSlot: React.FC<Props> = ({ customers, type, notes }) => {
           </TableRow>
         );
       })}
-      <Divider className={classes.divider} />
+      <Divider className={classes.divider} component="tr" />
     </TableBody>
   );
 };

--- a/packages/client/src/components/atoms/CustomerCard/ActionButtons.tsx
+++ b/packages/client/src/components/atoms/CustomerCard/ActionButtons.tsx
@@ -31,6 +31,7 @@ import { openModal } from "@/features/modal/actions";
 const ActionButtons: React.FC<ActionButtonProps> = ({
   customer,
   className,
+  onClose,
 }) => {
   const { t } = useTranslation();
 
@@ -41,7 +42,10 @@ const ActionButtons: React.FC<ActionButtonProps> = ({
 
   // redirect to customers `bookings` entry flow
   const bookingsRoute = `${Routes.CustomerArea}/${customer?.secretKey}`;
-  const redirectToBookings = () => history.push(bookingsRoute);
+  const redirectToBookings = () => {
+    history.push(bookingsRoute);
+    onClose();
+  };
 
   const openBookingsLinkModal = (method: SendBookingLinkMethod) => () => {
     dispatch(

--- a/packages/client/src/components/atoms/CustomerCard/CustomerCard.stories.tsx
+++ b/packages/client/src/components/atoms/CustomerCard/CustomerCard.stories.tsx
@@ -19,5 +19,5 @@ export default {
 } as ComponentMeta<typeof CustomerCard>;
 
 export const Default = (): JSX.Element => (
-  <CustomerCard customer={walt} onClose={(): void => {}} />
+  <CustomerCard customer={walt} onClose={() => {}} onCloseAll={() => {}} />
 );

--- a/packages/client/src/components/atoms/CustomerCard/CustomerCard.tsx
+++ b/packages/client/src/components/atoms/CustomerCard/CustomerCard.tsx
@@ -77,7 +77,7 @@ const CustomerCard: React.FC<CustomerCardProps> = ({
               : customer[property] || "-";
 
           return (
-            <>
+            <React.Fragment key={property}>
               <Typography
                 className={classes.property}
                 variant="h6"
@@ -87,7 +87,7 @@ const CustomerCard: React.FC<CustomerCardProps> = ({
                 <span className={classes.value}>{value}</span>
               </Typography>
               <div className={classes.divider} />
-            </>
+            </React.Fragment>
           );
         })}
       </>

--- a/packages/client/src/components/atoms/CustomerCard/__tests__/CustomerCard.test.tsx
+++ b/packages/client/src/components/atoms/CustomerCard/__tests__/CustomerCard.test.tsx
@@ -168,11 +168,13 @@ describe("Customer Card", () => {
 
   describe("Test bookings redirect button", () => {
     test("should redirect to 'bookings' route for a customer on bookings button click", () => {
-      render(<CustomerCard onClose={() => {}} customer={saul} />);
+      const mockOnClose = jest.fn();
+      render(<CustomerCard onClose={mockOnClose} customer={saul} />);
       screen.getByTestId(__openBookingsId__).click();
       expect(mockHistoryPush).toHaveBeenCalledWith(
         `${Routes.CustomerArea}/${saul.secretKey}`
       );
+      expect(mockOnClose).toHaveBeenCalled();
     });
   });
 

--- a/packages/client/src/components/atoms/CustomerCard/__tests__/CustomerCard.test.tsx
+++ b/packages/client/src/components/atoms/CustomerCard/__tests__/CustomerCard.test.tsx
@@ -60,7 +60,13 @@ describe("Customer Card", () => {
 
   describe("CustomerOperationButtons", () => {
     beforeEach(() => {
-      render(<CustomerCard onClose={() => {}} customer={saul} />);
+      render(
+        <CustomerCard
+          onCloseAll={() => {}}
+          onClose={() => {}}
+          customer={saul}
+        />
+      );
     });
 
     afterEach(() => {
@@ -88,7 +94,13 @@ describe("Customer Card", () => {
 
   describe("Test email button", () => {
     test("should open a 'SendBookingsLinkDialog' modal with method = \"email\" on email button click", () => {
-      render(<CustomerCard onClose={() => {}} customer={saul} />);
+      render(
+        <CustomerCard
+          onCloseAll={() => {}}
+          onClose={() => {}}
+          customer={saul}
+        />
+      );
       screen.getByTestId(__sendBookingsEmailId__).click();
       expect(mockDispatch).toHaveBeenCalledWith(
         openModal({
@@ -103,6 +115,7 @@ describe("Customer Card", () => {
       const { secretKey, ...noSecretKeySaul } = saul;
       render(
         <CustomerCard
+          onCloseAll={() => {}}
           onClose={() => {}}
           customer={noSecretKeySaul as Customer}
         />
@@ -117,7 +130,13 @@ describe("Customer Card", () => {
     test("should disable the button if email is not provided", () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { email, ...noEmailSaul } = saul;
-      render(<CustomerCard onClose={() => {}} customer={noEmailSaul} />);
+      render(
+        <CustomerCard
+          onCloseAll={() => {}}
+          onClose={() => {}}
+          customer={noEmailSaul}
+        />
+      );
       expect(screen.getByTestId(__sendBookingsEmailId__)).toHaveProperty(
         "disabled",
         true
@@ -127,7 +146,13 @@ describe("Customer Card", () => {
 
   describe("Test SMS button", () => {
     test("should open a 'SendBookingsLinkDialog' modal with method = \"sms\" on sms button click", () => {
-      render(<CustomerCard onClose={() => {}} customer={saul} />);
+      render(
+        <CustomerCard
+          onCloseAll={() => {}}
+          onClose={() => {}}
+          customer={saul}
+        />
+      );
       screen.getByTestId(__sendBookingsSMSId__).click();
       expect(mockDispatch).toHaveBeenCalledWith(
         openModal({
@@ -142,6 +167,7 @@ describe("Customer Card", () => {
       const { secretKey, ...noSecretKeySaul } = saul;
       render(
         <CustomerCard
+          onCloseAll={() => {}}
           onClose={() => {}}
           customer={noSecretKeySaul as Customer}
         />
@@ -157,7 +183,11 @@ describe("Customer Card", () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { phone, ...noPhoneSaul } = saul;
       render(
-        <CustomerCard onClose={() => {}} customer={noPhoneSaul as Customer} />
+        <CustomerCard
+          onCloseAll={() => {}}
+          onClose={() => {}}
+          customer={noPhoneSaul as Customer}
+        />
       );
       expect(screen.getByTestId(__sendBookingsSMSId__)).toHaveProperty(
         "disabled",
@@ -169,7 +199,13 @@ describe("Customer Card", () => {
   describe("Test bookings redirect button", () => {
     test("should redirect to 'bookings' route for a customer on bookings button click", () => {
       const mockOnClose = jest.fn();
-      render(<CustomerCard onClose={mockOnClose} customer={saul} />);
+      render(
+        <CustomerCard
+          onCloseAll={() => {}}
+          onClose={mockOnClose}
+          customer={saul}
+        />
+      );
       screen.getByTestId(__openBookingsId__).click();
       expect(mockHistoryPush).toHaveBeenCalledWith(
         `${Routes.CustomerArea}/${saul.secretKey}`
@@ -180,7 +216,13 @@ describe("Customer Card", () => {
 
   describe("Test booking extension button", () => {
     test("should open extend booking prompt on click 'extend booking date' button click", () => {
-      render(<CustomerCard onClose={() => {}} customer={saul} />);
+      render(
+        <CustomerCard
+          onCloseAll={() => {}}
+          onClose={() => {}}
+          customer={saul}
+        />
+      );
       screen
         .getByText(i18n.t(ActionButton.ExtendBookingDate) as string)
         .click();

--- a/packages/client/src/features/modal/__tests__/store.test.ts
+++ b/packages/client/src/features/modal/__tests__/store.test.ts
@@ -5,7 +5,7 @@ import { SlotInterface, SlotType } from "@eisbuk/shared";
 
 import { ModalPayload } from "../types";
 
-import { popModal, openModal } from "../actions";
+import { popModal, openModal, closeAllModals } from "../actions";
 
 import { getModal } from "../selectors";
 
@@ -49,8 +49,8 @@ describe("Modal store tests", () => {
   });
 
   describe("Close modal action", () => {
-    test("should set the store state to 'null' effectively removing the modal from the screen", () => {
-      // Test setup is the test above
+    test("should pop the latest modal from store state effectively removing the modal from the screen", () => {
+      // Setup
       const store = getNewStore();
       store.dispatch(openModal(modal1));
       store.dispatch(openModal(modal2));
@@ -61,6 +61,19 @@ describe("Modal store tests", () => {
       // Close the final modal
       store.dispatch(popModal);
       modalContent = getModal(store.getState());
+      expect(modalContent).toEqual([]);
+    });
+  });
+
+  describe("Close all modals action", () => {
+    test("should remove all modals from the state, removing any modal from the screen", () => {
+      // Setup
+      const store = getNewStore();
+      store.dispatch(openModal(modal1));
+      store.dispatch(openModal(modal2));
+      // Close the top-most modal
+      store.dispatch(closeAllModals);
+      const modalContent = getModal(store.getState());
       expect(modalContent).toEqual([]);
     });
   });

--- a/packages/client/src/features/modal/actions.ts
+++ b/packages/client/src/features/modal/actions.ts
@@ -18,3 +18,11 @@ export const openModal = (payload: ModalPayload): ModalReducerAction => ({
 export const popModal: ModalReducerAction = {
   type: ModalAction.Close,
 };
+
+/**
+ * This is a pure action object (not a function) dispatched
+ * to close an entire modal stack
+ */
+export const closeAllModals: ModalReducerAction = {
+  type: ModalAction.CloseAll,
+};

--- a/packages/client/src/features/modal/components/AddAttendedCustomersDialog/__tests__/AddAttendedCustomersDialog.test.tsx
+++ b/packages/client/src/features/modal/components/AddAttendedCustomersDialog/__tests__/AddAttendedCustomersDialog.test.tsx
@@ -42,6 +42,7 @@ describe("AddAttendedCustomersDialog", () => {
   test("should call onClose on 'x' button click", () => {
     render(
       <AddAttendedCustomersDialog
+        onCloseAll={() => {}}
         customers={[saul, walt]}
         onClose={mockOnClose}
         {...{ ...baseSlot, defaultInterval }}
@@ -54,6 +55,7 @@ describe("AddAttendedCustomersDialog", () => {
   test("should add customer as having attended a default interval of given slot on customer click", () => {
     render(
       <AddAttendedCustomersDialog
+        onCloseAll={() => {}}
         customers={[saul, walt]}
         onClose={mockOnClose}
         {...{ ...baseSlot, defaultInterval }}
@@ -76,6 +78,7 @@ describe("AddAttendedCustomersDialog", () => {
   test("should not render 'deleted' customers", () => {
     render(
       <AddAttendedCustomersDialog
+        onCloseAll={() => {}}
         customers={[{ ...saul, deleted: true }, walt]}
         onClose={mockOnClose}
         {...{ ...baseSlot, defaultInterval }}
@@ -90,6 +93,7 @@ describe("AddAttendedCustomersDialog", () => {
   test("should close the modal when last customer listed marked as attended", async () => {
     render(
       <AddAttendedCustomersDialog
+        onCloseAll={() => {}}
         customers={[{ ...saul, deleted: true }, walt]}
         onClose={mockOnClose}
         {...{ ...baseSlot, defaultInterval }}

--- a/packages/client/src/features/modal/components/CustomerFormDialog/__tests__/CustomerFormDialog.test.tsx
+++ b/packages/client/src/features/modal/components/CustomerFormDialog/__tests__/CustomerFormDialog.test.tsx
@@ -32,7 +32,13 @@ jest.mock("react-redux", () => ({
 
 describe("CustomerFormDialog", () => {
   beforeEach(() => {
-    render(<CustomerFormDialog onClose={mockOnClose} customer={saul} />);
+    render(
+      <CustomerFormDialog
+        onCloseAll={() => {}}
+        onClose={mockOnClose}
+        customer={saul}
+      />
+    );
   });
 
   afterEach(() => {

--- a/packages/client/src/features/modal/components/DeleteCustomerDialog/DeleteCustomerDialog.tsx
+++ b/packages/client/src/features/modal/components/DeleteCustomerDialog/DeleteCustomerDialog.tsx
@@ -13,6 +13,7 @@ type DeleteCustomerProps = BaseModalProps & Customer;
 
 const DeleteCustomerDialog: React.FC<DeleteCustomerProps> = ({
   onClose,
+  onCloseAll,
   className,
   ...customer
 }) => {
@@ -20,7 +21,7 @@ const DeleteCustomerDialog: React.FC<DeleteCustomerProps> = ({
 
   const onConfirm = () => {
     dispatch(deleteCustomer(customer));
-    onClose();
+    onCloseAll();
   };
 
   const { name, surname } = customer;

--- a/packages/client/src/features/modal/components/DeleteCustomerDialog/__tests__/DeleteCustomerDialog.test.tsx
+++ b/packages/client/src/features/modal/components/DeleteCustomerDialog/__tests__/DeleteCustomerDialog.test.tsx
@@ -31,7 +31,13 @@ jest.mock("react-redux", () => ({
 
 describe("DeleteCustomerDialog", () => {
   beforeEach(() => {
-    render(<DeleteCustomerDialog {...saul} onClose={mockOnClose} />);
+    render(
+      <DeleteCustomerDialog
+        {...saul}
+        onClose={mockOnClose}
+        onCloseAll={() => {}}
+      />
+    );
   });
 
   afterEach(() => {

--- a/packages/client/src/features/modal/components/DeleteCustomerDialog/__tests__/DeleteCustomerDialog.test.tsx
+++ b/packages/client/src/features/modal/components/DeleteCustomerDialog/__tests__/DeleteCustomerDialog.test.tsx
@@ -13,6 +13,7 @@ import * as customerOperations from "@/store/actions/customerOperations";
 import { saul } from "@/__testData__/customers";
 
 const mockOnClose = jest.fn();
+const mockOnCloseAll = jest.fn();
 // Mock deleteCustomer to a, sort of, identity function
 // to test it being dispatched to the store (with appropriate params)
 // rather than just being called
@@ -35,7 +36,7 @@ describe("DeleteCustomerDialog", () => {
       <DeleteCustomerDialog
         {...saul}
         onClose={mockOnClose}
-        onCloseAll={() => {}}
+        onCloseAll={mockOnCloseAll}
       />
     );
   });
@@ -45,14 +46,16 @@ describe("DeleteCustomerDialog", () => {
     cleanup();
   });
 
-  test("should call onClose on cancel", () => {
+  test("should call 'onClose' on cancel", () => {
     screen.getByText(i18n.t(ActionButton.Cancel) as string).click();
     expect(mockOnClose).toHaveBeenCalled();
+    expect(mockOnCloseAll).not.toHaveBeenCalled();
   });
 
-  test("should call delete customer with customer data and close the modal on confirm", () => {
+  test("should call delete customer with customer data and close all of the modals on confirm", () => {
     screen.getByText(i18n.t(ActionButton.Delete) as string).click();
     expect(mockDispatch).toHaveBeenCalledWith(mockDeleteCustomer(saul));
-    expect(mockOnClose).toHaveBeenCalled();
+    expect(mockOnClose).not.toHaveBeenCalled();
+    expect(mockOnCloseAll).toHaveBeenCalled();
   });
 });

--- a/packages/client/src/features/modal/components/DeleteSlotDialog/__tests__/DeleteSlotDialog.test.tsx
+++ b/packages/client/src/features/modal/components/DeleteSlotDialog/__tests__/DeleteSlotDialog.test.tsx
@@ -31,7 +31,13 @@ jest.mock("react-redux", () => ({
 
 describe("DeleteSlotDialog", () => {
   beforeEach(() => {
-    render(<DeleteSlotDialog {...baseSlot} onClose={mockOnClose} />);
+    render(
+      <DeleteSlotDialog
+        {...baseSlot}
+        onClose={mockOnClose}
+        onCloseAll={() => {}}
+      />
+    );
   });
 
   afterEach(() => {

--- a/packages/client/src/features/modal/components/ExtendBookingDateDialog/__tests__/ExtendBookingDateDialog.test.tsx
+++ b/packages/client/src/features/modal/components/ExtendBookingDateDialog/__tests__/ExtendBookingDateDialog.test.tsx
@@ -32,7 +32,13 @@ jest.mock("react-redux", () => ({
 
 describe("ExtendBookingDateDialog", () => {
   beforeEach(() => {
-    render(<ExtendBookingDateDialog {...saul} onClose={mockOnClose} />);
+    render(
+      <ExtendBookingDateDialog
+        {...saul}
+        onClose={mockOnClose}
+        onCloseAll={() => {}}
+      />
+    );
   });
 
   afterEach(() => {

--- a/packages/client/src/features/modal/components/Modal/Modal.tsx
+++ b/packages/client/src/features/modal/components/Modal/Modal.tsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { componentWhitelist } from "@/features/modal/components";
 
-import { popModal } from "@/features/modal/actions";
+import { closeAllModals, popModal } from "@/features/modal/actions";
 import { getModal } from "@/features/modal/selectors";
 
 /**
@@ -55,6 +55,9 @@ const Modal: React.FC = () => {
   const handleClose = () => {
     dispatch(popModal);
   };
+  const handleCloseAll = () => {
+    dispatch(closeAllModals);
+  };
 
   const content = (
     <ModalContainer onClose={handleClose}>
@@ -66,6 +69,7 @@ const Modal: React.FC = () => {
             key={`${component}-${i}`}
             {...(props as any)}
             onClose={handleClose}
+            onCloseAll={handleCloseAll}
           />
         );
       })}

--- a/packages/client/src/features/modal/components/Modal/Modal.tsx
+++ b/packages/client/src/features/modal/components/Modal/Modal.tsx
@@ -94,7 +94,10 @@ export const ModalContainer: React.FC<{ onClose?: () => void }> = ({
       // We need to split modal components if there are multiple in order to
       // apply the "centered" styling on each
       children.map((child) => (
-        <div className="center-absolute bg-white rounded-lg overflow-hidden shadow-2xl">
+        <div
+          key={child.key}
+          className="center-absolute bg-white rounded-lg overflow-hidden shadow-2xl"
+        >
           {child}
         </div>
       ))

--- a/packages/client/src/features/modal/components/SendBookingsLinkDialog/SendBookingsLinkDialog.tsx
+++ b/packages/client/src/features/modal/components/SendBookingsLinkDialog/SendBookingsLinkDialog.tsx
@@ -18,6 +18,9 @@ const SendBookingsLinkDialog: React.FC<SendBookingsLinkProps> = ({
   onClose,
   className,
   method,
+  // remove 'onCloseAll' from 'customer'
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  onCloseAll,
   ...customer
 }) => {
   const dispatch = useDispatch();

--- a/packages/client/src/features/modal/components/SendBookingsLinkDialog/__tests__/SendBookingsLinkDialog.test.tsx
+++ b/packages/client/src/features/modal/components/SendBookingsLinkDialog/__tests__/SendBookingsLinkDialog.test.tsx
@@ -44,6 +44,7 @@ describe("SendBookingsLinkDialog", () => {
   test("should call onClose on cancel", () => {
     render(
       <SendBookingsLinkDialog
+        onCloseAll={() => {}}
         {...saul}
         method={SendBookingLinkMethod.Email}
         onClose={mockOnClose}
@@ -56,6 +57,7 @@ describe("SendBookingsLinkDialog", () => {
   test("should call onClose on cancel", () => {
     render(
       <SendBookingsLinkDialog
+        onCloseAll={() => {}}
         {...saul}
         method={SendBookingLinkMethod.Email}
         onClose={mockOnClose}
@@ -68,6 +70,7 @@ describe("SendBookingsLinkDialog", () => {
   test("should call 'sendBookingsLink' with 'email' method if method = \"email\" and close the modal", () => {
     render(
       <SendBookingsLinkDialog
+        onCloseAll={() => {}}
         {...saul}
         method={SendBookingLinkMethod.Email}
         onClose={mockOnClose}
@@ -87,6 +90,7 @@ describe("SendBookingsLinkDialog", () => {
   test("should call 'sendBookingsLink' with 'sms' method if method = \"sms\" and close the modal", () => {
     render(
       <SendBookingsLinkDialog
+        onCloseAll={() => {}}
         {...saul}
         method={SendBookingLinkMethod.SMS}
         onClose={mockOnClose}

--- a/packages/client/src/features/modal/reducer.ts
+++ b/packages/client/src/features/modal/reducer.ts
@@ -18,6 +18,9 @@ const modalReducer: Reducer<ModalState, ModalReducerAction> = (
     case ModalAction.Close:
       return state.slice(0, -1);
 
+    case ModalAction.CloseAll:
+      return [];
+
     default:
       return state;
   }

--- a/packages/client/src/features/modal/types.ts
+++ b/packages/client/src/features/modal/types.ts
@@ -2,7 +2,14 @@ import { componentWhitelist } from "./components";
 
 // #region component
 export interface BaseModalProps {
+  /**
+   * Close the current modal (pop it from the stack)
+   */
   onClose: () => void;
+  /**
+   * Close all open modals
+   */
+  onCloseAll: () => void;
   className?: string;
 }
 
@@ -22,7 +29,7 @@ type GetComponentProps<C extends WhitelistedComponents> = Omit<
   // Omit the 'onClose' handler as it is specified by the Modal component
   // and it shouldn't be stored in `modal` store state.
   // Same goes for "className" and "children" (which should never be passed to a modal component)
-  "onClose" | "className" | "children"
+  "onCloseAll" | "onClose" | "className" | "children"
 >;
 // #endregion component
 
@@ -30,13 +37,14 @@ type GetComponentProps<C extends WhitelistedComponents> = Omit<
 export enum ModalAction {
   Open = "@@MODAL/OPEN",
   Close = "@@MODAL/CLOSE",
+  CloseAll = "@@MODAL/CLOSE_ALL",
 }
 
 /**
  * This is some heavy ninjutsu which I won't even begin to try to explain.
  *
  * It essentially allows us to infer from `component` what should the `props` interface be,
- * rather infering props as an intersection of all props for all whitelisted components.
+ * rather then infering props as an intersection of all props for all whitelisted components.
  */
 type ModalStateMap = {
   [C in WhitelistedComponents]: {
@@ -52,19 +60,22 @@ type ModalStateMap = {
 };
 
 /**
- * State of `modal` portion of the store with `
+ * Payload for modal open: used to specify the modal variant and pass appropriate props.
  */
 export type ModalPayload<
   C extends WhitelistedComponents = WhitelistedComponents
 > = ModalStateMap[C];
 
+/**
+ * State for `modal` portion of the store - a stack of open modals.
+ */
 export type ModalState = ModalPayload[];
 
 // There are only two variants to this type. If number of variants gets bigger,
 // it can be extended to more generic types/lookups
 export type ModalReducerAction =
   | {
-      type: ModalAction.Close;
+      type: ModalAction.Close | ModalAction.CloseAll;
     }
   | { type: ModalAction.Open; payload: ModalPayload };
 // #endregion Redux

--- a/packages/client/src/pages/attendance_printable/index.tsx
+++ b/packages/client/src/pages/attendance_printable/index.tsx
@@ -75,7 +75,9 @@ const DashboardPage: React.FC = () => {
       <AttendanceSheet date={date}>
         {attendanceSlots.map(
           (slot) =>
-            slot.customers.length > 0 && <AttendanceSheetSlot {...slot} />
+            slot.customers.length > 0 && (
+              <AttendanceSheetSlot key={slot.id} {...slot} />
+            )
         )}
       </AttendanceSheet>
     </Layout>

--- a/packages/client/src/pages/debug/index.tsx
+++ b/packages/client/src/pages/debug/index.tsx
@@ -5,7 +5,13 @@ import {
   signInWithEmailAndPassword,
 } from "@firebase/auth";
 
-import { Button, ButtonColor, ButtonSize, Layout } from "@eisbuk/ui";
+import {
+  Button,
+  ButtonColor,
+  ButtonProps,
+  ButtonSize,
+  Layout,
+} from "@eisbuk/ui";
 
 import { CloudFunction } from "@/enums/functions";
 
@@ -34,6 +40,18 @@ export const createAdminTestUsers = async (): Promise<void> => {
   }
 };
 
+const DebugPageButton: React.FC<Pick<ButtonProps, "color" | "onClick">> = ({
+  color = ButtonColor.Primary,
+  ...props
+}) => (
+  <Button
+    className="active:opacity-80"
+    {...props}
+    color={color}
+    size={ButtonSize.LG}
+  />
+);
+
 const DebugPage: React.FC = () => {
   useTitle("Debug");
 
@@ -45,69 +63,63 @@ const DebugPage: React.FC = () => {
     >
       <div className="content-container py-8">
         <div className="p-2">
-          <Button
+          <DebugPageButton
             onClick={createAdminTestUsers}
             color={ButtonColor.Secondary}
-            size={ButtonSize.LG}
           >
             Create admin test users
-          </Button>
+          </DebugPageButton>
         </div>
 
         <div className="p-2">
-          <Button
+          <DebugPageButton
             onClick={createCloudFunctionCaller(CloudFunction.CreateTestData, {
               numUsers: 10,
             })}
             color={ButtonColor.Primary}
-            size={ButtonSize.LG}
           >
             Create test users
-          </Button>
+          </DebugPageButton>
         </div>
 
         <div className="p-2">
-          <Button
+          <DebugPageButton
             onClick={createCloudFunctionCaller(CloudFunction.CreateTestSlots)}
             color={ButtonColor.Primary}
-            size={ButtonSize.LG}
           >
             Create test slots
-          </Button>
+          </DebugPageButton>
         </div>
 
         <div className="p-2">
-          <Button
+          <DebugPageButton
             onClick={createCloudFunctionCaller(CloudFunction.PruneSlotsByDay)}
             color={ButtonColor.Primary}
-            size={ButtonSize.LG}
           >
             Prune slots by day
-          </Button>
+          </DebugPageButton>
         </div>
 
         <div className="p-2">
-          <Button
+          <DebugPageButton
             onClick={createCloudFunctionCaller(
               CloudFunction.DeleteOrphanedBookings
             )}
             color={ButtonColor.Primary}
-            size={ButtonSize.LG}
           >
             Delete orphaned bookings
-          </Button>
+          </DebugPageButton>
         </div>
 
         <div className="p-2">
-          <Button
+          <DebugPageButton
             onClick={createCloudFunctionCaller(
               CloudFunction.MigrateCategoriesToExplicitMinors
             )}
             color={ButtonColor.Primary}
-            size={ButtonSize.LG}
           >
             Migrate categories to explicit minors
-          </Button>
+          </DebugPageButton>
         </div>
       </div>
     </Layout>

--- a/packages/client/src/pages/slots/index.tsx
+++ b/packages/client/src/pages/slots/index.tsx
@@ -142,8 +142,8 @@ const SlotsPage: React.FC = () => {
 
           return (
             <SlotsDayContainer
-              key={date.toISO()}
-              date={date.toISODate()}
+              key={dateISO}
+              date={dateISO}
               additionalContent={canEdit ? additionalButtons : undefined}
             >
               <div className="grid gap-4 grid-cols-2">
@@ -151,7 +151,7 @@ const SlotsPage: React.FC = () => {
                   const selected = checkSelected(slot.id, weekToPaste);
 
                   return (
-                    <div className="col-span-2 md:col-span-1">
+                    <div key={slot.id} className="col-span-2 md:col-span-1">
                       <SlotCard
                         {...{ ...slot, selected }}
                         onClick={

--- a/packages/ui/src/SlotsDayContainer/SlotsDayContainer.tsx
+++ b/packages/ui/src/SlotsDayContainer/SlotsDayContainer.tsx
@@ -37,7 +37,7 @@ const SlotsDayConatiner: React.FC<SlotsDayContainerProps> = ({
           {additionalContent}
         </div>
       </div>
-      <div className="flex flex-wrap items-end gap-6 min-h-[146px]">
+      <div className="p-1 flex flex-wrap items-end gap-6 min-h-[146px]">
         {children}
       </div>
     </div>


### PR DESCRIPTION
A collection of fixes:
- add 4px padding to `SlotsDayContainer` not to obscure (on y axis) or let overflow (on x axis) the slot card outline
- close the `CustomerCard` modal on `Bookings` button click and redirect
- add `@@MODAL/CLOSE_ALL` action used to close all modals in the modal stack and use when deleting customer
- make the `/debug` page buttons visually show click (by reducing opacity on `active` pseudo state)
- fix react `console.errors` across the app (Validate DOM Nesting and mapped element key props)