### PR TITLE
Enhancement/modal component update

### DIFF
--- a/packages/client/src/__testUtils__/testHooksWithRedux.tsx
+++ b/packages/client/src/__testUtils__/testHooksWithRedux.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect } from "react";
+import { Provider } from "react-redux";
+import { Store } from "redux";
+import { render } from "@testing-library/react";
+
+/**
+ * A test util used to test hooks controlling the behavior through redux hooks.
+ * @param store an initalized redux store
+ * @param hook a hook we're testing
+ * @param args args for the hook (if any)
+ */
+export const testHookWithRedux = <
+  S,
+  H extends (...args: any[]) => any,
+  P extends Parameters<H>,
+  R extends ReturnType<H>,
+  RO extends { updateProps: (...args: P) => void; result: R }
+>(
+  store: Store<S>,
+  hook: H,
+  ...args: P
+): RO => {
+  const returnObj = {} as RO;
+
+  /**
+   * A test component we're using to host the hook.
+   * @param {string} props.hookArgs args to pass to the hook.
+   */
+  const HookTestComponent: React.FC<{ hookArgs: Parameters<H> }> = ({
+    hookArgs,
+  }) => {
+    const r = hook(...hookArgs);
+
+    // Update the return object with result
+    // each time a hook result changes
+    useEffect(() => {
+      returnObj.result = r;
+    }, [r]);
+
+    return null;
+  };
+
+  // first render of the hook pass the initial `args` as `hookArgs`
+  const { rerender } = render(
+    <Provider store={store}>
+      <HookTestComponent {...{ hookArgs: args }} />
+    </Provider>
+  );
+
+  /**
+   * Runs `rerender` with `newArgs` passed as `hookArgs` to simulate updating
+   * of the props on a mounted hook
+   */
+  const updateProps = (...newArgs: P) =>
+    rerender(
+      <Provider store={store}>
+        <HookTestComponent {...{ hookArgs: newArgs }} />
+      </Provider>
+    );
+
+  returnObj.updateProps = updateProps;
+
+  return returnObj;
+};

