### PR TITLE
Enhancement/booked slot disable delete

### DIFF
--- a/packages/client/src/components/atoms/SlotCard/SlotCard.tsx
+++ b/packages/client/src/components/atoms/SlotCard/SlotCard.tsx
@@ -35,6 +35,10 @@ export interface SlotCardProps extends SlotInterface {
    */
   enableEdit?: boolean;
   /**
+   * Disable slot deletion (we use this if there are booked intervals on a particular slot)
+   */
+  disableDelete?: boolean;
+  /**
    * Click handler for the entire card, will default to empty function if none is provided
    */
   onClick?: (e: React.SyntheticEvent) => void;
@@ -49,6 +53,7 @@ export interface SlotCardProps extends SlotInterface {
 const SlotCard: React.FC<SlotCardProps> = ({
   selected,
   enableEdit,
+  disableDelete,
   onClick,
   ...slotData
 }) => {
@@ -157,6 +162,7 @@ const SlotCard: React.FC<SlotCardProps> = ({
           {enableEdit && (
             <SlotOperationButtons
               contextType={ButtonContextType.Slot}
+              disableDelete={disableDelete}
               slot={slotData}
               className={classes.actionButtons}
             >

--- a/packages/client/src/components/atoms/SlotCard/__tests__/SlotCard.test.tsx
+++ b/packages/client/src/components/atoms/SlotCard/__tests__/SlotCard.test.tsx
@@ -85,6 +85,15 @@ describe("SlotCard", () => {
         openModal({ component: "DeleteSlotDialog", props: baseSlot })
       );
     });
+
+    test("should show delete-disabled dialog on delete button click if delete disabled", () => {
+      cleanup();
+      render(<SlotCard {...baseSlot} enableEdit disableDelete />);
+      screen.getByTestId(__deleteButtonId__).click();
+      expect(mockDispatch).toHaveBeenCalledWith(
+        openModal({ component: "DeleteSlotDisabledDialog", props: baseSlot })
+      );
+    });
   });
 
   describe("Test clicking on slot card", () => {

--- a/packages/client/src/components/atoms/SlotOperationButtons/DeleteButton.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/DeleteButton.tsx
@@ -45,7 +45,7 @@ export const DeleteButton: React.FC = () => {
     return null;
   }
 
-  const { contextType, date, slot } = buttonGroupContext;
+  const { contextType, date, slot, disableDelete } = buttonGroupContext;
 
   // prevent component from rendering and log error to console (but don't throw)
   // if rendered within `contextType === "slot"` but no value was provided for `slot` within the context
@@ -70,7 +70,13 @@ export const DeleteButton: React.FC = () => {
     // choose proper delete function based on `contextType`
     switch (contextType) {
       case ButtonContextType.Slot:
-        dispatch(openModal({ component: "DeleteSlotDialog", props: slot! }));
+        if (disableDelete) {
+          dispatch(
+            openModal({ component: "DeleteSlotDisabledDialog", props: slot! })
+          );
+        } else {
+          dispatch(openModal({ component: "DeleteSlotDialog", props: slot! }));
+        }
         break;
 
       case ButtonContextType.Day:
@@ -87,6 +93,7 @@ export const DeleteButton: React.FC = () => {
     <SlotOperationButton
       onClick={handleDelete}
       data-testid={__deleteButtonId__}
+      className={disableDelete ? "!text-gray-400" : ""}
     >
       <Trash />
     </SlotOperationButton>

--- a/packages/client/src/components/atoms/SlotOperationButtons/SlotOperationButtons.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/SlotOperationButtons.tsx
@@ -14,6 +14,8 @@ type ContextParams = Partial<{
    * Slot to edit/delete/copy.
    * - should be truthy if the buttons are within `slot` context
    * - `undefined` otherwise
+   * - `disabledDelete` is an optional boolean property used to show delete-disabled dialog
+   *    rather than deleting the slot
    */
   slot: SlotInterface;
   /**
@@ -32,6 +34,11 @@ type ContextParams = Partial<{
     [ButtonContextType.Day]: boolean;
     [ButtonContextType.Week]: boolean;
   }>;
+  /**
+   * An optional boolean property used to show delete-disabled dialog
+   * rather than deleting on delete button click
+   */
+  disableDelete?: boolean;
 }>;
 
 export const ButtonGroupContext = createContext<ContextParams | undefined>(

--- a/packages/client/src/components/atoms/SlotOperationButtons/__tests__/DeleteButton.test.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/__tests__/DeleteButton.test.tsx
@@ -85,6 +85,23 @@ describe("SlotOperationButtons", () => {
       );
     });
 
+    test("should show 'DeleteSlotDisabledDialog' modal onClick if within \"slot\" context and delete disabled", () => {
+      render(
+        <SlotOperationButtons
+          contextType={ButtonContextType.Slot}
+          slot={baseSlot}
+          disableDelete
+        >
+          <DeleteButton />
+        </SlotOperationButtons>
+      );
+      // initiate delete
+      screen.getByTestId(__deleteButtonId__).click();
+      expect(mockDispatch).toHaveBeenCalledWith(
+        openModal({ component: "DeleteSlotDisabledDialog", props: baseSlot })
+      );
+    });
+
     test("should dispatch 'deleteSlotsDay' onClick if within \"day\" context", () => {
       render(
         <SlotOperationButtons

--- a/packages/client/src/features/modal/components/CancelBookingDialog/CancelBookingDialog.tsx
+++ b/packages/client/src/features/modal/components/CancelBookingDialog/CancelBookingDialog.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from "react-redux";
 
 import { SlotInterface, SlotInterval } from "@eisbuk/shared";
 import { ActionDialog, IntervalCard, IntervalCardVariant } from "@eisbuk/ui";
-import i18n, { Prompt } from "@eisbuk/translations";
+import i18n, { ActionButton, Prompt } from "@eisbuk/translations";
 
 import { cancelBooking } from "@/store/actions/bookingOperations";
 
@@ -33,6 +33,8 @@ const CancelBookingDialog: React.FC<CancelBookingContent> = ({
     <ActionDialog
       title={i18n.t(Prompt.CancelBookingTitle)}
       onCancel={onClose}
+      cancelLabel={i18n.t(ActionButton.Cancel)}
+      confirmLabel={i18n.t(ActionButton.Confirm)}
       {...{ onConfirm, className }}
     >
       <IntervalCard

--- a/packages/client/src/features/modal/components/DeleteSlotDisabledDialog/DeleteSlotDisabledDialog.tsx
+++ b/packages/client/src/features/modal/components/DeleteSlotDisabledDialog/DeleteSlotDisabledDialog.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+import { SlotInterface } from "@eisbuk/shared";
+import { ActionDialog } from "@eisbuk/ui";
+import i18n, { ActionButton, Prompt } from "@eisbuk/translations";
+
+import { BaseModalProps } from "../../types";
+
+import SlotCard from "@/components/atoms/SlotCard";
+
+type DeleteSlotDisabledDialogProps = BaseModalProps & SlotInterface;
+
+const DeleteSlotDialog: React.FC<DeleteSlotDisabledDialogProps> = ({
+  onClose,
+  className,
+  ...slot
+}) => {
+  const title = i18n.t(Prompt.DeleteSlotDisabledTitle);
+
+  const body = (
+    <div>
+      <p className="mb-2">{i18n.t(Prompt.DeleteSlotDisabled)}</p>
+      <SlotCard {...slot} />
+    </div>
+  );
+
+  return (
+    <ActionDialog
+      onCancel={onClose}
+      {...{ title, className }}
+      cancelLabel={i18n.t(ActionButton.Dismiss)}
+    >
+      {body}
+    </ActionDialog>
+  );
+};
+
+export default DeleteSlotDialog;

--- a/packages/client/src/features/modal/components/DeleteSlotDisabledDialog/__tests__/DeleteSlotDisabledDialog.test.tsx
+++ b/packages/client/src/features/modal/components/DeleteSlotDisabledDialog/__tests__/DeleteSlotDisabledDialog.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from "react";
+import { screen, render, cleanup } from "@testing-library/react";
+
+import i18n, { ActionButton } from "@eisbuk/translations";
+
+import DeleteSlotDisabledDialog from "../DeleteSlotDisabledDialog";
+import * as slotOperations from "@/store/actions/slotOperations";
+
+import { baseSlot } from "@/__testData__/slots";
+
+const mockOnClose = jest.fn();
+// Mock deleteSlot to a, sort of, identity function
+// to test it being dispatched to the store (with appropriate params)
+// rather than just being called
+const mockDeleteSlot = (params: any) => ({
+  ...params,
+  type: "deleteSlot",
+});
+jest
+  .spyOn(slotOperations, "deleteSlot")
+  .mockImplementation(mockDeleteSlot as any);
+
+const mockDispatch = jest.fn();
+jest.mock("react-redux", () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+describe("DeleteSlotDisabledDialog", () => {
+  beforeEach(() => {
+    render(
+      <DeleteSlotDisabledDialog
+        {...baseSlot}
+        onClose={mockOnClose}
+        onCloseAll={() => {}}
+      />
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    cleanup();
+  });
+
+  test("should call onClose on 'Dismiss' button click", () => {
+    screen.getByText(i18n.t(ActionButton.Dismiss) as string).click();
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/features/modal/components/DeleteSlotDisabledDialog/index.ts
+++ b/packages/client/src/features/modal/components/DeleteSlotDisabledDialog/index.ts
@@ -1,0 +1,3 @@
+import DeleteSlotDisabledDialog from "./DeleteSlotDisabledDialog";
+
+export default DeleteSlotDisabledDialog;

--- a/packages/client/src/features/modal/components/index.ts
+++ b/packages/client/src/features/modal/components/index.ts
@@ -6,6 +6,7 @@ import SendBookingsLinkDialog from "./SendBookingsLinkDialog";
 import DeleteCustomerDialog from "./DeleteCustomerDialog";
 import ExtendBookingDateDialog from "./ExtendBookingDateDialog";
 import DeleteSlotDialog from "./DeleteSlotDialog";
+import DeleteSlotDisabledDialog from "./DeleteSlotDisabledDialog";
 import AddAttendedCustomersDialog from "./AddAttendedCustomersDialog";
 import CustomerFormDialog from "./CustomerFormDialog";
 import SlotForm from "@/components/atoms/SlotForm";
@@ -22,6 +23,7 @@ export const componentWhitelist = {
   DeleteCustomerDialog,
   ExtendBookingDateDialog,
   DeleteSlotDialog,
+  DeleteSlotDisabledDialog,
   AddAttendedCustomersDialog,
   BirthdayDialog,
   SlotForm,

--- a/packages/translations/src/dict/en.json
+++ b/packages/translations/src/dict/en.json
@@ -135,6 +135,8 @@
   "Prompt": {
     "DeleteCustomer": "Are you sure you want to remove {{ name }} {{ surname }}?",
     "DeleteSlot": "Are you sure you want to delete the slot:",
+    "DeleteSlotDisabledTitle": "Unable to delete",
+    "DeleteSlotDisabled": "Unable to delete the slot, as it has already been booked by one or more athletes",
 
     "NonReversible": "This action is non-reversible",
 

--- a/packages/translations/src/dict/en.json
+++ b/packages/translations/src/dict/en.json
@@ -181,6 +181,7 @@
     "Save": "Save",
     "Next": "Next",
     "Cancel": "Cancel",
+    "Confirm": "Confirm",
     "ShowAll": "ShowAll",
     "Done": "Done",
     "Send": "Send",

--- a/packages/translations/src/dict/it.json
+++ b/packages/translations/src/dict/it.json
@@ -135,6 +135,8 @@
   "Prompt": {
     "DeleteCustomer": "Sei sicuro di voler rimuovere  {{ name }} {{ surname }}?",
     "DeleteSlot": "Sei sicuro di voler rimuovere lo slot:",
+    "DeleteSlotDisabledTitle": "Unable to delete",
+    "DeleteSlotDisabled": "Unable to delete the slot, as it has already been booked by one or more athletes",
 
     "NonReversible": "Questa azione non è reversibile",
 

--- a/packages/translations/src/dict/it.json
+++ b/packages/translations/src/dict/it.json
@@ -3,7 +3,7 @@
     "Attendance": "Presenze",
     "Athletes": "Atleti",
     "Bookings": "Prenotazioni",
-    "OrganizationSettings": "Settings",
+    "OrganizationSettings": "Impostazioni",
     "Slots": "Slots"
   },
   "CustomerNavigation": {
@@ -135,8 +135,8 @@
   "Prompt": {
     "DeleteCustomer": "Sei sicuro di voler rimuovere  {{ name }} {{ surname }}?",
     "DeleteSlot": "Sei sicuro di voler rimuovere lo slot:",
-    "DeleteSlotDisabledTitle": "Unable to delete",
-    "DeleteSlotDisabled": "Unable to delete the slot, as it has already been booked by one or more athletes",
+    "DeleteSlotDisabledTitle": "Impossibile rimuovere",
+    "DeleteSlotDisabled": "Impossibile rimuovere lo slot: esistono prenotazioni per questo slot",
 
     "NonReversible": "Questa azione non è reversibile",
 
@@ -186,20 +186,20 @@
     "Done": "Fatto",
     "Send": "Invia",
     "Resend": "Invia di nuovo",
-    "Dismiss": "Ignora",
+    "Dismiss": "Chiudi",
     "Submit": "Invia",
-    "Verify": "verifica",
+    "Verify": "Verifica",
     "Edit": "Modificare",
-    "Add": "Add",
-    "Delete": "Delete"
+    "Add": "Aggiungi",
+    "Delete": "Elimina"
   },
 
   "Notification": {
     "BookingSuccess": "Prenotazione effettuata",
     "BookingCanceled": "Prenotazione rimossa",
     "BookingCanceledError": "Errore nel rimuovere la prenotazione",
-    "BookingNotesUpdated": "Booking notes updated",
-    "BookingNotesError": "Error updating booking notes",
+    "BookingNotesUpdated": "Nota della prenotazione aggiornata",
+    "BookingNotesError": "Errore durante l'aggiornamento della nota alla prenotazione",
 
     "SlotAdded": "Slot Aggiunto",
     "SlotUpdated": "Slot Aggiornato",

--- a/packages/translations/src/dict/it.json
+++ b/packages/translations/src/dict/it.json
@@ -181,6 +181,7 @@
     "Save": "Salva",
     "Next": "Seguente",
     "Cancel": "Annulla",
+    "Confirm": "Confermare",
     "ShowAll": "Mostra tutti",
     "Done": "Fatto",
     "Send": "Invia",

--- a/packages/translations/src/translations.ts
+++ b/packages/translations/src/translations.ts
@@ -193,6 +193,7 @@ export enum ActionButton {
   Save = "ActionButton.Save",
   Next = "ActionButton.Next",
   Cancel = "ActionButton.Cancel",
+  Confirm = "ActionButton.Confirm",
   ShowAll = "ActionButton.ShowAll",
   Done = "ActionButton.Done",
   Send = "ActionButton.Send",

--- a/packages/translations/src/translations.ts
+++ b/packages/translations/src/translations.ts
@@ -146,6 +146,8 @@ export enum BookingNotesForm {
 export enum Prompt {
   DeleteCustomer = "Prompt.DeleteCustomer",
   DeleteSlot = "Prompt.DeleteSlot",
+  DeleteSlotDisabledTitle = "Prompt.DeleteSlotDisabledTitle",
+  DeleteSlotDisabled = "Prompt.DeleteSlotDisabled",
 
   NonReversible = "Prompt.NonReversible",
 

--- a/packages/ui/src/ActionDialog/ActionDialog.stories.tsx
+++ b/packages/ui/src/ActionDialog/ActionDialog.stories.tsx
@@ -15,11 +15,22 @@ export const Default = (): JSX.Element => (
       title="Cancel booking for"
       cancelLabel="Go Back"
       confirmLabel="Confirm Cancellation"
-      onCancel={() => {}}
-      onConfirm={() => {}}
     >
       This is a placeholder message for a Simple Interval Card, but also stunt
       doubles as a TextContent variant?
+    </ActionDialog>
+  </div>
+);
+
+export const OneActionButton = (): JSX.Element => (
+  <div className="absolute top-0 right-0 bottom-0 left-0 bg-gray-800">
+    <ActionDialog
+      className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10"
+      title="Unable to delete"
+      cancelLabel="Dismiss"
+    >
+      This is an action dialog with only one (Cancel) button, Confirm button
+      should not be shown
     </ActionDialog>
   </div>
 );

--- a/packages/ui/src/ActionDialog/ActionDialog.tsx
+++ b/packages/ui/src/ActionDialog/ActionDialog.tsx
@@ -5,8 +5,8 @@ import { ButtonSize } from "../Button/Button";
 
 export interface ActionDialogProps extends React.HTMLAttributes<HTMLElement> {
   title: string;
-  onCancel: () => void;
-  onConfirm: () => void;
+  onCancel?: () => void;
+  onConfirm?: () => void;
   confirmLabel?: string;
   cancelLabel?: string;
   disabled?: boolean;
@@ -16,21 +16,16 @@ const ActionDialog: React.FC<ActionDialogProps> = ({
   title,
   onCancel = () => {},
   onConfirm = () => {},
-  confirmLabel = "Confirm",
-  cancelLabel = "Cancel",
+  confirmLabel,
+  cancelLabel,
   disabled,
   children,
   className = "",
-}) => (
-  <div
-    className={[
-      "flex flex-col min-w-[320px] items-start gap-y-4 p-5 rounded-md bg-white",
-      className,
-    ].join(" ")}
-  >
-    <h3 className="text-base leading-6 font-semibold text-red-700">{title}</h3>
-    <div>{children}</div>
-    <div className="w-full flex gap-2 flex-wrap justify-end">
+}) => {
+  const buttonsToRender: JSX.Element[] = [];
+
+  if (cancelLabel) {
+    buttonsToRender.push(
       <Button
         className="w-full !text-gray-700 font-medium bg-gray-100 hover:bg-opacity-0 md:w-auto"
         size={ButtonSize.LG}
@@ -38,6 +33,11 @@ const ActionDialog: React.FC<ActionDialogProps> = ({
       >
         {cancelLabel}
       </Button>
+    );
+  }
+
+  if (confirmLabel) {
+    buttonsToRender.push(
       <Button
         className="w-full !text-red-700 bg-red-200 hover:bg-red-100 md:w-auto"
         size={ButtonSize.LG}
@@ -46,8 +46,25 @@ const ActionDialog: React.FC<ActionDialogProps> = ({
       >
         {confirmLabel}
       </Button>
+    );
+  }
+
+  return (
+    <div
+      className={[
+        "flex flex-col min-w-[320px] items-start gap-y-4 p-5 rounded-md bg-white",
+        className,
+      ].join(" ")}
+    >
+      <h3 className="text-base leading-6 font-semibold text-red-700">
+        {title}
+      </h3>
+      <div>{children}</div>
+      <div className="w-full flex gap-2 flex-wrap justify-end">
+        {buttonsToRender}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default ActionDialog;


### PR DESCRIPTION
Fixes #631 
- Created `DeleteSlotDisabledDialog`
- Update of `ActionDialog` to render buttons conditionally with respect to confirm/cancel label being present
- Updated `SlotCard` and `SlotOperationButtons/DeleteButton` to accept `disableDelete` and if `true`, show `DeleteSlotDisabledDialog` modal instead of proceeding with slot deletion
- Painted `SlotOperations/DeleteButton` lighter gray to indicate it being disabled-ish
- Applied logic to differentiate booked slots in `slots` page (by cross referencing with `attendance` entries in store)