### PR TITLE
Feature/textarea editable

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -699,6 +699,7 @@ importers:
       eslint-plugin-react: ^7.29.4
       eslint-plugin-react-hooks: ^4.4.0
       eslint-plugin-unused-imports: ^2.0.0
+      formik: ^2.1.5
       jest: ^27.5.1
       luxon: ^2.0.5
       postcss: ~8.4.13
@@ -748,6 +749,7 @@ importers:
       eslint-plugin-react: 7.30.1_eslint@8.19.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.19.0
       eslint-plugin-unused-imports: 2.0.0_c296cfcf20d280cfb2cd3afc88aefdcf
+      formik: 2.2.9_react@16.14.0
       jest: 27.5.1
       postcss: 8.4.14
       react: 16.14.0
@@ -10181,7 +10183,6 @@ packages:
   /deepmerge/2.2.1:
     resolution: {integrity: sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /deepmerge/4.2.2:
     resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
@@ -12382,7 +12383,6 @@ packages:
       react-fast-compare: 2.0.4
       tiny-warning: 1.0.3
       tslib: 1.14.1
-    dev: false
 
   /forwarded/0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -15406,7 +15406,6 @@ packages:
 
   /lodash-es/4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
-    dev: false
 
   /lodash._isnative/2.4.1:
     resolution: {integrity: sha512-BOlKGKNHhCHswGOWtmVb5zBygyxN7EmTuzVOSQI6QSoGhG+kvv71gICFS1TBpnqvT1n53txK8CDK3u5D2/GZxQ==}
@@ -18001,7 +18000,6 @@ packages:
 
   /react-fast-compare/2.0.4:
     resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==}
-    dev: false
 
   /react-i18next/11.18.0_i18next@21.8.13+react@16.14.0:
     resolution: {integrity: sha512-coJujU20xJ5Wa5rHjTyB5LFKZb1yfXo2A+40RRSyAF0FlZRHyy+3C1Mr92x1JPfS7W7v2TWNn8mRhpDFGJwXVg==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "5102cc9bd6b8469f45d627e9979e63cff99dcf91",
+  "pnpmShrinkwrapHash": "05d132bba2ac6850bcc1f5dda6131379d17d7e1b",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
   },
   "types": "dist/index.d.ts",
   "peerDependencies": {
+    "formik": "^2.1.5",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "5.x"
@@ -74,6 +75,7 @@
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.4.0",
     "eslint-plugin-unused-imports": "^2.0.0",
+    "formik": "^2.1.5",
     "jest": "^27.5.1",
     "postcss": "~8.4.13",
     "react": "^16.13.1",

--- a/packages/ui/src/TextareaEditable/TextareaEditable.stories.tsx
+++ b/packages/ui/src/TextareaEditable/TextareaEditable.stories.tsx
@@ -1,11 +1,42 @@
-import React from "react";
+import React, { useState } from "react";
 import { ComponentMeta } from "@storybook/react";
 
 import TextareaEditable from "./TextareaEditable";
+import Button, { ButtonColor } from "../Button";
 
 export default {
   title: "Textarea Editable",
   component: TextareaEditable,
 } as ComponentMeta<typeof TextareaEditable>;
 
-export const Default = (): JSX.Element => <TextareaEditable />;
+const initialValue =
+  "The quick brown fox jumps over the lazy dog while colourless green ideas sleep furiously.";
+
+export const Interactive = (): JSX.Element => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [value, setValue] = useState(initialValue);
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setValue(e.target.value);
+
+  const baseClasses = "h-full w-full rounded border-2";
+  const nonActiveBorder = "border-transparent";
+  const activeBorder = "border-cyan-500";
+  const className = [
+    baseClasses,
+    isEditing ? activeBorder : nonActiveBorder,
+  ].join(" ");
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-[100px] w-[400px]">
+        <TextareaEditable {...{ value, onChange, isEditing, className }} />
+      </div>
+      <Button
+        onClick={() => setIsEditing(!isEditing)}
+        color={ButtonColor.Primary}
+      >
+        {isEditing ? "Disable Edit" : "Enable Edit"}
+      </Button>
+    </div>
+  );
+};

--- a/packages/ui/src/TextareaEditable/TextareaEditable.stories.tsx
+++ b/packages/ui/src/TextareaEditable/TextareaEditable.stories.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { ComponentMeta } from "@storybook/react";
+
+import TextareaEditable from "./TextareaEditable";
+
+export default {
+  title: "Textarea Editable",
+  component: TextareaEditable,
+} as ComponentMeta<typeof TextareaEditable>;
+
+export const Default = (): JSX.Element => <TextareaEditable />;

