### PR TITLE
Fix duplicate entries for 'emailTemplate(s)'

### DIFF
--- a/packages/client/src/pages/admin_preferences/index.tsx
+++ b/packages/client/src/pages/admin_preferences/index.tsx
@@ -137,7 +137,7 @@ const emptyValues = {
   displayName: "",
   emailFrom: "",
   emailNameFrom: "",
-  emailTemplate: defaultEmailTemplates,
+  emailTemplates: defaultEmailTemplates,
   existingSecrets: [],
   location: "",
   defaultCountryCode: "",
@@ -180,7 +180,7 @@ const emailFields: FormSectionFieldProps[] = [
     label: i18n.t(OrganizationLabel.BCC),
   },
   {
-    name: "emailTemplate",
+    name: "emailTemplates",
     label: i18n.t(OrganizationLabel.EmailTemplate),
     multiline: true,
     rows: 6,


### PR DESCRIPTION
The recent implementation features `emailTemplates` field in organization preferences. The UI hasn't been created yet, the current UI for `admin_preferences` features a field named `emailTemplate`. Saving the organization that way creates a duplicate entry that way (both `emailTemplate` as well as `emailTemplates`). This is a quick fix until the email templates UI is developed.