### PR TITLE
Fix/sms and email bug

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -8,9 +8,7 @@
       "cd packages/functions && rushx build",
       "sed -i '/\"workspace:\\*/d\"' \"$RESOURCE_DIR/package.json\""
     ],
-    "postdeploy": [
-      "sed -i -e \\'s/  .dependencies.: {/  \"dependencies\": {\\n    \"@eisbuk\\/shared\": \"1.0.0\",/\\' \"$RESOURCE_DIR/package.json\""
-    ],
+    "postdeploy": ["git restore packages/functions/package.json"],
     "source": "packages/functions"
   },
   "hosting": [

--- a/packages/client/src/__tests__/cloudFunctions.test.ts
+++ b/packages/client/src/__tests__/cloudFunctions.test.ts
@@ -65,13 +65,15 @@ describe("Cloud functions", () => {
             organization,
             secretKey: saul.secretKey,
             to,
-            message: { html, subject },
+            html,
+            subject,
           })
         ).resolves.toEqual({
           data: {
             email: {
               to,
-              message: { html, subject },
+              html,
+              subject,
             },
             organization,
             success: true,
@@ -87,13 +89,13 @@ describe("Cloud functions", () => {
           httpsCallable(
             functions,
             CloudFunction.SendEmail
-          )({ to, message: { html, subject } })
+          )({ to, html, subject })
         ).rejects.toThrow(HTTPSErrors.Unauth);
       }
     );
 
     testWithEmulator(
-      "should reject if no recipient or message provided",
+      "should reject if no recipient or message content provided",
       async () => {
         const { organization } = await setUpOrganization();
         try {
@@ -103,24 +105,7 @@ describe("Cloud functions", () => {
           )({ organization });
         } catch (error) {
           expect((error as FunctionsError).message).toEqual(
-            `${HTTPSErrors.MissingParameter}: to, message`
-          );
-        }
-      }
-    );
-    testWithEmulator(
-      "should reject if message has no html or subject provided",
-      async () => {
-        const { organization } = await setUpOrganization();
-
-        try {
-          await httpsCallable(
-            functions,
-            CloudFunction.SendEmail
-          )({ organization, to, message: {} });
-        } catch (error) {
-          expect((error as FunctionsError).message).toEqual(
-            `${HTTPSErrors.MissingParameter}: html, subject`
+            `${HTTPSErrors.MissingParameter}: to, html, subject`
           );
         }
       }

--- a/packages/client/src/features/modal/components/ExtendBookingDateDialog/utils.ts
+++ b/packages/client/src/features/modal/components/ExtendBookingDateDialog/utils.ts
@@ -95,10 +95,8 @@ export const sendBookingsLink: SendBookingsLink =
           handler: CloudFunction.SendEmail,
           payload: {
             to: email,
-            message: {
-              html,
-              subject,
-            },
+            html,
+            subject,
           } as EmailPayload,
           successMessage: i18n.t(NotificationMessage.EmailSent),
         },

--- a/packages/client/src/features/modal/components/SendBookingsLinkDialog/__tests__/sendBookingsLinkDialogUtils.test.ts
+++ b/packages/client/src/features/modal/components/SendBookingsLinkDialog/__tests__/sendBookingsLinkDialogUtils.test.ts
@@ -127,11 +127,11 @@ describe("Send bookings link dialog utils", () => {
         const sentMail = mockSendMail.mock.calls[0][0] as EmailPayload;
 
         expect(sentMail.to).toEqual(saul.email);
-        expect(sentMail.message.subject).toBeDefined();
+        expect(sentMail.subject).toBeDefined();
         // we're not matching the complete html of message
         // but are asserting that it contains important parts
-        expect(sentMail.message.html.includes(bookingsLink)).toBeTruthy();
-        expect(sentMail.message.html.includes(saul.name)).toBeTruthy();
+        expect(sentMail.html.includes(bookingsLink)).toBeTruthy();
+        expect(sentMail.html.includes(saul.name)).toBeTruthy();
 
         // check for success notification
         expect(mockDispatch).toHaveBeenCalledWith(

--- a/packages/client/src/features/modal/components/SendBookingsLinkDialog/utils.ts
+++ b/packages/client/src/features/modal/components/SendBookingsLinkDialog/utils.ts
@@ -95,10 +95,8 @@ export const sendBookingsLink: SendBookingsLink =
           handler: CloudFunction.SendEmail,
           payload: {
             to: email,
-            message: {
-              html,
-              subject,
-            },
+            html,
+            subject,
           } as EmailPayload,
           successMessage: i18n.t(NotificationMessage.EmailSent),
         },

--- a/packages/client/src/store/actions/bookingOperations.ts
+++ b/packages/client/src/store/actions/bookingOperations.ts
@@ -157,10 +157,12 @@ export const createCalendarEvents =
         })
       );
     } catch (error) {
-      dispatch({
-        message: i18n.t(NotificationMessage.Error),
-        vatiant: NotifVariant.Error,
-      });
+      dispatch(
+        enqueueNotification({
+          message: i18n.t(NotificationMessage.Error),
+          variant: NotifVariant.Error,
+        })
+      );
     }
   };
 