--- a/packages/ui/src/TextareaEditable/TextareaEditable.tsx
+++ b/packages/ui/src/TextareaEditable/TextareaEditable.tsx
@@ -1,11 +1,55 @@
 import React from "react";
 
 interface TextareaEditableProps extends React.HTMLAttributes<HTMLElement> {
+  /**
+   * A boolean flag to toggle between editing and display mode
+   */
   isEditing?: boolean;
+  value: string;
 }
 
-const TextareaEditable: React.FC<TextareaEditableProps> = () => {
-  return null;
+/**
+ * A wysiwyg text area component. On default it show the text while with 'isEditing' turns into
+ * a textarea elmenent with all appropriate functionality.
+ */
+const TextareaEditable: React.FC<TextareaEditableProps> = ({
+  isEditing,
+  value,
+  className: inputClasses = "",
+  ...props
+}) => {
+  const element: "textarea" | "p" = isEditing ? "textarea" : "p";
+
+  // To achieve wysiwyg editable element, we're displaying the text value
+  // as different properties whether we're using 'p' element or 'textarea'
+  const displayedText = isEditing ? { value } : { children: value };
+
+  const className = [...baseClasses, inputClasses].join(" ").trim();
+
+  const innerClasses = "w-full h-full block resize-none focus:outline-none";
+
+  return (
+    <div className={className}>
+      {React.createElement<
+        React.HTMLAttributes<HTMLParagraphElement | HTMLTextAreaElement>,
+        HTMLParagraphElement | HTMLTextAreaElement
+      >(element, {
+        className: innerClasses,
+        ...props,
+        ...displayedText,
+        // Focus element when switching from non editable to editable
+        ...(element === "textarea" && { autoFocus: true }),
+      })}
+    </div>
+  );
 };
+
+const baseClasses: string[] = [
+  "py-[9px]",
+  "px-[13px]",
+  "font-normal",
+  "text-gray-900",
+  "overflow-y-auto",
+];
 
 export default TextareaEditable;

--- a/packages/ui/src/TextareaEditable/TextareaEditable.tsx
+++ b/packages/ui/src/TextareaEditable/TextareaEditable.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+interface TextareaEditableProps extends React.HTMLAttributes<HTMLElement> {
+  isEditing?: boolean;
+}
+
+const TextareaEditable: React.FC<TextareaEditableProps> = () => {
+  return null;
+};
+
+export default TextareaEditable;

--- a/packages/ui/src/TextareaEditable/TextareaEditable.tsx
+++ b/packages/ui/src/TextareaEditable/TextareaEditable.tsx
@@ -1,12 +1,14 @@
 import React from "react";
+import { FieldProps } from "formik";
 
-interface TextareaEditableProps extends React.HTMLAttributes<HTMLElement> {
-  /**
-   * A boolean flag to toggle between editing and display mode
-   */
-  isEditing?: boolean;
-  value: string;
-}
+type TextareaEditableProps = React.HTMLAttributes<HTMLElement> &
+  Partial<Pick<FieldProps, "field">> & {
+    /**
+     * A boolean flag to toggle between editing and display mode
+     */
+    isEditing?: boolean;
+    value?: string;
+  };
 
 /**
  * A wysiwyg text area component. On default it show the text while with 'isEditing' turns into
@@ -14,10 +16,13 @@ interface TextareaEditableProps extends React.HTMLAttributes<HTMLElement> {
  */
 const TextareaEditable: React.FC<TextareaEditableProps> = ({
   isEditing,
-  value,
   className: inputClasses = "",
-  ...props
+  field = {},
+  ...initialProps
 }) => {
+  // Transform props to use formik 'field' props if provided
+  const { value, ...props } = { ...initialProps, ...field };
+
   const element: "textarea" | "p" = isEditing ? "textarea" : "p";
 
   // To achieve wysiwyg editable element, we're displaying the text value

--- a/packages/ui/src/TextareaEditable/__tests__/TextareaEditable.test.tsx
+++ b/packages/ui/src/TextareaEditable/__tests__/TextareaEditable.test.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Formik, FormikConfig, Field, Form } from "formik";
 
 import TextareaEditable from "../TextareaEditable";
 
@@ -49,6 +50,41 @@ describe("TextareaEditable", () => {
       userEvent.type(textarea, "test-input");
 
       expect(testValue).toEqual("test-input");
+    });
+  });
+
+  describe("Test with Formik", () => {
+    test("should integrate with Formik seamlessly", async () => {
+      const initialValues = { foo: "initial-input" };
+
+      // Create this function logic to call onSubmit with only the values (relevant for testing)
+      // without additional formik helpers
+      const mockSubmit = jest.fn();
+      const onSubmit: FormikConfig<typeof initialValues>["onSubmit"] = (
+        values
+      ) => mockSubmit(values);
+
+      render(
+        <Formik {...{ initialValues, onSubmit }}>
+          <Form>
+            <Field component={TextareaEditable} name="foo" isEditing />
+            <button type="submit" />
+          </Form>
+        </Formik>
+      );
+
+      screen.getByText("initial-input");
+
+      const textarea = screen.getByRole("textbox");
+      const submitButton = screen.getByRole("button");
+
+      userEvent.clear(textarea);
+      userEvent.type(textarea, "test-input");
+      submitButton.click();
+
+      await waitFor(() =>
+        expect(mockSubmit).toHaveBeenCalledWith({ foo: "test-input" })
+      );
     });
   });
 });

