### PR TITLE
Enable passing of 'multiline' to the FormField

### DIFF
--- a/packages/ui/src/Forms/FormField.tsx
+++ b/packages/ui/src/Forms/FormField.tsx
@@ -51,7 +51,6 @@ const FormField: React.FC<FormFieldProps> = ({
   name = "",
   label,
   variant,
-  helpText,
   Icon,
   width = FormFieldWitdh.SM,
   disabled: propsDisabled,
@@ -66,25 +65,26 @@ const FormField: React.FC<FormFieldProps> = ({
   const disabled =
     propsDisabled || sectionDisabled || disabledFields.includes(name);
 
+  // We're optionally adding these props (if they're defined) as we
+  // don't want to get: "React doesn't recognize the following props on a DOM element" error
+  const additionalProps = {
+    ...(Icon && {
+      StartAdornment: (
+        <IconAdornment Icon={<Icon />} position="start" disabled={disabled} />
+      ),
+    }),
+  };
+
   return (
     <div className={width}>
       <Field
+        {...props}
+        {...additionalProps}
         name={name}
         label={label}
         component={componentLookup[variant]}
         type={typeLookup[variant]}
-        StartAdornment={
-          Icon && (
-            <IconAdornment
-              Icon={<Icon />}
-              position="start"
-              disabled={disabled}
-            />
-          )
-        }
         disabled={disabled}
-        helpText={helpText}
-        defauldDialCode={(props as PhoneInputProps).defaultDialCode}
       />
     </div>
   );

--- a/packages/ui/src/TextInput/TextInput.tsx
+++ b/packages/ui/src/TextInput/TextInput.tsx
@@ -54,6 +54,10 @@ const TextInput: React.FC<TextInputFieldProps> = ({
 
   const inputElement = multiline ? "textarea" : "input";
 
+  const adornmentClasses = `flex mr-1 ${
+    multiline ? "items-start my-3" : "items-center"
+  }`;
+
   return (
     <div className={["space-y-1", className].join(" ")}>
       <label htmlFor={name} className={labelClasses}>
@@ -61,7 +65,7 @@ const TextInput: React.FC<TextInputFieldProps> = ({
       </label>
       <div className={containerClasses}>
         {StartAdornment && (
-          <div className="flex items-center mr-1">{StartAdornment}</div>
+          <div className={adornmentClasses}>{StartAdornment}</div>
         )}
 
         {React.createElement(inputElement, {
@@ -75,9 +79,7 @@ const TextInput: React.FC<TextInputFieldProps> = ({
           ...rest,
         })}
 
-        {EndAdornment && (
-          <div className="flex items-center ml-1">{EndAdornment}</div>
-        )}
+        {EndAdornment && <div className={adornmentClasses}>{EndAdornment}</div>}
       </div>
       <p className={helpTextClasses}>{!disabled && supportContent}</p>
     </div>


### PR DESCRIPTION
Enables passing of `multiline` and `rows` props to the `FormField` component (propagating those props to rendered `TextInput`)

Additionally, places a start adornment icon (in `TextInput`) to the top left corner in case of `multiline` variant (instead of center)