--- a/packages/client/src/components/atoms/AttendanceCard/AttendanceCard.tsx
+++ b/packages/client/src/components/atoms/AttendanceCard/AttendanceCard.tsx
@@ -129,7 +129,7 @@ const AttendanceCard: React.FC<Props> = ({ allCustomers, ...slot }) => {
     markAbsence({ slotId, customerId });
 
   return (
-    <div className={classes.container}>
+    <div aria-label="attendance-card" className={classes.container}>
       <ListItem className={classes.listHeader}>
         <ListItemText
           primary={
@@ -180,6 +180,7 @@ const AttendanceCard: React.FC<Props> = ({ allCustomers, ...slot }) => {
           )
       )}
       <IconButton
+        aria-label="add-athletes"
         className={classes.addCustomersButton}
         onClick={openAddCustomers}
         data-testid={__addCustomersButtonId__}

--- a/packages/client/src/components/atoms/AttendanceCard/AttendanceCard.tsx
+++ b/packages/client/src/components/atoms/AttendanceCard/AttendanceCard.tsx
@@ -15,6 +15,8 @@ import i18n, { CategoryLabel, SlotTypeLabel } from "@eisbuk/translations";
 
 import { CustomerWithAttendance } from "@/types/components";
 
+import { ETheme } from "@/themes";
+
 import UserAttendance from "@/components/atoms/AttendanceCard/UserAttendance";
 
 import {
@@ -22,13 +24,12 @@ import {
   markAttendance,
 } from "@/store/actions/attendanceOperations";
 
+import { createModal } from "@/features/modal/useModal";
+
 import { getSlotTimespan } from "@/utils/helpers";
 import { comparePeriods } from "@/utils/sort";
 
-import { ETheme } from "@/themes";
-
 import { __addCustomersButtonId__ } from "./__testData__/testIds";
-import { openModal } from "@/features/modal/actions";
 
 export interface Props extends SlotInterface {
   /**
@@ -113,18 +114,11 @@ const AttendanceCard: React.FC<Props> = ({ allCustomers, ...slot }) => {
     [attendedCustomers]
   );
 
-  const openAddCustomers = () => {
-    dispatch(
-      openModal({
-        component: "AddAttendedCustomersDialog",
-        props: {
-          ...slot,
-          customers: filteredCustomers,
-          defaultInterval: orderedIntervals[0],
-        },
-      })
-    );
-  };
+  const { open: openAddCustomers } = useAddCustomersModal({
+    ...slot,
+    customers: filteredCustomers,
+    defaultInterval: orderedIntervals[0],
+  });
 
   const createAttendanceThunk = (payload: {
     customerId: string;
@@ -196,6 +190,8 @@ const AttendanceCard: React.FC<Props> = ({ allCustomers, ...slot }) => {
     </div>
   );
 };
+
+const useAddCustomersModal = createModal("AddAttendedCustomersDialog");
 
 // #region Styles
 const useStyles = makeStyles((theme: ETheme) => ({

--- a/packages/client/src/components/atoms/AttendanceCard/__tests__/AttendanceCard.test.tsx
+++ b/packages/client/src/components/atoms/AttendanceCard/__tests__/AttendanceCard.test.tsx
@@ -30,7 +30,6 @@ import {
   __nextIntervalButtonId__,
   __prevIntervalButtonId__,
 } from "../__testData__/testIds";
-import { openModal } from "@/features/modal/actions";
 
 const mockDispatch = jest.fn();
 jest.mock("react-redux", () => ({
@@ -295,6 +294,7 @@ describe("AttendanceCard", () => {
           ]}
         />
       );
+      jest.clearAllMocks();
       // we're testing with first interval as initial
       const nextButton = screen.getByTestId(__nextIntervalButtonId__);
       // selectedInterval -> interval[1]
@@ -353,16 +353,15 @@ describe("AttendanceCard", () => {
       render(<AttendanceCard {...attendanceCard} />);
 
       screen.getByTestId(__addCustomersButtonId__).click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({
-          component: "AddAttendedCustomersDialog",
-          props: {
-            ...testSlot,
-            customers: [saul, walt],
-            defaultInterval: "10:00-11:00",
-          },
-        })
+      const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(dispatchCallPayload.component).toEqual(
+        "AddAttendedCustomersDialog"
       );
+      expect(dispatchCallPayload.props).toEqual({
+        ...testSlot,
+        customers: [saul, walt],
+        defaultInterval: "10:00-11:00",
+      });
     });
   });
 

--- a/packages/client/src/components/atoms/BirthdayMenu/BirthdayMenu.tsx
+++ b/packages/client/src/components/atoms/BirthdayMenu/BirthdayMenu.tsx
@@ -1,9 +1,5 @@
 import React, { useState, useMemo, useEffect } from "react";
-import { useDispatch } from "react-redux";
 import { DateTime } from "luxon";
-
-import { CustomersByBirthday } from "@eisbuk/shared";
-import { Cake } from "@eisbuk/svg";
 
 import Menu from "@mui/material/Menu";
 import Table from "@mui/material/Table";
@@ -16,12 +12,15 @@ import {
   useTranslation,
   BirthdayMenu as BirthdayEnums,
 } from "@eisbuk/translations";
+import { CustomersByBirthday } from "@eisbuk/shared";
+import { Cake } from "@eisbuk/svg";
+import { Button } from "@eisbuk/ui";
 
 import BirthdayMenuItem from "./BirthdayMenuItem";
 
+import { createModal } from "@/features/modal/useModal";
+
 import { __birthdayMenu__ } from "@/__testData__/testIds";
-import { openModal } from "@/features/modal/actions";
-import { Button } from "@eisbuk/ui";
 
 interface BirthdayMenuProps {
   customers: CustomersByBirthday[];
@@ -30,7 +29,7 @@ interface BirthdayMenuProps {
 const BirthdayMenu: React.FC<BirthdayMenuProps> = ({ customers }) => {
   const classes = useStyles();
   const { t } = useTranslation();
-  const dispatch = useDispatch();
+  const { openWithProps: openBirthdayDialog } = useBirthdayModal();
 
   const [birthdaysAnchorEl, setBirthdaysAnchorEl] =
     useState<HTMLElement | null>(null);
@@ -43,7 +42,7 @@ const BirthdayMenu: React.FC<BirthdayMenuProps> = ({ customers }) => {
     // Close the small popup (menu)
     setBirthdaysAnchorEl(null);
     // Open the full birthday - customer list in modal
-    dispatch(openModal({ component: "BirthdayDialog", props: { customers } }));
+    openBirthdayDialog({ customers });
   };
 
   const calculateTimeDiff = (now: DateTime) =>
@@ -118,6 +117,9 @@ const BirthdayMenu: React.FC<BirthdayMenuProps> = ({ customers }) => {
     </>
   );
 };
+
+const useBirthdayModal = createModal("BirthdayDialog");
+
 const useStyles = makeStyles(() => ({
   birthdayHeader: {
     display: "flex",

--- a/packages/client/src/components/atoms/BirthdayMenu/__tests__/BirthdayMenu.test.tsx
+++ b/packages/client/src/components/atoms/BirthdayMenu/__tests__/BirthdayMenu.test.tsx
@@ -4,14 +4,13 @@
 
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import { DateTime } from "luxon";
 
 import i18n, { BirthdayMenu as BirthdayMenuLabel } from "@eisbuk/translations";
 
 import BirthdayMenu from "../BirthdayMenu";
 
 import { saul, gus, jane, jian } from "@/__testData__/customers";
-import { DateTime } from "luxon";
-import { openModal } from "@/features/modal/actions";
 
 const customers = [
   {
@@ -41,6 +40,7 @@ describe("BirthdayMenu", () => {
   describe("Smoke test", () => {
     beforeEach(() => {
       render(<BirthdayMenu customers={customers} />);
+      jest.clearAllMocks();
     });
 
     test("should display existing customers in 3 dates only", () => {
@@ -51,9 +51,9 @@ describe("BirthdayMenu", () => {
 
     test("should open a BidthdayDialog modal on 'show all' click", () => {
       screen.getByText(i18n.t(BirthdayMenuLabel.ShowAll) as string).click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({ component: "BirthdayDialog", props: { customers } })
-      );
+      const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(dispatchCallPayload.component).toEqual("BirthdayDialog");
+      expect(dispatchCallPayload.props).toEqual({ customers });
     });
   });
 });

--- a/packages/client/src/components/atoms/CustomerCard/ActionButtons.tsx
+++ b/packages/client/src/components/atoms/CustomerCard/ActionButtons.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useHistory } from "react-router-dom";
-import { useDispatch } from "react-redux";
 
 import Button from "@mui/material/Button";
 
@@ -10,6 +9,7 @@ import DateRangeIcon from "@mui/icons-material/DateRange";
 import Mail from "@mui/icons-material/Mail";
 import Phone from "@mui/icons-material/Phone";
 
+import { OrganizationData } from "@eisbuk/shared";
 import { useTranslation, ActionButton } from "@eisbuk/translations";
 
 import { Routes } from "@/enums/routes";
@@ -17,13 +17,13 @@ import { SendBookingLinkMethod } from "@/enums/other";
 
 import { ActionButtonProps } from "./types";
 
+import { createModal } from "@/features/modal/useModal";
+
 import {
   __openBookingsId__,
   __sendBookingsEmailId__,
   __sendBookingsSMSId__,
 } from "./__testData__/testIds";
-import { openModal } from "@/features/modal/actions";
-import { OrganizationData } from "@eisbuk/shared";
 
 /**
  * Labeled action buttons to open customer's bookings or send
@@ -34,10 +34,11 @@ const ActionButtons: React.FC<
 > = ({ customer, className, onClose, displayName }) => {
   const { t } = useTranslation();
 
-  const dispatch = useDispatch();
   const history = useHistory();
 
   const classes = useStyles();
+
+  const { openWithProps: openBookingsLinkDialog } = useBookingsLinkModal();
 
   // redirect to customers `bookings` entry flow
   const bookingsRoute = `${Routes.CustomerArea}/${customer?.secretKey}`;
@@ -47,12 +48,11 @@ const ActionButtons: React.FC<
   };
 
   const openBookingsLinkModal = (method: SendBookingLinkMethod) => () => {
-    dispatch(
-      openModal({
-        component: "SendBookingsLinkDialog",
-        props: { ...customer, method, displayName },
-      })
-    );
+    openBookingsLinkDialog({
+      ...customer,
+      method,
+      displayName,
+    });
   };
 
   return (
@@ -94,6 +94,8 @@ const ActionButtons: React.FC<
     </div>
   );
 };
+
+const useBookingsLinkModal = createModal("SendBookingsLinkDialog");
 
 const useStyles = makeStyles((theme) => ({
   actionButton: {

--- a/packages/client/src/components/atoms/CustomerCard/CustomerCard.tsx
+++ b/packages/client/src/components/atoms/CustomerCard/CustomerCard.tsx
@@ -102,7 +102,10 @@ const CustomerCard: React.FC<CustomerCardProps> = ({
   };
 
   return (
-    <Card className={[...containerClasses, className].join(" ")}>
+    <Card
+      aria-label="customer-dialog"
+      className={[...containerClasses, className].join(" ")}
+    >
       <CardContent>
         <Box className={classes.topSection}>
           <EisbukAvatar {...customer!} className={classes.avatar} />
@@ -128,7 +131,12 @@ const CustomerCard: React.FC<CustomerCardProps> = ({
         onClose={onClose}
         displayName={displayName}
       />
-      <IconButton onClick={onClose} className={classes.exitButton} size="large">
+      <IconButton
+        aria-label="close-button"
+        onClick={onClose}
+        className={classes.exitButton}
+        size="large"
+      >
         <Close />
       </IconButton>
     </Card>

--- a/packages/client/src/components/atoms/CustomerCard/CustomerOperationButtons.tsx
+++ b/packages/client/src/components/atoms/CustomerCard/CustomerOperationButtons.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useDispatch } from "react-redux";
 
 import CardActions from "@mui/material/CardActions";
 import IconButton from "@mui/material/IconButton";
@@ -9,7 +8,7 @@ import EditIcon from "@mui/icons-material/Edit";
 
 import { ActionButtonProps } from "./types";
 
-import { openModal } from "@/features/modal/actions";
+import { createModal } from "@/features/modal/useModal";
 
 import {
   __customerDeleteId__,
@@ -23,16 +22,12 @@ const CustomerOperationButtons: React.FC<ActionButtonProps> = ({
   customer,
   className,
 }) => {
-  const dispatch = useDispatch();
+  const { openWithProps: openCustomerForm } = useCustomerFormModal();
+  const { openWithProps: openDeleteCustomerDialog } = useDeleteCustomerModal();
 
-  const handleDelete = () => {
-    dispatch(openModal({ component: "DeleteCustomerDialog", props: customer }));
-  };
+  const handleDelete = () => openDeleteCustomerDialog(customer);
 
-  const handleEditCustoer = () =>
-    dispatch(
-      openModal({ component: "CustomerFormDialog", props: { customer } })
-    );
+  const handleEditCustoer = () => openCustomerForm({ customer });
 
   return (
     <CardActions {...{ className }}>
@@ -55,5 +50,8 @@ const CustomerOperationButtons: React.FC<ActionButtonProps> = ({
     </CardActions>
   );
 };
+
+const useCustomerFormModal = createModal("CustomerFormDialog");
+const useDeleteCustomerModal = createModal("DeleteCustomerDialog");
 
 export default CustomerOperationButtons;

--- a/packages/client/src/components/atoms/CustomerCard/ExtendedDateField.tsx
+++ b/packages/client/src/components/atoms/CustomerCard/ExtendedDateField.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useDispatch } from "react-redux";
 
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
@@ -13,7 +12,7 @@ import {
   CustomerLabel,
 } from "@eisbuk/translations";
 
-import { openModal } from "@/features/modal/actions";
+import { createModal } from "@/features/modal/useModal";
 
 interface Props {
   customer: Customer;
@@ -21,9 +20,10 @@ interface Props {
 }
 
 const ExtendedDateField: React.FC<Props> = ({ customer }) => {
-  const dispatch = useDispatch();
   const { t } = useTranslation();
   const classes = useStyles();
+
+  const { openWithProps: openExtendDateDialog } = useExtendDateModal();
 
   const displayValue = customer.extendedDate || "-";
 
@@ -39,14 +39,7 @@ const ExtendedDateField: React.FC<Props> = ({ customer }) => {
         <Button
           className={classes.buttonPrimary}
           color="primary"
-          onClick={() =>
-            dispatch(
-              openModal({
-                component: "ExtendBookingDateDialog",
-                props: customer,
-              })
-            )
-          }
+          onClick={() => openExtendDateDialog(customer)}
           variant="contained"
         >
           {t(ActionButton.ExtendBookingDate)}
@@ -55,6 +48,8 @@ const ExtendedDateField: React.FC<Props> = ({ customer }) => {
     </>
   );
 };
+
+const useExtendDateModal = createModal("ExtendBookingDateDialog");
 
 const useStyles = makeStyles((theme) => ({
   field: { display: "flex", justifyContent: "space-between", flexWrap: "wrap" },

--- a/packages/client/src/components/atoms/CustomerCard/__tests__/CustomerCard.test.tsx
+++ b/packages/client/src/components/atoms/CustomerCard/__tests__/CustomerCard.test.tsx
@@ -3,13 +3,14 @@
  */
 
 import React from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { Customer } from "@eisbuk/shared";
 import i18n, { ActionButton } from "@eisbuk/translations";
 
 import "@/__testSetup__/firestoreSetup";
+import { __testOrganization__ } from "@/__testSetup__/envData";
 
 import { SendBookingLinkMethod } from "@/enums/other";
 import { Routes } from "@/enums/routes";
@@ -19,8 +20,6 @@ import CustomerCard from "../CustomerCard";
 import * as customerActions from "@/store/actions/customerOperations";
 
 import { saul } from "@/__testData__/customers";
-import { __testOrganization__ } from "@/__testSetup__/envData";
-
 import {
   __customerDeleteId__,
   __customerEditId__,
@@ -28,7 +27,6 @@ import {
   __sendBookingsEmailId__,
   __sendBookingsSMSId__,
 } from "../__testData__/testIds";
-import { openModal } from "@/features/modal/actions";
 
 const mockDispatch = jest.fn();
 const mockHistoryPush = jest.fn();
@@ -55,13 +53,13 @@ jest
   .mockImplementation(mockUpdateCustomerImplementation as any);
 
 describe("Customer Card", () => {
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
-    cleanup();
   });
 
   describe("CustomerOperationButtons", () => {
     beforeEach(() => {
+      jest.clearAllMocks();
       render(
         <CustomerCard
           onCloseAll={() => {}}
@@ -72,30 +70,22 @@ describe("Customer Card", () => {
       );
     });
 
-    afterEach(() => {
-      jest.clearAllMocks();
-      cleanup();
-    });
-
     test("should open 'DeleteCustomerDialog' modal on delete button click", () => {
       screen.getByTestId(__customerDeleteId__).click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({ component: "DeleteCustomerDialog", props: saul })
-      );
+      const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(dispatchCallPayload.component).toEqual("DeleteCustomerDialog");
+      expect(dispatchCallPayload.props).toEqual(saul);
     });
 
     test("should open 'CustomerFormDialog' modal on edit click", () => {
       screen.getByTestId(__customerEditId__).click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({
-          component: "CustomerFormDialog",
-          props: { customer: saul },
-        })
-      );
+      const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(dispatchCallPayload.component).toEqual("CustomerFormDialog");
+      expect(dispatchCallPayload.props).toEqual({ customer: saul });
     });
   });
 
-  describe("Test email button", () => {
+  describe("test email button", () => {
     test("should open a 'SendBookingsLinkDialog' modal with method = \"email\" on email button click", () => {
       render(
         <CustomerCard
@@ -106,16 +96,13 @@ describe("Customer Card", () => {
         />
       );
       screen.getByTestId(__sendBookingsEmailId__).click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({
-          component: "SendBookingsLinkDialog",
-          props: {
-            ...saul,
-            method: SendBookingLinkMethod.Email,
-            displayName: __testOrganization__,
-          },
-        })
-      );
+      const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(dispatchCallPayload.component).toEqual("SendBookingsLinkDialog");
+      expect(dispatchCallPayload.props).toEqual({
+        ...saul,
+        method: SendBookingLinkMethod.Email,
+        displayName: __testOrganization__,
+      });
     });
 
     test("should disable the button if secretKey not defined", () => {
@@ -154,7 +141,7 @@ describe("Customer Card", () => {
     });
   });
 
-  describe("Test SMS button", () => {
+  describe("test SMS button", () => {
     test("should open a 'SendBookingsLinkDialog' modal with method = \"sms\" on sms button click", () => {
       render(
         <CustomerCard
@@ -165,16 +152,13 @@ describe("Customer Card", () => {
         />
       );
       screen.getByTestId(__sendBookingsSMSId__).click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({
-          component: "SendBookingsLinkDialog",
-          props: {
-            ...saul,
-            method: SendBookingLinkMethod.SMS,
-            displayName: __testOrganization__,
-          },
-        })
-      );
+      const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(dispatchCallPayload.component).toEqual("SendBookingsLinkDialog");
+      expect(dispatchCallPayload.props).toEqual({
+        ...saul,
+        method: SendBookingLinkMethod.SMS,
+        displayName: __testOrganization__,
+      });
     });
 
     test("should disable the button if secretKey not defined", () => {
@@ -213,7 +197,7 @@ describe("Customer Card", () => {
     });
   });
 
-  describe("Test bookings redirect button", () => {
+  describe("test bookings redirect button", () => {
     test("should redirect to 'bookings' route for a customer on bookings button click", () => {
       const mockOnClose = jest.fn();
       render(
@@ -232,7 +216,7 @@ describe("Customer Card", () => {
     });
   });
 
-  describe("Test booking extension button", () => {
+  describe("test booking extension button", () => {
     test("should open extend booking prompt on click 'extend booking date' button click", () => {
       render(
         <CustomerCard
@@ -245,9 +229,9 @@ describe("Customer Card", () => {
       screen
         .getByText(i18n.t(ActionButton.ExtendBookingDate) as string)
         .click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({ component: "ExtendBookingDateDialog", props: saul })
-      );
+      const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(dispatchCallPayload.component).toEqual("ExtendBookingDateDialog");
+      expect(dispatchCallPayload.props).toEqual(saul);
     });
   });
 });

--- a/packages/client/src/components/atoms/CustomerGrid/__tests__/CustomerGrid.test.tsx
+++ b/packages/client/src/components/atoms/CustomerGrid/__tests__/CustomerGrid.test.tsx
@@ -3,13 +3,13 @@
  */
 
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { __testOrganization__ } from "@/__testSetup__/envData";
 
 import CustomerGrid from "../CustomerGrid";
 
 import { saul } from "@/__testData__/customers";
-import { openModal } from "@/features/modal/actions";
-import { __testOrganization__ } from "@/__testSetup__/envData";
 
 const mockDispatch = jest.fn();
 jest.mock("react-redux", () => ({
@@ -22,16 +22,17 @@ describe("CustomerGrid", () => {
     jest.clearAllMocks();
   });
 
-  test("should open customer in CustomerCard modal on customer click", () => {
+  test("should open customer in CustomerCard modal on customer click", async () => {
     render(
       <CustomerGrid displayName={__testOrganization__} customers={[saul]} />
     );
     screen.getByText(saul.name).click();
-    expect(mockDispatch).toHaveBeenCalledWith(
-      openModal({
-        component: "CustomerCard",
-        props: { customer: saul, displayName: __testOrganization__ },
-      })
-    );
+    await waitFor(() => expect(mockDispatch).toHaveBeenCalled());
+    const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+    expect(dispatchCallPayload.component).toEqual("CustomerCard");
+    expect(dispatchCallPayload.props).toEqual({
+      customer: saul,
+      displayName: __testOrganization__,
+    });
   });
 });

--- a/packages/client/src/components/atoms/SlotCard/__tests__/SlotCard.test.tsx
+++ b/packages/client/src/components/atoms/SlotCard/__tests__/SlotCard.test.tsx
@@ -13,7 +13,6 @@ import {
   __editSlotButtonId__,
 } from "@/__testData__/testIds";
 import { baseSlot } from "@/__testData__/slots";
-import { openModal } from "@/features/modal/actions";
 
 const mockDispatch = jest.fn();
 
@@ -28,9 +27,8 @@ jest.mock("react-router-dom", () => ({
 }));
 
 describe("SlotCard", () => {
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
-    cleanup();
   });
 
   describe("Smoke test", () => {
@@ -67,32 +65,36 @@ describe("SlotCard", () => {
   describe("SlotOperationButtons functionality", () => {
     beforeEach(() => {
       render(<SlotCard {...baseSlot} enableEdit />);
+      jest.clearAllMocks();
     });
 
     test("should open slot form on edit slot click", () => {
       screen.getByTestId(__editSlotButtonId__).click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({
-          component: "SlotForm",
-          props: { date: baseSlot.date, slotToEdit: baseSlot },
-        })
-      );
+      const mockDispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(mockDispatchCallPayload.component).toEqual("SlotForm");
+      expect(mockDispatchCallPayload.props).toEqual({
+        date: baseSlot.date,
+        slotToEdit: baseSlot,
+      });
     });
 
     test("should initiate delete-slot flow on delete button click", () => {
       screen.getByTestId(__deleteButtonId__).click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({ component: "DeleteSlotDialog", props: baseSlot })
-      );
+      const mockDispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(mockDispatchCallPayload.component).toEqual("DeleteSlotDialog");
+      expect(mockDispatchCallPayload.props).toEqual(baseSlot);
     });
 
     test("should show delete-disabled dialog on delete button click if delete disabled", () => {
       cleanup();
       render(<SlotCard {...baseSlot} enableEdit disableDelete />);
+      jest.clearAllMocks();
       screen.getByTestId(__deleteButtonId__).click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({ component: "DeleteSlotDisabledDialog", props: baseSlot })
+      const mockDispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(mockDispatchCallPayload.component).toEqual(
+        "DeleteSlotDisabledDialog"
       );
+      expect(mockDispatchCallPayload.props).toEqual(baseSlot);
     });
   });
 

--- a/packages/client/src/components/atoms/SlotOperationButtons/DeleteButton.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/DeleteButton.tsx
@@ -13,6 +13,8 @@ import {
   deleteSlotsWeek,
 } from "@/store/actions/slotOperations";
 
+import { createModal } from "@/features/modal/useModal";
+
 import {
   __noDateDelete,
   __noSlotToDelete,
@@ -20,7 +22,6 @@ import {
 } from "@/lib/errorMessages";
 
 import { __deleteButtonId__ } from "@/__testData__/testIds";
-import { openModal } from "@/features/modal/actions";
 
 /**
  * Button in charge of delete functionality.
@@ -37,6 +38,10 @@ export const DeleteButton: React.FC = () => {
   const dispatch = useDispatch();
 
   const buttonGroupContext = useContext(ButtonGroupContext);
+
+  const { openWithProps: openDeleteSlotDialog } = useDeleteSlotModal();
+  const { openWithProps: openDeleteSlotDisabledDialog } =
+    useDeleteSlotDieabledModal();
 
   // prevent component from rendering and log error to console (but don't throw)
   // if not rendered within the `SlotOperationButtons` context
@@ -71,11 +76,9 @@ export const DeleteButton: React.FC = () => {
     switch (contextType) {
       case ButtonContextType.Slot:
         if (disableDelete) {
-          dispatch(
-            openModal({ component: "DeleteSlotDisabledDialog", props: slot! })
-          );
+          openDeleteSlotDisabledDialog(slot!);
         } else {
-          dispatch(openModal({ component: "DeleteSlotDialog", props: slot! }));
+          openDeleteSlotDialog(slot!);
         }
         break;
 
@@ -99,5 +102,8 @@ export const DeleteButton: React.FC = () => {
     </SlotOperationButton>
   );
 };
+
+const useDeleteSlotModal = createModal("DeleteSlotDialog");
+const useDeleteSlotDieabledModal = createModal("DeleteSlotDisabledDialog");
 
 export default DeleteButton;

--- a/packages/client/src/components/atoms/SlotOperationButtons/EditSlotButton.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/EditSlotButton.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { useDispatch } from "react-redux";
 
 import { Pencil } from "@eisbuk/svg";
 
@@ -8,7 +7,8 @@ import { ButtonContextType } from "@/enums/components";
 import SlotOperationButton from "./SlotOperationButton";
 
 import { ButtonGroupContext } from "./SlotOperationButtons";
-import { openModal } from "@/features/modal/actions";
+
+import { createModal } from "@/features/modal/useModal";
 
 import {
   __editSlotButtonWrongContextError,
@@ -28,8 +28,9 @@ import { __editSlotButtonId__ } from "@/__testData__/testIds";
  * - no value for `slot` has been provided within the context (as it is needed for full functionality)
  */
 export const EditSlotButton: React.FC = () => {
-  const dispatch = useDispatch();
   const buttonGroupContext = useContext(ButtonGroupContext);
+
+  const { openWithProps: openSlotForm } = useSlotFormModal();
 
   // prevent component from rendering and log error to console (but don't throw)
   // if not rendered within the `SlotOperationButtons` context
@@ -49,12 +50,10 @@ export const EditSlotButton: React.FC = () => {
 
   const openForm = (e: React.SyntheticEvent) => {
     e.stopPropagation();
-    dispatch(
-      openModal({
-        component: "SlotForm",
-        props: { date: slot.date, slotToEdit: slot },
-      })
-    );
+    openSlotForm({
+      date: slot.date,
+      slotToEdit: slot,
+    });
   };
 
   // prevent component from rendering and log error to console (but don't throw)
@@ -70,5 +69,7 @@ export const EditSlotButton: React.FC = () => {
     </SlotOperationButton>
   );
 };
+
+const useSlotFormModal = createModal("SlotForm");
 
 export default EditSlotButton;

--- a/packages/client/src/components/atoms/SlotOperationButtons/NewSlotButton.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/NewSlotButton.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { useDispatch } from "react-redux";
 
 import { useTranslation, AdminAria, DateFormat } from "@eisbuk/translations";
 import { PlusCircle } from "@eisbuk/svg";
@@ -15,7 +14,7 @@ import {
   __newSlotButtonWrongContextError,
 } from "@/lib/errorMessages";
 
-import { openModal } from "@/features/modal/actions";
+import { createModal } from "@/features/modal/useModal";
 
 import { __newSlotButtonId__ } from "@/__testData__/testIds";
 
@@ -31,7 +30,8 @@ export const NewSlotButton: React.FC = () => {
   const buttonGroupContext = useContext(ButtonGroupContext);
 
   const { t } = useTranslation();
-  const dispatch = useDispatch();
+
+  const { openWithProps: openSlotForm } = useSlotFormModal();
 
   // prevent component from rendering and log error to console (but don't throw)
   // if not rendered within the `SlotOpeartionButtons` context
@@ -60,12 +60,9 @@ export const NewSlotButton: React.FC = () => {
 
   const openForm = (e: React.SyntheticEvent) => {
     e.preventDefault();
-    dispatch(
-      openModal({
-        component: "SlotForm",
-        props: { date: luxonDate?.toISODate() },
-      })
-    );
+    openSlotForm({
+      date: luxonDate?.toISODate(),
+    });
   };
 
   return (
@@ -81,5 +78,7 @@ export const NewSlotButton: React.FC = () => {
     </SlotOperationButton>
   );
 };
+
+const useSlotFormModal = createModal("SlotForm");
 
 export default NewSlotButton;

--- a/packages/client/src/components/atoms/SlotOperationButtons/__tests__/DeleteButton.test.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/__tests__/DeleteButton.test.tsx
@@ -12,7 +12,6 @@ import SlotOperationButtons from "../SlotOperationButtons";
 import DeleteButton from "../DeleteButton";
 
 import * as slotOperations from "@/store/actions/slotOperations";
-import { openModal } from "@/features/modal/actions";
 
 import {
   __noDateDelete,
@@ -63,7 +62,7 @@ jest
 const testDate = DateTime.fromISO("2021-03-01");
 
 describe("SlotOperationButtons", () => {
-  afterEach(() => {
+  beforeEach(() => {
     jest.clearAllMocks();
     cleanup();
   });
@@ -80,9 +79,9 @@ describe("SlotOperationButtons", () => {
       );
       // initiate delete
       screen.getByTestId(__deleteButtonId__).click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({ component: "DeleteSlotDialog", props: baseSlot })
-      );
+      const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(dispatchCallPayload.component).toEqual("DeleteSlotDialog");
+      expect(dispatchCallPayload.props).toEqual(baseSlot);
     });
 
     test("should show 'DeleteSlotDisabledDialog' modal onClick if within \"slot\" context and delete disabled", () => {
@@ -97,9 +96,9 @@ describe("SlotOperationButtons", () => {
       );
       // initiate delete
       screen.getByTestId(__deleteButtonId__).click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({ component: "DeleteSlotDisabledDialog", props: baseSlot })
-      );
+      const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(dispatchCallPayload.component).toEqual("DeleteSlotDisabledDialog");
+      expect(dispatchCallPayload.props).toEqual(baseSlot);
     });
 
     test("should dispatch 'deleteSlotsDay' onClick if within \"day\" context", () => {

--- a/packages/client/src/components/atoms/SlotOperationButtons/__tests__/EditSlotButton.test.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/__tests__/EditSlotButton.test.tsx
@@ -18,7 +18,6 @@ import {
 
 import { __editSlotButtonId__ } from "@/__testData__/testIds";
 import { baseSlot } from "@/__testData__/slots";
-import { openModal } from "@/features/modal/actions";
 
 const mockDispatch = jest.fn();
 jest.mock("react-redux", () => ({
@@ -42,12 +41,12 @@ describe("SlotOperationButtons", () => {
         </SlotOperationButtons>
       );
       screen.getByTestId(__editSlotButtonId__).click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({
-          component: "SlotForm",
-          props: { date: baseSlot.date, slotToEdit: baseSlot },
-        })
-      );
+      const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(dispatchCallPayload.component).toEqual("SlotForm");
+      expect(dispatchCallPayload.props).toEqual({
+        date: baseSlot.date,
+        slotToEdit: baseSlot,
+      });
     });
   });
 

--- a/packages/client/src/components/atoms/SlotOperationButtons/__tests__/NewSlotButton.test.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/__tests__/NewSlotButton.test.tsx
@@ -10,7 +10,6 @@ import { ButtonContextType } from "@/enums/components";
 
 import SlotOperationButtons from "../SlotOperationButtons";
 import NewSlotButton from "../NewSlotButton";
-import { openModal } from "@/features/modal/actions";
 
 import {
   __newSlotButtonWrongContextError,
@@ -47,12 +46,11 @@ describe("SlotOperationButtons", () => {
         </SlotOperationButtons>
       );
       screen.getByTestId(__newSlotButtonId__).click();
-      expect(mockDispatch).toHaveBeenCalledWith(
-        openModal({
-          component: "SlotForm",
-          props: { date: dummyDate.toISODate() },
-        })
-      );
+      const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+      expect(dispatchCallPayload.component).toEqual("SlotForm");
+      expect(dispatchCallPayload.props).toEqual({
+        date: dummyDate.toISODate(),
+      });
     });
   });
 

--- a/packages/client/src/controllers/BookingsCountdown/BookingsCountdownContainer.tsx
+++ b/packages/client/src/controllers/BookingsCountdown/BookingsCountdownContainer.tsx
@@ -1,15 +1,16 @@
 import React from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 
 import { BookingsCountdown, EmptySpace } from "@eisbuk/ui";
 import i18n, { Alerts } from "@eisbuk/translations";
+
+import { createModal } from "@/features/modal/useModal";
 
 import {
   getBookingsCustomer,
   getCountdownProps,
   getMonthEmptyForBooking,
 } from "@/store/selectors/bookings";
-import { openModal } from "@/features/modal/actions";
 import { getCalendarDay } from "@/store/selectors/app";
 
 interface Props extends React.HTMLAttributes<HTMLElement> {
@@ -22,12 +23,13 @@ interface Props extends React.HTMLAttributes<HTMLElement> {
  * state to the store (for bookings finalisation).
  */
 const BookingsCountdownContainer: React.FC<Props> = (props) => {
-  const dispatch = useDispatch();
-
   const currentDate = useSelector(getCalendarDay);
   const countdownProps = useSelector(getCountdownProps);
   const isMonthEmpty = useSelector(getMonthEmptyForBooking);
   const { id: customerId } = useSelector(getBookingsCustomer) || {};
+
+  const { openWithProps: openFinalizeBookingsDialog } =
+    useFinalizeBooksingsModal();
 
   // No slots for booking message is shown using a bit different styles,
   // hence a different component
@@ -44,12 +46,10 @@ const BookingsCountdownContainer: React.FC<Props> = (props) => {
   const handleFinalize = () => {
     const { month } = countdownProps;
 
-    dispatch(
-      openModal({
-        component: "FinalizeBookingsDialog",
-        props: { customerId, month },
-      })
-    );
+    openFinalizeBookingsDialog({
+      customerId,
+      month,
+    });
   };
 
   return (
@@ -60,5 +60,7 @@ const BookingsCountdownContainer: React.FC<Props> = (props) => {
     />
   );
 };
+
+const useFinalizeBooksingsModal = createModal("FinalizeBookingsDialog");
 
 export default BookingsCountdownContainer;

--- a/packages/client/src/controllers/BookingsCountdown/__tests__/BookingsCountdownContainer.test.tsx
+++ b/packages/client/src/controllers/BookingsCountdown/__tests__/BookingsCountdownContainer.test.tsx
@@ -10,13 +10,10 @@ import i18n, { ActionButton } from "@eisbuk/translations";
 import { OrgSubCollection } from "@eisbuk/shared";
 import { updateLocalDocuments } from "@eisbuk/react-redux-firebase-firestore";
 
-import { ModalPayload } from "@/features/modal/types";
-
 import BookingsCountdownContainer from "../BookingsCountdownContainer";
 
 import { getNewStore } from "@/store/createStore";
 import { changeCalendarDate } from "@/store/actions/appActions";
-import { openModal } from "@/features/modal/actions";
 
 import { renderWithRedux } from "@/__testUtils__/wrappers";
 
@@ -62,10 +59,12 @@ describe("BookingsCountdown", () => {
     // provided 'month'
     renderWithRedux(<BookingsCountdownContainer />, store);
     screen.getByText(i18n.t(ActionButton.FinalizeBookings) as string).click();
-    const wantModal: ModalPayload = {
+    const wantModal = {
       component: "FinalizeBookingsDialog",
       props: { customerId: saul.id, month },
     };
-    expect(mockDispatch).toHaveBeenCalledWith(openModal(wantModal));
+    const mockDispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
+    expect(mockDispatchCallPayload.component).toEqual(wantModal.component);
+    expect(mockDispatchCallPayload.props).toEqual(wantModal.props);
   });
 });

--- a/packages/client/src/features/modal/__tests__/store.test.ts
+++ b/packages/client/src/features/modal/__tests__/store.test.ts
@@ -5,7 +5,13 @@ import { SlotInterface, SlotType } from "@eisbuk/shared";
 
 import { ModalPayload } from "../types";
 
-import { popModal, openModal, closeAllModals, closeModal } from "../actions";
+import {
+  popModal,
+  openModal,
+  closeAllModals,
+  closeModal,
+  updateModal,
+} from "../actions";
 
 import { getModal } from "../selectors";
 
@@ -48,6 +54,43 @@ describe("Modal store tests", () => {
       modalContent = getModal(store.getState());
       expect(modalContent).toEqual([modal1, modal2]);
     });
+
+    test("if the modal is already open, should fail with a warning", () => {
+      const store = getNewStore();
+      store.dispatch(openModal(modal1));
+      store.dispatch(openModal(modal2));
+      store.dispatch(
+        openModal({
+          ...modal1,
+          props: { ...modal1.props, date: "2022-10-15" },
+        })
+      );
+      const modalContent = getModal(store.getState());
+      expect(modalContent).toEqual([modal1, modal2]);
+    });
+  });
+
+  describe("Update modal action", () => {
+    test("should update an existing modal in the store with the updated props", async () => {
+      const store = getNewStore();
+      store.dispatch(openModal(modal1));
+      store.dispatch(openModal(modal2));
+      let modalContent = getModal(store.getState());
+      const updatedModal1 = {
+        ...modal1,
+        props: { ...modal1.props, date: "2022-10-14" },
+      };
+      store.dispatch(updateModal(updatedModal1));
+      modalContent = getModal(store.getState());
+      expect(modalContent).toEqual([updatedModal1, modal2]);
+    });
+
+    test("should fail silently if updated modal doesn't exist in open modals stack", () => {
+      const store = getNewStore();
+      store.dispatch(updateModal(modal1));
+      const modalState = getModal(store.getState());
+      expect(modalState).toEqual([]);
+    });
   });
 
   describe("Close modal action", () => {
@@ -57,7 +100,7 @@ describe("Modal store tests", () => {
       store.dispatch(openModal(modal1));
       store.dispatch(openModal(modal2));
       // Close the first modal (by explicitly specifying its id)
-      store.dispatch(closeModal({ id: modal1.id }));
+      store.dispatch(closeModal(modal1.id));
       const modalContent = getModal(store.getState());
       expect(modalContent).toEqual([modal2]);
     });

--- a/packages/client/src/features/modal/__tests__/store.test.ts
+++ b/packages/client/src/features/modal/__tests__/store.test.ts
@@ -5,7 +5,7 @@ import { SlotInterface, SlotType } from "@eisbuk/shared";
 
 import { ModalPayload } from "../types";
 
-import { popModal, openModal, closeAllModals } from "../actions";
+import { popModal, openModal, closeAllModals, closeModal } from "../actions";
 
 import { getModal } from "../selectors";
 
@@ -25,11 +25,13 @@ const dummySlot: SlotInterface = {
 };
 
 const modal1: ModalPayload = {
+  id: "modal1",
   component: "CancelBookingDialog",
   props: { ...dummySlot, interval },
 };
 
 const modal2: ModalPayload = {
+  id: "modal2",
   component: "FinalizeBookingsDialog",
   props: { customerId: "dummy-cusotmer", month: DateTime.now() },
 };
@@ -49,6 +51,19 @@ describe("Modal store tests", () => {
   });
 
   describe("Close modal action", () => {
+    test("should remove the specific modal from store state effectively removing the modal from the screen", () => {
+      // Setup
+      const store = getNewStore();
+      store.dispatch(openModal(modal1));
+      store.dispatch(openModal(modal2));
+      // Close the first modal (by explicitly specifying its id)
+      store.dispatch(closeModal({ id: modal1.id }));
+      const modalContent = getModal(store.getState());
+      expect(modalContent).toEqual([modal2]);
+    });
+  });
+
+  describe("Pop modal action", () => {
     test("should pop the latest modal from store state effectively removing the modal from the screen", () => {
       // Setup
       const store = getNewStore();

--- a/packages/client/src/features/modal/__tests__/useModal.test.ts
+++ b/packages/client/src/features/modal/__tests__/useModal.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { SlotInterface, SlotType } from "@eisbuk/shared";
+import * as reactRedux from "react-redux";
+
+import { ModalPayload } from "../types";
+
+import { getModal } from "../selectors";
+import { getNewStore } from "@/store/createStore";
+
+import { createModal } from "../useModal";
+
+import { testHookWithRedux } from "@/__testUtils__/testHooksWithRedux";
+
+const interval = {
+  startTime: "09:00",
+  endTime: "10:00",
+};
+
+const dummySlot: SlotInterface = {
+  id: "slot",
+  type: SlotType.Ice,
+  categories: [],
+  intervals: {
+    "09:00-10:00": interval,
+  },
+  date: "2022-01-01",
+};
+
+const modal1: Omit<ModalPayload<"CancelBookingDialog">, "id"> = {
+  component: "CancelBookingDialog",
+  props: { ...dummySlot, interval },
+};
+
+describe("useModal hook", () => {
+  test("should open a modal on open call", () => {
+    const store = getNewStore();
+
+    const useModal = createModal(modal1.component);
+    const testRes = testHookWithRedux(store, useModal, modal1.props);
+
+    // No modal is rendered yet, without running of the 'open' method
+    let modalState = getModal(store.getState());
+    expect(modalState).toEqual([]);
+
+    // Fire 'open' to add the modal to the state
+    testRes.result.open();
+
+    modalState = getModal(store.getState());
+    let modalProps = modalState[0].props;
+
+    expect(modalState.length).toEqual(1);
+    expect(modalProps).toEqual(modal1.props);
+
+    // Update the props in the store
+    const updatedProps = { ...modal1.props, date: "2022-10-15" };
+    testRes.updateProps(updatedProps);
+
+    modalState = getModal(store.getState());
+    modalProps = modalState[0].props;
+
+    expect(modalState.length).toEqual(1);
+    expect(modalProps).toEqual(updatedProps);
+
+    // Close the modal
+    testRes.result.close();
+
+    modalState = getModal(store.getState());
+    expect(modalState.length).toEqual(0);
+  });
+
+  test("should open the modal with props explicitly passed in on 'openWithProps'", () => {
+    const store = getNewStore();
+
+    const useModal = createModal(modal1.component);
+    const testRes = testHookWithRedux(store, useModal);
+
+    testRes.result.openWithProps(modal1.props);
+
+    const modalState = getModal(store.getState());
+    expect(modalState.length).toEqual(1);
+    expect(modalState[0].props).toEqual(modal1.props);
+  });
+
+  test("should not open the modal on 'open' call if props not passed in through hook call", () => {
+    const store = getNewStore();
+
+    const useModal = createModal(modal1.component);
+    const testRes = testHookWithRedux(store, useModal);
+
+    testRes.result.open();
+
+    const modalState = getModal(store.getState());
+    expect(modalState).toEqual([]);
+  });
+
+  test("should dispatch 'updateModal' only if the props aren't deeply equal", () => {
+    const dispatchSpy = jest.fn();
+    const useDispatchSpy = jest.spyOn(reactRedux, "useDispatch");
+    useDispatchSpy.mockImplementation(() => dispatchSpy);
+
+    const store = getNewStore();
+
+    // Initialise useModal with 'modal1' props
+    const useModal = createModal(modal1.component);
+    const testRes = testHookWithRedux(store, useModal, modal1.props);
+    testRes.result.open();
+
+    // Clear previous calls to dispatch ('updateModal' on hook mount and 'openModal' on explicit call)
+    dispatchSpy.mockClear();
+    useDispatchSpy.mockImplementation(() => dispatchSpy);
+
+    // Update props with the same structure (store shouldn't get updated)
+    testRes.updateProps({ ...modal1.props });
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/features/modal/actions.ts
+++ b/packages/client/src/features/modal/actions.ts
@@ -12,11 +12,20 @@ export const openModal = (payload: ModalPayload): ModalReducerAction => ({
 });
 
 /**
+ * Delete a specific modal from the modal stack by specifying the modal's id.
+ * @param {Object} payload
+ * @param {string} payload.id id of the modal to remove from stack
+ */
+export const closeModal = (
+  payload: Pick<ModalPayload, "id">
+): ModalReducerAction => ({ type: ModalAction.Close, payload });
+
+/**
  * This is a pure action object (not a function) dispatched
  * to pop the (top-most) modal from the modal stack
  */
 export const popModal: ModalReducerAction = {
-  type: ModalAction.Close,
+  type: ModalAction.Pop,
 };
 
 /**

--- a/packages/client/src/features/modal/actions.ts
+++ b/packages/client/src/features/modal/actions.ts
@@ -2,12 +2,25 @@ import { ModalAction, ModalPayload, ModalReducerAction } from "./types";
 
 /**
  * Open a modal by adding it to the modal stack in store, renering a specified component and passing appropriate props to it.
- * @param {Object} payload essentially a modal state passed to open up a modal
+ * @param {Object} payload id and modal props used to render the newly added modal
+ * @param {string} payload.id uuid of the modal to add
  * @param {string} payload.component name of a (whitelisted) component should be rendered inside a modal
- * @param {Object} payload.props appropriate props for the component rendered within modal
+ * @param {Object} payload.props appropriate props for the component rendered within a modal
  */
 export const openModal = (payload: ModalPayload): ModalReducerAction => ({
   type: ModalAction.Open,
+  payload,
+});
+
+/**
+ * Update the existing modal (we use this to update the props on the shown modal when external update happens)
+ * @param {Object} payload id and props of the modal to update
+ * @param {string} payload.id uuid of the modal to update
+ * @param {string} payload.component name of a (whitelisted) component should be rendered inside a modal
+ * @param {Object} payload.props appropriate props for the component rendered within modal
+ */
+export const updateModal = (payload: ModalPayload): ModalReducerAction => ({
+  type: ModalAction.Update,
   payload,
 });
 
@@ -16,9 +29,10 @@ export const openModal = (payload: ModalPayload): ModalReducerAction => ({
  * @param {Object} payload
  * @param {string} payload.id id of the modal to remove from stack
  */
-export const closeModal = (
-  payload: Pick<ModalPayload, "id">
-): ModalReducerAction => ({ type: ModalAction.Close, payload });
+export const closeModal = (id: ModalPayload["id"]): ModalReducerAction => ({
+  type: ModalAction.Close,
+  payload: { id },
+});
 
 /**
  * This is a pure action object (not a function) dispatched

--- a/packages/client/src/features/modal/components/AddAttendedCustomersDialog/AddAttendedCustomersDialog.tsx
+++ b/packages/client/src/features/modal/components/AddAttendedCustomersDialog/AddAttendedCustomersDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect } from "react";
 import { useDispatch } from "react-redux";
 
 import Typography from "@mui/material/Typography";
@@ -35,34 +35,22 @@ const AddAttendedCustomersDialog: React.FC<AddAttendedCustomersProps> = ({
     dispatch(
       markAttendance({ customerId, slotId, attendedInterval: defaultInterval })
     );
-    // Remove customer from list when marked as attended
-    setRemovedFromList((s) => [...s, customerId]);
   };
-
-  // Each customer marked as attended should be marked here
-  // and removed from the list
-  const [removedFromList, setRemovedFromList] = useState<string[]>([]);
-  const filteredCustomers = useMemo(
-    () =>
-      customers.filter(
-        /** @TODO Deleted customers should probably not be retrieved from store */
-        // Filter customers marked as attended as well as customers marked as deleted
-        ({ id, deleted }) => !removedFromList.includes(id) && !deleted
-      ),
-    [removedFromList]
-  );
 
   // Close the modal when there are no more customers to show
   useEffect(() => {
-    if (!filteredCustomers.length) {
+    if (!customers.length) {
       onClose();
     }
-  }, [filteredCustomers]);
+  }, [customers]);
 
   const classes = useStyles();
 
   return (
-    <div className={[className, classes.container].join(" ")}>
+    <div
+      aria-label="add-athletes-dialog"
+      className={[className, classes.container].join(" ")}
+    >
       <Typography variant="h6" component="h2" className={classes.title}>
         {i18n.t(ActionButton.AddCustomers)}
       </Typography>
@@ -77,7 +65,7 @@ const AddAttendedCustomersDialog: React.FC<AddAttendedCustomersProps> = ({
       <CustomerList
         className={classes.listContainer}
         tableContainerClassName={classes.tableContainer}
-        customers={filteredCustomers}
+        customers={customers}
         onCustomerClick={handleCustomerClick}
       />
     </div>

--- a/packages/client/src/features/modal/components/AddAttendedCustomersDialog/__tests__/AddAttendedCustomersDialog.test.tsx
+++ b/packages/client/src/features/modal/components/AddAttendedCustomersDialog/__tests__/AddAttendedCustomersDialog.test.tsx
@@ -71,8 +71,6 @@ describe("AddAttendedCustomersDialog", () => {
     );
     // Shouldn't close modal on each customer click
     expect(mockOnClose).not.toHaveBeenCalled();
-    // Should remove customer from the list when marked as attended
-    expect(screen.queryByText(saul.name)).toBeFalsy();
   });
 
   test("should not render 'deleted' customers", () => {
@@ -90,8 +88,8 @@ describe("AddAttendedCustomersDialog", () => {
     screen.getByText(walt.name);
   });
 
-  test("should close the modal when last customer listed marked as attended", async () => {
-    render(
+  test("should close the modal when there are no customers to mark as having attended", async () => {
+    const { rerender } = render(
       <AddAttendedCustomersDialog
         onCloseAll={() => {}}
         customers={[{ ...saul, deleted: true }, walt]}
@@ -99,7 +97,15 @@ describe("AddAttendedCustomersDialog", () => {
         {...{ ...baseSlot, defaultInterval }}
       />
     );
-    screen.getByText(walt.name).click();
+    // Update props from outside to mark there are no more customers to show
+    rerender(
+      <AddAttendedCustomersDialog
+        onCloseAll={() => {}}
+        customers={[]}
+        onClose={mockOnClose}
+        {...{ ...baseSlot, defaultInterval }}
+      />
+    );
     await waitFor(() => {
       expect(mockOnClose).toHaveBeenCalled();
     });

--- a/packages/client/src/features/modal/components/Modal/Modal.stories.tsx
+++ b/packages/client/src/features/modal/components/Modal/Modal.stories.tsx
@@ -24,6 +24,7 @@ export const CancelBookingsDialog = (): JSX.Element => (
         onClick={() =>
           store.dispatch(
             openModal({
+              id: "modal",
               component: "CancelBookingDialog",
               props: {
                 id: "slot",

--- a/packages/client/src/features/modal/components/Modal/__tests__/Modal.test.tsx
+++ b/packages/client/src/features/modal/components/Modal/__tests__/Modal.test.tsx
@@ -42,6 +42,7 @@ describe("Modal", () => {
       // Add first modal
       testStore.dispatch(
         openModal({
+          id: "modal",
           component: "CancelBookingDialog",
           props: intervalCardProps,
         })
@@ -53,6 +54,7 @@ describe("Modal", () => {
       // Add second modal
       testStore.dispatch(
         openModal({
+          id: "another-modal",
           component: "FinalizeBookingsDialog",
           props: { customerId: "test-customer", month: DateTime.now() },
         })
@@ -69,12 +71,14 @@ describe("Modal", () => {
       renderWithRedux(<Modal />, testStore);
       testStore.dispatch(
         openModal({
+          id: "modal",
           component: "CancelBookingDialog",
           props: intervalCardProps,
         })
       );
       testStore.dispatch(
         openModal({
+          id: "another-modal",
           component: "FinalizeBookingsDialog",
           props: finalizeBookingsProps,
         })

--- a/packages/client/src/features/modal/reducer.ts
+++ b/packages/client/src/features/modal/reducer.ts
@@ -13,23 +13,55 @@ const modalReducer: Reducer<ModalState, ModalReducerAction> = (
 ): ModalState => {
   switch (action.type) {
     // Add a modal to the top of the stack
-    case ModalAction.Open:
+    case ModalAction.Open: {
+      // Check if the modal already exists
+      const modalIndex = state.findIndex(({ id }) => id === action.payload.id);
+      if (modalIndex !== -1) {
+        console.warn(
+          "Modal to open already exists in the state.",
+          "This is a no-op, but it might not have been what you've indented, consider using 'updateModal' instead if you wish to update modal props",
+          "Updated modal",
+          action.payload
+        );
+        return state;
+      }
+
+      // If modal not already open, add it to the end of the stack
       return [...state, action.payload];
+    }
+
+    // Update the existing (open) modal
+    case ModalAction.Update: {
+      const modalIndex = state.findIndex(({ id }) => id === action.payload.id);
+
+      // If modal not found, exit silently
+      if (modalIndex === -1) {
+        return state;
+      }
+
+      const safeState = [...state];
+      safeState[modalIndex] = action.payload;
+      return safeState;
+    }
 
     // Remove the modal with specified id from the stack
-    case ModalAction.Close:
+    case ModalAction.Close: {
       return state.filter(({ id }) => id !== action.payload.id);
+    }
 
     // Pop the last modal from the stack
-    case ModalAction.Pop:
+    case ModalAction.Pop: {
       return state.slice(0, -1);
+    }
 
     // Empty the modal stack, effectively closing all of the modals
-    case ModalAction.CloseAll:
+    case ModalAction.CloseAll: {
       return [];
+    }
 
-    default:
+    default: {
       return state;
+    }
   }
 };
 

--- a/packages/client/src/features/modal/reducer.ts
+++ b/packages/client/src/features/modal/reducer.ts
@@ -12,12 +12,19 @@ const modalReducer: Reducer<ModalState, ModalReducerAction> = (
   action
 ): ModalState => {
   switch (action.type) {
+    // Add a modal to the top of the stack
     case ModalAction.Open:
       return [...state, action.payload];
 
+    // Remove the modal with specified id from the stack
     case ModalAction.Close:
+      return state.filter(({ id }) => id !== action.payload.id);
+
+    // Pop the last modal from the stack
+    case ModalAction.Pop:
       return state.slice(0, -1);
 
+    // Empty the modal stack, effectively closing all of the modals
     case ModalAction.CloseAll:
       return [];
 

--- a/packages/client/src/features/modal/types.ts
+++ b/packages/client/src/features/modal/types.ts
@@ -17,14 +17,14 @@ export interface BaseModalProps {
  * A type alias for whitelisted components to avoid typing `keyof typeof ...`
  * each time.
  */
-type WhitelistedComponents = keyof typeof componentWhitelist;
+export type WhitelistedComponents = keyof typeof componentWhitelist;
 
 /**
  * This contraption returns appropriate prop interace for specified
  * component. Provided that the component is in the whitelist of components
  * that can be rendered inside the Modal
  */
-type GetComponentProps<C extends WhitelistedComponents> = Omit<
+export type GetComponentProps<C extends WhitelistedComponents> = Omit<
   Parameters<typeof componentWhitelist[C]>[0],
   // Omit the 'onClose' handler as it is specified by the Modal component
   // and it shouldn't be stored in `modal` store state.
@@ -37,6 +37,7 @@ type GetComponentProps<C extends WhitelistedComponents> = Omit<
 export enum ModalAction {
   Open = "@@MODAL/OPEN",
   Close = "@@MODAL/CLOSE",
+  Pop = "@@MODAL/POP",
   CloseAll = "@@MODAL/CLOSE_ALL",
 }
 
@@ -48,6 +49,10 @@ export enum ModalAction {
  */
 type ModalStateMap = {
   [C in WhitelistedComponents]: {
+    /**
+     * A uuid of the modal (used later to close a specific modal or update props)
+     */
+    id: string;
     /**
      * Component to render inside the modal component.
      */
@@ -72,10 +77,11 @@ export type ModalPayload<
 export type ModalState = ModalPayload[];
 
 // There are only two variants to this type. If number of variants gets bigger,
-// it can be extended to more generic types/lookups
+// it can be extended to more generic types/lookup
 export type ModalReducerAction =
   | {
-      type: ModalAction.Close | ModalAction.CloseAll;
+      type: ModalAction.Pop | ModalAction.CloseAll;
     }
+  | { type: ModalAction.Close; payload: Pick<ModalPayload, "id"> }
   | { type: ModalAction.Open; payload: ModalPayload };
 // #endregion Redux

--- a/packages/client/src/features/modal/types.ts
+++ b/packages/client/src/features/modal/types.ts
@@ -36,6 +36,7 @@ export type GetComponentProps<C extends WhitelistedComponents> = Omit<
 // #region Redux
 export enum ModalAction {
   Open = "@@MODAL/OPEN",
+  Update = "@@MODAL/UPDATE",
   Close = "@@MODAL/CLOSE",
   Pop = "@@MODAL/POP",
   CloseAll = "@@MODAL/CLOSE_ALL",
@@ -83,5 +84,5 @@ export type ModalReducerAction =
       type: ModalAction.Pop | ModalAction.CloseAll;
     }
   | { type: ModalAction.Close; payload: Pick<ModalPayload, "id"> }
-  | { type: ModalAction.Open; payload: ModalPayload };
+  | { type: ModalAction.Open | ModalAction.Update; payload: ModalPayload };
 // #endregion Redux

--- a/packages/client/src/features/modal/useModal.ts
+++ b/packages/client/src/features/modal/useModal.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from "react";
+import { useDispatch } from "react-redux";
+import { v4 as uuid } from "uuid";
+import { isEqual } from "lodash";
+
+import { WhitelistedComponents, GetComponentProps } from "./types";
+
+import { closeModal, openModal, updateModal } from "./actions";
+
+/**
+ * A function used to create a 'useModal' hook. We pass the `component` as a param
+ * into the factory (as `component` shouldn't really change) throughout the lifetime of the hook.
+ *
+ * The hook handles opening of the modal with appropriate props and propagating the props update to the
+ * modal open in store. The opening and closing is handled through methods returned from the hook.
+ *
+ * The props (for the modal to render) are passed either as a parameter to the hook call or though
+ * `openWithProps` method.
+ *
+ * _note: props passed through `openWithProps` are passed imperatively to the open modal, while props passed
+ * in hook call automaticaly pass updates to the component when the underlaying props get updated._
+ * @example
+ * ```
+ * const useModal = createModal("some-whitelisted-component")
+ * const { open, close, openWithProps } = useModal(initialProps)
+ *
+ * // open the modal with 'initialProps' passed to the rendered modal component
+ * open()
+
+ * // close the modal
+ * close()
+
+ * // open the modal with 'differentProps' passed to the rendered modal component
+ * openWithProps(differentProps)
+ * ```
+ * @param component
+ * @returns
+ */
+export const createModal = <C extends WhitelistedComponents>(component: C) => {
+  const id = uuid();
+
+  return (props?: GetComponentProps<C>) => {
+    // Keep track of last prop update in odred to do deep comparison
+    // of props and dispatch 'updateModal' only when the props aren't deeply equal
+    const lastUpdate = useRef<GetComponentProps<C> | undefined>();
+
+    const dispatch = useDispatch();
+
+    // Update props of the modal in store (only if open)
+    useEffect(() => {
+      if (!props) {
+        return;
+      }
+      // If updated props are the same as last update
+      // don't propagate any updates
+      if (isEqual(props, lastUpdate.current)) {
+        return;
+      }
+      dispatch(updateModal({ id, component, props }));
+      lastUpdate.current = props;
+    }, [props]);
+
+    const open = () => {
+      if (!props) {
+        console.warn(
+          "Trying to open a modal without the props passed in. Pass the props to hook call, or use 'openWithProps' to pass props explicitly." +
+            ` Opening dialog with component: ${component}`
+        );
+        return;
+      }
+      dispatch(openModal({ id, component, props }));
+    };
+    const openWithProps = (props: GetComponentProps<C>) => {
+      dispatch(openModal({ id, component, props }));
+    };
+    const close = () => {
+      dispatch(closeModal(id));
+    };
+
+    return {
+      open,
+      openWithProps,
+      close,
+    };
+  };
+};

--- a/packages/client/src/pages/customer_area/views/Book.tsx
+++ b/packages/client/src/pages/customer_area/views/Book.tsx
@@ -14,9 +14,8 @@ import { getCalendarDay } from "@/store/selectors/app";
 
 import { bookInterval } from "@/store/actions/bookingOperations";
 
-import { openModal } from "@/features/modal/actions";
-
 import { getSecretKey } from "@/utils/localStorage";
+import { createModal } from "@/features/modal/useModal";
 
 const BookView: React.FC = () => {
   const daysToRender = useSelector(getSlotsForBooking);
@@ -52,6 +51,8 @@ const BookView: React.FC = () => {
 const useBooking = () => {
   const dispatch = useDispatch();
 
+  const { openWithProps: openCancelBookingDialog } = useCancelBookingModal();
+
   return {
     handleBooking:
       ({ date, id: slotId }: SlotInterface) =>
@@ -65,14 +66,14 @@ const useBooking = () => {
 
       const [startTime, endTime] = interval.split("-");
 
-      dispatch(
-        openModal({
-          component: "CancelBookingDialog",
-          props: { ...slot, interval: { startTime, endTime } },
-        })
-      );
+      openCancelBookingDialog({
+        ...slot,
+        interval: { startTime, endTime },
+      });
     },
   };
 };
+
+const useCancelBookingModal = createModal("CancelBookingDialog");
 
 export default BookView;

--- a/packages/client/src/pages/customer_area/views/Calendar.tsx
+++ b/packages/client/src/pages/customer_area/views/Calendar.tsx
@@ -13,11 +13,12 @@ import {
   getIsBookingAllowed,
   getBookedAndAttendedSlotsForCalendar,
 } from "@/store/selectors/bookings";
-import { openModal } from "@/features/modal/actions";
 import { getCalendarDay } from "@/store/selectors/app";
 import { updateBookingNotes } from "@/store/actions/bookingOperations";
 
 import { getSecretKey } from "@/utils/localStorage";
+import { createModal } from "@/features/modal/useModal";
+import { ModalPayload } from "@/features/modal/types";
 
 const CalendarView: React.FC = () => {
   const { dispatch, getState } = useStore();
@@ -33,16 +34,12 @@ const CalendarView: React.FC = () => {
     ? IntervalCardState.Disabled
     : IntervalCardState.Default;
 
+  const { openWithProps: openCancelBookingDialog } = useCancelBookingModal();
+
   const handleCancellation = (
-    props: Parameters<typeof openModal>[0]["props"]
-  ) => {
-    dispatch(
-      openModal({
-        component: "CancelBookingDialog",
-        props,
-      })
-    );
-  };
+    props: ModalPayload<"CancelBookingDialog">["props"]
+  ) => openCancelBookingDialog(props);
+
   const handleNotesUpdate = (bookingNotes: string, slotId: string) =>
     // In order to be able to await this update, we're
     // using a bit of a different approach to firing a thunk
@@ -76,5 +73,7 @@ const CalendarView: React.FC = () => {
     <EmptySpace>{i18n.t(Alerts.NoBookings, { currentDate })}</EmptySpace>
   );
 };
+
+const useCancelBookingModal = createModal("CancelBookingDialog");
 
 export default CalendarView;

--- a/packages/client/src/pages/customers/index.tsx
+++ b/packages/client/src/pages/customers/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useSelector, useDispatch } from "react-redux";
+import { useSelector } from "react-redux";
 
 import Fab from "@mui/material/Fab";
 import Grid from "@mui/material/Grid";
@@ -32,19 +32,17 @@ import { getDefaultCountryCode } from "@/store/selectors/orgInfo";
 import useTitle from "@/hooks/useTitle";
 import { useFirestoreSubscribe } from "@eisbuk/react-redux-firebase-firestore";
 
-import { openModal } from "@/features/modal/actions";
-
 import { isEmpty } from "@/utils/helpers";
 import { getNewSubscriptionNumber } from "./utils";
 
 import { adminLinks } from "@/data/navigation";
 import { DateTime } from "luxon";
 import { __organization__ } from "@/lib/constants";
+import { createModal } from "@/features/modal/useModal";
 
 const CustomersPage: React.FC = () => {
   const { t } = useTranslation();
   const classes = useStyles();
-  const dispatch = useDispatch();
 
   const defaultDialCode = useSelector(getDefaultCountryCode);
 
@@ -62,17 +60,17 @@ const CustomersPage: React.FC = () => {
     useSelector(getAboutOrganization)[__organization__] || {};
   useFirestoreSubscribe([OrgSubCollection.Customers]);
 
+  const { openWithProps: openCustomerForm } = useCustomerFormModal();
+
   const handleAddAthlete = () => {
     // Get next subscription number to start the customer form
     // it can still be updated in the form if needed
     const subscriptionNumber = getNewSubscriptionNumber(customers);
 
-    dispatch(
-      openModal({
-        component: "CustomerFormDialog",
-        props: { customer: { subscriptionNumber }, defaultDialCode },
-      })
-    );
+    openCustomerForm({
+      customer: { subscriptionNumber },
+      defaultDialCode,
+    });
   };
 
   /** @TODO update below when we create `isEmpty` and `isLoaded` helpers */
@@ -105,6 +103,8 @@ const CustomersPage: React.FC = () => {
     </Layout>
   );
 };
+
+const useCustomerFormModal = createModal("CustomerFormDialog");
 
 const useStyles = makeStyles((theme: ETheme) => ({
   headerHero: {

--- a/packages/e2e/integration/athlete_grid_spec.ts
+++ b/packages/e2e/integration/athlete_grid_spec.ts
@@ -1,64 +1,30 @@
 import { PrivateRoutes } from "../temp";
 
-/** @TEMP test ids, @TODO replace these with aria-labels if at all possible and use the single source of truth */
-const __customerDeleteId__ = "customer-delete-button";
-const __customerEditId__ = "customer-edit-button";
-const __create100Athletes__ = "create-athletes";
-const __debugButtonId__ = "debug-button";
-const __customersGridId__ = "customer-grid";
-const __confirmDialogYesId__ = "confirm-dialog-yes-button";
-const __customersDialogId__ = "customer-dialog";
-/** @TEMP */
-
-xdescribe("athletes grid", () => {
+describe("athletes grid", () => {
   beforeEach(() => {
     // Initialize app, create default user,
     // create default organization, sign in as admin
-    // cy.intercept("POST", "http://localhost:5001/eisbuk/europe-west6/createTestData", { result: { success: true } }).as('createTestData')
-    cy.initAdminApp();
-    cy.visit(PrivateRoutes.Athletes);
-    cy.getAttrWith("data-testid", __debugButtonId__).click();
-    cy.getAttrWith("data-testid", __create100Athletes__).click();
-    cy.wait("@createTestData");
-  });
-  it("should click the athlete to open a dialog", () => {
-    cy.getAttrWith("data-testid", __customersGridId__)
-      .children()
-      .first()
-      .click();
-    cy.getAttrWith("data-testid", __customersDialogId__);
-  });
-});
-
-xdescribe("button actions", () => {
-  beforeEach(() => {
-    // Initialize app, create default user,
-    // create default organization, sign in as admin
-    cy.initAdminApp();
-    cy.visit(PrivateRoutes.Athletes);
-    cy.getAttrWith("data-testid", __debugButtonId__).click();
-    cy.getAttrWith("data-testid", __create100Athletes__).click();
-    // cy.intercept("http://localhost:5001/eisbuk/europe-west6/createTestData", { result: { success: true } }).as('createTestData')
-    // cy.wait('@createTestData')
+    cy.initAdminApp()
+      .then((organization) =>
+        cy.updateFirestore(organization, ["customers.json"])
+      )
+      .then(() => cy.signIn())
+      .then(() => cy.visit(PrivateRoutes.Athletes));
   });
 
-  it("should delete an athlete and check for dialog closing", () => {
-    cy.getAttrWith("data-testid", __customersGridId__)
-      .children()
-      .first()
-      .click();
-    cy.getAttrWith("data-testid", __customerDeleteId__).click();
-    cy.getAttrWith("data-testid", __confirmDialogYesId__).click();
-    cy.getAttrWith("data-testid", __customersDialogId__).should("not.exist");
+  it("opens CustomerCard modal with the customer on customer click and closes on close button click", () => {
+    cy.contains("Saul").click();
+    cy.getAttrWith("aria-label", "customer-dialog");
+    cy.getAttrWith("aria-label", "close-button").click();
+    cy.getAttrWith("aria-label", "customer-dialog").should("not.exist");
   });
-  it("should edit an athlete and check for dialog closing", () => {
-    cy.getAttrWith("data-testid", __customersGridId__)
-      .children()
-      .first()
-      .click();
-    cy.getAttrWith("data-testid", __customerEditId__).click();
-    cy.getAttrWith("value", "competitive").check();
+
+  it("updates CustomerCard modal when customer gets updated", () => {
+    cy.contains("Saul").click();
+    cy.getAttrWith("aria-label", "edit").click();
+    cy.getAttrWith("name", "phone").clearAndType("1111 111");
+    cy.getAttrWith("name", "name").clearAndType("Jimmy");
     cy.getAttrWith("type", "submit").click();
-    cy.getAttrWith("data-testid", __customersDialogId__).should("not.exist");
+    cy.getAttrWith("aria-label", "customer-dialog").contains("Jimmy");
   });
 });

--- a/packages/e2e/integration/attendance_spec.ts
+++ b/packages/e2e/integration/attendance_spec.ts
@@ -1,0 +1,50 @@
+import { DateTime } from "luxon";
+import { PrivateRoutes } from "../temp";
+
+import { customers } from "../__testData__/customers.json";
+
+describe("AddAttendedCustomersDialog", () => {
+  beforeEach(() => {
+    // Initialize app, create default user,
+    // create default organization, sign in as admin
+    cy.initAdminApp()
+      .then((organization) =>
+        // Load test data into firestore
+        cy.updateFirestore(organization, ["customers.json", "slots.json"])
+      )
+      .then(() => cy.signIn())
+      .then(() =>
+        // Our test slot's date is "2022-01-01" so we want to set the clock to that date to open it immediately
+        cy.setClock(DateTime.fromISO("2022-01-01").toMillis())
+      )
+      .then(() => cy.visit(PrivateRoutes.Root));
+  });
+
+  it("Adds attended athletes from eligible (by slot category) althetes from the list", () => {
+    cy.getAttrWith("aria-label", "add-athletes").click();
+    cy.getAttrWith("aria-label", "add-athletes-dialog");
+
+    // Add customer
+    cy.contains("Saul").click();
+
+    // Saul should be added to the attendance card as having attended
+    cy.getAttrWith("aria-label", "attendance-card").contains("Saul");
+    // Saul should be removed from the add-athletes-dialog (as it's already marked as attended)
+    cy.getAttrWith("aria-label", "add-athletes-dialog")
+      .contains("Saul")
+      .should("not.exist");
+  });
+
+  it("closes the add-athletes-dialog when there are no more customers to show", () => {
+    cy.getAttrWith("aria-label", "add-athletes").click();
+    cy.getAttrWith("aria-label", "add-athletes-dialog");
+
+    // Add all customers
+    Object.values(customers).forEach(({ name }) => {
+      cy.contains(name).click();
+    });
+
+    // All customers are added, add-athletes-dialog should automatically close
+    cy.getAttrWith("aria-label", "add-athletes-dialog").should("not.exist");
+  });
+});


### PR DESCRIPTION
Allows for a modal component to get updated by outside change. Instead of dispatching `openModal` we're using `useModal` hook, passing the props to the hook (the updates to props get automatically propagated to the modal component), and firing `open` to open the modal, or simply firing `openWithProps` to set the modal component props directly (for modals which won't get updated by outside change, e.g. confirmation dialogs, etc.)

**Example 1 (automatic update)**
```typescript
const useModal = createModal("modal-component-name")

// In parent component
const { open } = useModal(componentProps)

// open modal on some action/state update
open()
```

**Example 2 (explicit props set)**
```typescript
const useModal = createModal("modal-component-name")

// In parent component
const { openWithProps } = useModal()

// open the modal with props explicitly set
openWithProps(modalProps)
```