--- a/packages/ui/src/TextareaEditable/__tests__/TextareaEditable.test.tsx
+++ b/packages/ui/src/TextareaEditable/__tests__/TextareaEditable.test.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import TextareaEditable from "../TextareaEditable";
+
+describe("TextareaEditable", () => {
+  describe("Test edit functionality", () => {
+    test("should display 'value' as paragraph if 'isEditing' falsy", () => {
+      render(<TextareaEditable value="test-text" />);
+      screen.getByText("test-text");
+      expect(screen.queryByRole("textbox")).toBeFalsy();
+    });
+
+    test("should display the 'value' passed in and call 'onChange' with each value update", () => {
+      // We'll be using this value to lift the internal value of the test component
+      // updated by user interaction with Textarea
+      let testValue = "test-value";
+
+      // This component is used to allow for stateful updates (useState) triggered by
+      // the 'Textarea' component
+      const TestComponent = () => {
+        const [internalValue, setInternalValue] = useState(testValue);
+        // Each time internal value changes, lift it to 'testValue' variable so that we can
+        // run assertions against it
+        useEffect(() => {
+          testValue = internalValue;
+        }, [internalValue]);
+
+        const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+          setInternalValue(e.target.value);
+        };
+        return (
+          <TextareaEditable
+            value={internalValue}
+            onChange={onChange}
+            isEditing
+          />
+        );
+      };
+      render(<TestComponent />);
+
+      // Assert the initial value has been rendered to the screen
+      screen.getByText("test-value");
+
+      const textarea = screen.getByRole("textbox");
+
+      userEvent.clear(textarea);
+      userEvent.type(textarea, "test-input");
+
+      expect(testValue).toEqual("test-input");
+    });
+  });
+});

--- a/packages/ui/src/TextareaEditable/index.ts
+++ b/packages/ui/src/TextareaEditable/index.ts
@@ -1,0 +1,3 @@
+import TextareaEditable from "./TextareaEditable";
+
+export default TextareaEditable;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -17,6 +17,7 @@ import SlotsDayContainer from "./SlotsDayContainer";
 import BookingsCountdown from "./BookingsCountdown";
 import HoverText from "./HoverText";
 import IconButton from "./IconButton";
+import TextareaEditable from "./TextareaEditable";
 
 export * from "./UserAvatar";
 export * from "./NotificationToast";
@@ -43,4 +44,5 @@ export {
   BookingsCountdown,
   HoverText,
   IconButton,
+  TextareaEditable,
 };

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     rollupOptions: {
       // React should be used in the main app, and not bundled in
       // as multiple instances of React can cause a bunch of problems
-      external: ["react", "react-dom", "react-router-dom"],
+      external: ["formik", "react", "react-dom", "react-router-dom"],
       output: {
         exports: "named",
 


### PR DESCRIPTION
Fixes #613 
I used a slightly different approach than the one described in the spec. On initial pass I stuck closely to the spec, but have realised that such approach wouldn't work all that nicely in production (inside the app). Instead I've created a simple, but versatile, `TextareaEditable` component solely displaying text and switching to textarea when editing as well as integrating with Formik.
I'm continuing to pursue the `IntervalCardWithNotes` work and trying to reuse as much of the existing work as possible. 