--- a/packages/client/src/store/actions/bookingOperations.ts
+++ b/packages/client/src/store/actions/bookingOperations.ts
@@ -1,8 +1,12 @@
 import { deleteDoc, doc, getFirestore, setDoc } from "@firebase/firestore";
 
-import { BookingSubCollection, Customer, SlotInterface } from "@eisbuk/shared";
+import {
+  BookingSubCollection,
+  Customer,
+  SlotInterface,
+  SendEmailPayload,
+} from "@eisbuk/shared";
 import i18n, { NotificationMessage } from "@eisbuk/translations";
-
 import { NotifVariant } from "@/enums/store";
 import { CloudFunction } from "@/enums/functions";
 
@@ -188,18 +192,16 @@ export const sendICSFile: sendICSFile =
         <a href="${icsFile}">Clicca qui per aggiungere le tue prenotazioni al tuo calendario</a>`;
 
       const handler = CloudFunction.SendEmail;
-      const payload = {
+      const payload: Omit<SendEmailPayload, "organization"> = {
         to: email,
-        message: {
-          html,
-          subject,
-          attachments: [
-            {
-              filename: "bookedSlots.ics",
-              content: icsFile,
-            },
-          ],
-        },
+        html,
+        subject,
+        attachments: [
+          {
+            filename: "bookedSlots.ics",
+            content: icsFile,
+          },
+        ],
         secretKey: secretKey,
       };
 
@@ -212,9 +214,11 @@ export const sendICSFile: sendICSFile =
         })
       );
     } catch (error) {
-      dispatch({
-        message: i18n.t(NotificationMessage.Error),
-        variant: NotifVariant.Error,
-      });
+      dispatch(
+        enqueueNotification({
+          message: i18n.t(NotificationMessage.Error),
+          variant: NotifVariant.Error,
+        })
+      );
     }
   };

--- a/packages/functions/src/sendEmail/deliver.ts
+++ b/packages/functions/src/sendEmail/deliver.ts
@@ -17,7 +17,7 @@ import { SMTPPreferences, TransportConfig } from "./types";
 
 import { __functionsZone__, __noSecretsError } from "../constants";
 
-import { EmailSchema, SMTPPreferencesSchema } from "./validations";
+import { EmailMessageSchema, SMTPPreferencesSchema } from "./validations";
 import { validateJSON } from "../utils";
 
 /**
@@ -119,7 +119,7 @@ export const deliverEmail = functions
 
       // Validate email and throw if not a valid schema
       const [email, emailErrs] = validateJSON(
-        EmailSchema,
+        EmailMessageSchema,
         {
           from: emailFrom,
           ...data.payload,

--- a/packages/functions/src/sendEmail/https.ts
+++ b/packages/functions/src/sendEmail/https.ts
@@ -29,10 +29,7 @@ export const sendEmail = functions
         throwUnauth();
       }
 
-      checkRequiredFields(email, ["to", "message"]);
-
-      const { message } = email;
-      checkRequiredFields(message, ["html", "subject"]);
+      checkRequiredFields(email, ["to", "message", "html", "subject"]);
 
       // add email to firestore, firing data trigger
       await admin

--- a/packages/functions/src/sendEmail/https.ts
+++ b/packages/functions/src/sendEmail/https.ts
@@ -29,7 +29,7 @@ export const sendEmail = functions
         throwUnauth();
       }
 
-      checkRequiredFields(email, ["to", "message", "html", "subject"]);
+      checkRequiredFields(email, ["to", "html", "subject"]);
 
       // add email to firestore, firing data trigger
       await admin

--- a/packages/functions/src/sendEmail/validations.ts
+++ b/packages/functions/src/sendEmail/validations.ts
@@ -1,6 +1,6 @@
 import { JSONSchemaType } from "ajv";
 
-import { EmailAttachment, Email, EmailMessage } from "@eisbuk/shared";
+import { EmailAttachment, EmailMessage } from "@eisbuk/shared";
 
 import { SMTPPreferences } from "./types";
 
@@ -49,29 +49,12 @@ const EmailAttachmentSchema: JSONSchemaType<EmailAttachment> = {
 };
 
 /**
- * A validation schema for a `message` (`subject`, `html`, `attachments`) field of an email interface
- */
-const EmailMessageSchema: JSONSchemaType<EmailMessage> = {
-  type: "object",
-  required: ["html", "subject"],
-  properties: {
-    subject: { type: "string" },
-    html: { type: "string" },
-    attachments: {
-      type: "array",
-      items: EmailAttachmentSchema,
-      nullable: true,
-    },
-  },
-};
-
-/**
  * Validation schema for a fully constructed email (to be send over SMTP),
  * including `to`, `from` and valid `message`
  */
-export const EmailSchema: JSONSchemaType<Email> = {
+export const EmailMessageSchema: JSONSchemaType<EmailMessage> = {
   type: "object",
-  required: ["from", "to", "message"],
+  required: ["from", "to", "subject"],
   properties: {
     from: {
       type: "string",
@@ -83,7 +66,13 @@ export const EmailSchema: JSONSchemaType<Email> = {
       pattern: emailPattern,
       errorMessage: __invalidEmailError,
     },
-    message: EmailMessageSchema,
+    subject: { type: "string" },
+    html: { type: "string" },
+    attachments: {
+      type: "array",
+      items: EmailAttachmentSchema,
+      nullable: true,
+    },
   },
 };
 // #region validations

--- a/packages/functions/src/sendSMS/deliver.ts
+++ b/packages/functions/src/sendSMS/deliver.ts
@@ -12,7 +12,7 @@ import processDelivery, {
   ProcessDocument,
 } from "@eisbuk/firestore-process-delivery";
 
-import { __smsUrl__, __functionsZone__ } from "../constants";
+import { __smsUrl__, __functionsZone__, __noSecretsError } from "../constants";
 
 import { SMSResponse } from "./types";
 
@@ -59,6 +59,9 @@ export const deliverSMS = functions
       const smsFrom = orgData.smsFrom || organization.substring(0, 11);
 
       const secretsData = secretsSnap.data() as OrganizationSecrets;
+      if (!secretsData) {
+        throw new Error(__noSecretsError);
+      }
       const authToken = secretsData.smsAuthToken || "";
 
       // Construct request options
@@ -71,7 +74,7 @@ export const deliverSMS = functions
       // Construct and validate SMS data
       const [sms, errs] = validateJSON(SMSAPIPayloadSchema, {
         message,
-        smsFrom,
+        sender: smsFrom,
         recipients: [{ msisdn: to }],
         callback_url: getSMSCallbackUrl(),
       });

--- a/packages/functions/src/sendSMS/types.ts
+++ b/packages/functions/src/sendSMS/types.ts
@@ -12,9 +12,9 @@ export interface SMSResponse {
   };
 }
 
-export interface SMSAPIPayloed {
+export interface SMSAPIPayload {
   message: string;
-  smsFrom: string;
+  sender: string;
   recipients: SMSRecipient[];
   /* eslint-disable camelcase */
   callback_url?: string;

--- a/packages/functions/src/sendSMS/validations.ts
+++ b/packages/functions/src/sendSMS/validations.ts
@@ -1,6 +1,6 @@
 import { JSONSchemaType } from "ajv";
 
-import { SMSRecipient, SMSAPIPayloed } from "./types";
+import { SMSRecipient, SMSAPIPayload } from "./types";
 
 const SMSRecipientSchema: JSONSchemaType<SMSRecipient> = {
   type: "object",
@@ -8,12 +8,12 @@ const SMSRecipientSchema: JSONSchemaType<SMSRecipient> = {
   required: ["msisdn"],
 };
 
-export const SMSAPIPayloadSchema: JSONSchemaType<SMSAPIPayloed> = {
+export const SMSAPIPayloadSchema: JSONSchemaType<SMSAPIPayload> = {
   type: "object",
-  required: ["message", "smsFrom", "recipients"],
+  required: ["message", "sender", "recipients"],
   properties: {
     message: { type: "string" },
-    smsFrom: {
+    sender: {
       type: "string",
       maxLength: 11,
       errorMessage:

--- a/packages/shared/src/types/firestore.ts
+++ b/packages/shared/src/types/firestore.ts
@@ -293,14 +293,7 @@ export interface EmailAttachment {
   filename: string;
   content: string | Buffer;
 }
-/**
- * `message` portion of an email interface
- */
-export interface EmailMessage {
-  subject: string;
-  html: string;
-  attachments?: EmailAttachment[];
-}
+
 /**
  * Interface used as `payload` in email process-delivery.
  * It's basically a full email payload without the `from`
@@ -308,15 +301,19 @@ export interface EmailMessage {
  */
 export interface EmailPayload {
   to: string;
-  message: EmailMessage;
+  subject: string;
+  html: string;
+  attachments?: EmailAttachment[];
 }
+
 /**
  * A full email interface, including:
- * `to`, `from` and `message` (`subject`, `html`, `attachments`).
+ * `to`, `from`, `subject`, `html` and `attachments`.
  */
-export interface Email extends EmailPayload {
+export interface EmailMessage extends EmailPayload {
   from: string;
 }
+
 /**
  * A payload used in `sendEmail` cloud function.
  */


### PR DESCRIPTION
Fixes #637 

### Email

A fix for email sending bug, where emails were passed around in the form:
```typescript
{
  from: string
  to: string
  message: {
    subject: string
    html: string
    attachments: Attachment[]
  }
}
```
to (more convenient) form:
```typescript
{
  from: string
  to: string
  subject: string
  html: string
  attachments: Attachment[]
}
```

I don't know if this was a `nodemailer` change, or a simple misconstruction on our part, but now it works.

### SMS

GatewayAPI followed suit and changed `smsFrom` to `sender`, leaving the rest the same.