### PR TITLE
Link to customer profile from customer list items:

### DIFF
--- a/packages/client/src/__testData__/testIds.ts
+++ b/packages/client/src/__testData__/testIds.ts
@@ -60,7 +60,3 @@ export const __create100Athletes__ = "create-athletes";
 // #region notificationButton
 export const __notificationButton__ = "notification-button";
 // #endregion notificationButton
-
-// #region birthdayBadge
-export const __birthdayMenu__ = "birthday-menu";
-// #endregion birthdayBadge

--- a/packages/client/src/__tests__/cloudFunctions.test.ts
+++ b/packages/client/src/__tests__/cloudFunctions.test.ts
@@ -176,7 +176,7 @@ describe("Cloud functions", () => {
       }
     );
 
-    test("should reject if no recipient provided", async () => {
+    testWithEmulator("should reject if no recipient provided", async () => {
       const { organization } = await setUpOrganization();
       const payload = {
         type: EmailType.SendBookingsLink,

--- a/packages/client/src/components/atoms/AttendanceCard/AttendanceCard.tsx
+++ b/packages/client/src/components/atoms/AttendanceCard/AttendanceCard.tsx
@@ -11,7 +11,12 @@ import AddNew from "@mui/icons-material/AddCircle";
 import makeStyles from "@mui/styles/makeStyles";
 
 import { CustomerFull, SlotInterface } from "@eisbuk/shared";
-import i18n, { CategoryLabel, SlotTypeLabel } from "@eisbuk/translations";
+import i18n, {
+  AdminAria,
+  CategoryLabel,
+  SlotTypeLabel,
+  useTranslation,
+} from "@eisbuk/translations";
 
 import { CustomerWithAttendance } from "@/types/components";
 
@@ -28,8 +33,8 @@ import { createModal } from "@/features/modal/useModal";
 
 import { getSlotTimespan } from "@/utils/helpers";
 import { comparePeriods } from "@/utils/sort";
-
-import { __addCustomersButtonId__ } from "./__testData__/testIds";
+import { Link } from "react-router-dom";
+import { PrivateRoutes } from "@/enums/routes";
 
 export interface Props extends SlotInterface {
   /**
@@ -63,6 +68,7 @@ const AttendanceCard: React.FC<Props> = ({ allCustomers, ...slot }) => {
 
   const classes = useStyles();
   const dispatch = useDispatch();
+  const { t } = useTranslation();
 
   const timeString = getSlotTimespan(intervals);
 
@@ -143,20 +149,22 @@ const AttendanceCard: React.FC<Props> = ({ allCustomers, ...slot }) => {
       {attendedCustomers.map(
         (customer) =>
           customer.bookedInterval && (
-            <UserAttendance
-              {...customer}
-              key={customer.id}
-              intervals={orderedIntervals}
-              markAttendance={({ attendedInterval }) =>
-                dispatch(
-                  createAttendanceThunk({
-                    attendedInterval,
-                    customerId: customer.id,
-                  })
-                )
-              }
-              markAbsence={() => dispatch(createAbsenceThunk(customer.id))}
-            />
+            <Link to={`${PrivateRoutes.Athletes}/${customer.id}`}>
+              <UserAttendance
+                {...customer}
+                key={customer.id}
+                intervals={orderedIntervals}
+                markAttendance={({ attendedInterval }) =>
+                  dispatch(
+                    createAttendanceThunk({
+                      attendedInterval,
+                      customerId: customer.id,
+                    })
+                  )
+                }
+                markAbsence={() => dispatch(createAbsenceThunk(customer.id))}
+              />
+            </Link>
           )
       )}
       <Divider className={classes.thickerDivider} />
@@ -180,10 +188,9 @@ const AttendanceCard: React.FC<Props> = ({ allCustomers, ...slot }) => {
           )
       )}
       <IconButton
-        aria-label="add-athletes"
+        aria-label={t(AdminAria.AddAttendedCustomers)}
         className={classes.addCustomersButton}
         onClick={openAddCustomers}
-        data-testid={__addCustomersButtonId__}
         size="large"
       >
         <AddNew />

--- a/packages/client/src/components/atoms/AttendanceCard/UserAttendance.tsx
+++ b/packages/client/src/components/atoms/AttendanceCard/UserAttendance.tsx
@@ -1,11 +1,14 @@
 import React, { useState, useEffect } from "react";
 import { useTranslation } from "@eisbuk/translations";
+import { Link } from "react-router-dom";
 
 import ListItem from "@mui/material/ListItem";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 
 import makeStyles from "@mui/styles/makeStyles";
+
+import { PrivateRoutes } from "@/enums/routes";
 
 import { CustomerWithAttendance } from "@/types/components";
 
@@ -165,37 +168,39 @@ const UserAttendance: React.FC<Props> = ({
   ].join(" ");
 
   return (
-    <ListItem style={{}} className={listItemClass}>
-      <div className={classes.avatarContainer}>
-        <EisbukAvatar {...customer} />
-        <Typography style={{ margin: "0 0.75rem" }}>
-          {customerString}
-        </Typography>
-      </div>
-      <div className={buttonContainerClasses}>
-        <Button
-          className={buttonClasses}
-          data-testid={__attendanceButton__}
-          variant="contained"
-          size="small"
-          onClick={handleClick}
-          disabled={disableButton}
-          style={{ justifySelf: "end" }}
-        >
-          {localAttended ? attendanceButton : absenceButton}
-        </Button>
-      </div>
-      <div className={intervalContainerClasses}>
-        <IntervalPicker
-          disabled={!localAttended}
-          intervals={intervals}
-          attendedInterval={selectedInterval}
-          bookedInterval={bookedInterval}
-          onChange={handleIntervalChange}
-          style={{ justifySelf: "center" }}
-        />
-      </div>
-    </ListItem>
+    <Link to={`${PrivateRoutes.Athletes}/${customer.id}`}>
+      <ListItem style={{}} className={listItemClass}>
+        <div className={classes.avatarContainer}>
+          <EisbukAvatar {...customer} />
+          <Typography style={{ margin: "0 0.75rem" }}>
+            {customerString}
+          </Typography>
+        </div>
+        <div className={buttonContainerClasses}>
+          <Button
+            className={buttonClasses}
+            data-testid={__attendanceButton__}
+            variant="contained"
+            size="small"
+            onClick={handleClick}
+            disabled={disableButton}
+            style={{ justifySelf: "end" }}
+          >
+            {localAttended ? attendanceButton : absenceButton}
+          </Button>
+        </div>
+        <div className={intervalContainerClasses}>
+          <IntervalPicker
+            disabled={!localAttended}
+            intervals={intervals}
+            attendedInterval={selectedInterval}
+            bookedInterval={bookedInterval}
+            onChange={handleIntervalChange}
+            style={{ justifySelf: "center" }}
+          />
+        </div>
+      </ListItem>
+    </Link>
   );
 };
 

--- a/packages/client/src/components/atoms/AttendanceCard/__testData__/testIds.ts
+++ b/packages/client/src/components/atoms/AttendanceCard/__testData__/testIds.ts
@@ -2,6 +2,4 @@ export const __attendanceButton__ = "attendance-button";
 export const __prevIntervalButtonId__ = "prev-interval-button";
 export const __nextIntervalButtonId__ = "next-interval-button";
 
-export const __addCustomersButtonId__ = "add-customers-button";
 export const __addCustomersDialogId__ = "add-customers-dialog";
-export const __closeCustomersListId__ = "close-customers-list";

--- a/packages/client/src/components/atoms/AttendanceCard/__tests__/AttendanceCard.test.tsx
+++ b/packages/client/src/components/atoms/AttendanceCard/__tests__/AttendanceCard.test.tsx
@@ -3,11 +3,15 @@
  */
 
 import React from "react";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { Customer, SlotInterface } from "@eisbuk/shared";
-import i18n, { CategoryLabel, SlotTypeLabel } from "@eisbuk/translations";
+import i18n, {
+  AdminAria,
+  CategoryLabel,
+  SlotTypeLabel,
+} from "@eisbuk/translations";
 
 import "@/__testSetup__/firestoreSetup";
 
@@ -20,12 +24,12 @@ import * as attendanceOperations from "@/store/actions/attendanceOperations";
 import { comparePeriods } from "@/utils/sort";
 
 import { testWithEmulator } from "@/__testUtils__/envUtils";
+import { renderWithRouter } from "@/__testUtils__/wrappers";
 
 import { baseAttendanceCard, intervals } from "@/__testData__/attendance";
 import { gus, saul, walt } from "@/__testData__/customers";
 import { baseSlot } from "@/__testData__/slots";
 import {
-  __addCustomersButtonId__,
   __attendanceButton__,
   __nextIntervalButtonId__,
   __prevIntervalButtonId__,
@@ -104,7 +108,7 @@ describe("AttendanceCard", () => {
 
   describe("Smoke test", () => {
     test("should render proper values passed from props", () => {
-      render(
+      renderWithRouter(
         <AttendanceCard
           {...baseAttendanceCard}
           customers={[saul as CustomerWithAttendance]}
@@ -129,7 +133,7 @@ describe("AttendanceCard", () => {
 
   describe("Test marking attendance functionality", () => {
     test("should update local state immediately on button click", () => {
-      render(
+      renderWithRouter(
         <AttendanceCard
           {...baseAttendanceCard}
           customers={[{ ...saul, bookedInterval, attendedInterval: null }]}
@@ -145,7 +149,7 @@ describe("AttendanceCard", () => {
     });
 
     test("should dispatch 'markAttendance' on attendance button click if `attended = null` (and default to booked interval if no interval was specified)", () => {
-      render(
+      renderWithRouter(
         <AttendanceCard
           {...baseAttendanceCard}
           customers={[{ ...saul, bookedInterval, attendedInterval: null }]}
@@ -162,7 +166,7 @@ describe("AttendanceCard", () => {
     });
 
     test("should dispatch 'markAbsence' on attendance button click if `attended != null`", () => {
-      render(
+      renderWithRouter(
         <AttendanceCard
           {...baseAttendanceCard}
           customers={[{ ...saul, bookedInterval, attendedInterval }]}
@@ -178,7 +182,7 @@ describe("AttendanceCard", () => {
     });
 
     test("should disable attendance button while there's a discrepency between local attended and attended from firestore (boolean)", () => {
-      render(
+      renderWithRouter(
         <AttendanceCard
           {...baseAttendanceCard}
           customers={[{ ...saul, bookedInterval, attendedInterval }]}
@@ -193,7 +197,7 @@ describe("AttendanceCard", () => {
     });
 
     test("should disable attendance button while picking new interval - 'attendedInterval != selectedInterval' (this doesn't apply when 'attendedInterval = null'", () => {
-      render(
+      renderWithRouter(
         <AttendanceCard
           {...baseAttendanceCard}
           customers={[{ ...saul, bookedInterval, attendedInterval }]}
@@ -210,7 +214,7 @@ describe("AttendanceCard", () => {
 
   describe("Test interval picker ->", () => {
     beforeEach(() => {
-      render(
+      renderWithRouter(
         <AttendanceCard
           {...baseAttendanceCard}
           customers={[{ ...saul, bookedInterval, attendedInterval }]}
@@ -220,7 +224,7 @@ describe("AttendanceCard", () => {
 
     test("should show booked interval (if any) when the attended and booked interval are different", () => {
       cleanup();
-      render(
+      renderWithRouter(
         <AttendanceCard
           {...baseAttendanceCard}
           customers={[
@@ -286,7 +290,7 @@ describe("AttendanceCard", () => {
 
   describe("Test debounce", () => {
     test("should only dispatch interval update once if changes are to close to each other", async () => {
-      render(
+      renderWithRouter(
         <AttendanceCard
           {...baseAttendanceCard}
           customers={[
@@ -350,9 +354,11 @@ describe("AttendanceCard", () => {
         ],
       };
 
-      render(<AttendanceCard {...attendanceCard} />);
+      renderWithRouter(<AttendanceCard {...attendanceCard} />);
 
-      screen.getByTestId(__addCustomersButtonId__).click();
+      screen
+        .getByLabelText(i18n.t(AdminAria.AddAttendedCustomers) as string)
+        .click();
       const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
       expect(dispatchCallPayload.component).toEqual(
         "AddAttendedCustomersDialog"
@@ -397,9 +403,9 @@ describe("AttendanceCard", () => {
           customers: [saulWithAttendandce],
           allCustomers: [],
         };
-        // we're rendering two views one to interact with one
+        // we're renderWithRoutering two views one to interact with one
         // for opservation of the updates
-        render(
+        renderWithRouter(
           <>
             <AttendanceCard {...testProps} />
             <AttendanceCard {...testProps} />

--- a/packages/client/src/components/atoms/BirthdayMenu/BirthdayMenu.tsx
+++ b/packages/client/src/components/atoms/BirthdayMenu/BirthdayMenu.tsx
@@ -9,6 +9,7 @@ import makeStyles from "@mui/styles/makeStyles";
 import {
   useTranslation,
   BirthdayMenu as BirthdayEnums,
+  AdminAria,
 } from "@eisbuk/translations";
 import { CustomersByBirthday } from "@eisbuk/shared";
 import { Cake } from "@eisbuk/svg";
@@ -17,8 +18,6 @@ import { Button } from "@eisbuk/ui";
 import BirthdayMenuItem from "./BirthdayMenuItem";
 
 import { createModal } from "@/features/modal/useModal";
-
-import { __birthdayMenu__ } from "@/__testData__/testIds";
 
 interface BirthdayMenuProps {
   customers: CustomersByBirthday[];
@@ -68,7 +67,7 @@ const BirthdayMenu: React.FC<BirthdayMenuProps> = ({ customers }) => {
         className={[classes.badge, "cursor-normal", "select-none"].join(" ")}
         color="error"
         badgeContent={getTodaysBirthdays}
-        data-testid={__birthdayMenu__}
+        aria-label={t(AdminAria.BirthdayMenu)}
       >
         <Button
           onClick={handleBirthdaysClick}

--- a/packages/client/src/components/atoms/BirthdayMenu/BirthdayMenuItem.tsx
+++ b/packages/client/src/components/atoms/BirthdayMenu/BirthdayMenuItem.tsx
@@ -1,8 +1,11 @@
 import React from "react";
 import { DateTime } from "luxon";
+import { Link } from "react-router-dom";
 
 import { Customer } from "@eisbuk/shared";
 import { DateFormat, useTranslation } from "@eisbuk/translations";
+
+import { PrivateRoutes } from "@/enums/routes";
 
 import EisbukAvatar from "@/components/users/EisbukAvatar";
 
@@ -21,11 +24,13 @@ const BirthdayMenuItem: React.FC<Props> = ({ customer, showAll = false }) => {
           date: DateTime.fromISO(customer.birthday || ""),
         });
   return (
-    <li className="p-4 flex gap-8 items-center">
-      <EisbukAvatar {...customer} wrap={false} />
-      {customer.name} {customer.surname}
-      {!showAll && <span className="block ml-auto">{customerBirthday}</span>}
-    </li>
+    <Link to={`${PrivateRoutes.Athletes}/${customer.id}`}>
+      <li className="p-4 flex gap-8 items-center">
+        <EisbukAvatar {...customer} wrap={false} />
+        {customer.name} {customer.surname}
+        {!showAll && <span className="block ml-auto">{customerBirthday}</span>}
+      </li>
+    </Link>
   );
 };
 

--- a/packages/client/src/components/atoms/BirthdayMenu/__tests__/BirthdayMenu.test.tsx
+++ b/packages/client/src/components/atoms/BirthdayMenu/__tests__/BirthdayMenu.test.tsx
@@ -3,12 +3,14 @@
  */
 
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { DateTime } from "luxon";
 
 import i18n, { BirthdayMenu as BirthdayMenuLabel } from "@eisbuk/translations";
 
 import BirthdayMenu from "../BirthdayMenu";
+
+import { renderWithRouter } from "@/__testUtils__/wrappers";
 
 import { saul, gus, jane, jian } from "@/__testData__/customers";
 
@@ -39,7 +41,7 @@ jest.mock("react-redux", () => ({
 describe("BirthdayMenu", () => {
   describe("Smoke test", () => {
     beforeEach(() => {
-      render(<BirthdayMenu customers={customers} />);
+      renderWithRouter(<BirthdayMenu customers={customers} />);
       jest.clearAllMocks();
     });
 

--- a/packages/client/src/features/modal/components/AddAttendedCustomersDialog/AddAttendedCustomersDialog.tsx
+++ b/packages/client/src/features/modal/components/AddAttendedCustomersDialog/AddAttendedCustomersDialog.tsx
@@ -6,11 +6,14 @@ import Typography from "@mui/material/Typography";
 import makeStyles from "@mui/styles/makeStyles";
 
 import { CustomerFull, SlotInterface } from "@eisbuk/shared";
-import i18n, { ActionButton } from "@eisbuk/translations";
+import i18n, {
+  ActionButton,
+  AdminAria,
+  useTranslation,
+} from "@eisbuk/translations";
 
 import { BaseModalProps } from "../../types";
 import IconButton from "@mui/material/IconButton";
-import { __closeCustomersListId__ } from "@/components/atoms/AttendanceCard/__testData__/testIds";
 import Close from "@mui/icons-material/Close";
 import CustomerList from "@/components/atoms/CustomerList";
 import { markAttendance } from "@/store/actions/attendanceOperations";
@@ -29,6 +32,7 @@ const AddAttendedCustomersDialog: React.FC<AddAttendedCustomersProps> = ({
   ...slot
 }) => {
   const dispatch = useDispatch();
+  const { t } = useTranslation();
 
   const { id: slotId } = slot;
   const handleCustomerClick = ({ id: customerId }: CustomerFull) => {
@@ -56,8 +60,8 @@ const AddAttendedCustomersDialog: React.FC<AddAttendedCustomersProps> = ({
       </Typography>
       <IconButton
         className={classes.closeButton}
+        aria-label={t(AdminAria.CloseModal)}
         onClick={() => onClose()}
-        data-testid={__closeCustomersListId__}
         size="large"
       >
         <Close />

--- a/packages/client/src/features/modal/components/AddAttendedCustomersDialog/__tests__/AddAttendedCustomersDialog.test.tsx
+++ b/packages/client/src/features/modal/components/AddAttendedCustomersDialog/__tests__/AddAttendedCustomersDialog.test.tsx
@@ -5,12 +5,13 @@
 import React from "react";
 import { screen, render, cleanup, waitFor } from "@testing-library/react";
 
+import i18n, { AdminAria } from "@eisbuk/translations";
+
 import AddAttendedCustomersDialog from "../AddAttendedCustomersDialog";
 import * as attendanceOperations from "@/store/actions/attendanceOperations";
 
 import { saul, walt } from "@/__testData__/customers";
 import { baseSlot } from "@/__testData__/slots";
-import { __closeCustomersListId__ } from "@/components/atoms/AttendanceCard/__testData__/testIds";
 
 const mockOnClose = jest.fn();
 // Mock markAttendance to a, sort of, identity function
@@ -48,7 +49,7 @@ describe("AddAttendedCustomersDialog", () => {
         {...{ ...baseSlot, defaultInterval }}
       />
     );
-    screen.getByTestId(__closeCustomersListId__).click();
+    screen.getByLabelText(i18n.t(AdminAria.CloseModal) as string).click();
     expect(mockOnClose).toHaveBeenCalled();
   });
 

--- a/packages/client/src/pages/admin_preferences/index.tsx
+++ b/packages/client/src/pages/admin_preferences/index.tsx
@@ -19,6 +19,8 @@ import {
   ButtonSize,
 } from "@eisbuk/ui";
 
+import { getOrganization } from "@/lib/getters";
+
 import AdminsField from "./AdminsField";
 import FormSection, {
   FormSectionFieldProps,
@@ -75,8 +77,6 @@ const OrganizationSettings: React.FC = () => {
     ...(organization as OrganizationData),
   };
 
-  const title = `${organization?.displayName || "Organization"}  Settings`;
-
   return (
     <Layout
       isAdmin
@@ -87,7 +87,9 @@ const OrganizationSettings: React.FC = () => {
       <div className="content-container pt-[44px] px-[71px] pb-8 md:pt-[62px]">
         <div className="pt-6 pb-8">
           <h1 className="text-2xl font-normal leading-none text-gray-700 cursor-normal select-none">
-            {title}
+            {t(OrganizationLabel.SettingsTitle, {
+              organization: getOrganization(),
+            })}
           </h1>
         </div>
         <Formik

--- a/packages/client/src/pages/athlete_profile/index.tsx
+++ b/packages/client/src/pages/athlete_profile/index.tsx
@@ -79,7 +79,7 @@ const AthleteProfilePage: React.FC = () => {
       <div className="content-container pt-[44px] px-[71px] pb-8 md:pt-[62px]">
         <CustomerForm.Admin
           onSave={handleSave}
-          onClose={() => history.push(PrivateRoutes.Athletes)}
+          onClose={() => history.goBack()}
           onDelete={() => {
             if (customer) {
               openDeleteCustomerDialog(customer);

--- a/packages/e2e/integration/attendance_spec.ts
+++ b/packages/e2e/integration/attendance_spec.ts
@@ -1,3 +1,4 @@
+import i18n, { AdminAria } from "@eisbuk/translations";
 import { DateTime } from "luxon";
 import { PrivateRoutes } from "../temp";
 
@@ -21,7 +22,10 @@ describe("AddAttendedCustomersDialog", () => {
   });
 
   it("Adds attended athletes from eligible (by slot category) althetes from the list", () => {
-    cy.getAttrWith("aria-label", "add-athletes").click();
+    cy.getAttrWith(
+      "aria-label",
+      i18n.t(AdminAria.AddAttendedCustomers) as string
+    ).click();
     cy.getAttrWith("aria-label", "add-athletes-dialog");
 
     // Add customer
@@ -36,7 +40,10 @@ describe("AddAttendedCustomersDialog", () => {
   });
 
   it("closes the add-athletes-dialog when there are no more customers to show", () => {
-    cy.getAttrWith("aria-label", "add-athletes").click();
+    cy.getAttrWith(
+      "aria-label",
+      i18n.t(AdminAria.AddAttendedCustomers) as string
+    ).click();
     cy.getAttrWith("aria-label", "add-athletes-dialog");
 
     // Add all customers

--- a/packages/e2e/integration/birthday_menu_spec.ts
+++ b/packages/e2e/integration/birthday_menu_spec.ts
@@ -1,12 +1,9 @@
+import i18n, { AdminAria } from "@eisbuk/translations";
 import { DateTime } from "luxon";
 
 import { __testDate__ } from "../constants";
 
 import { PrivateRoutes } from "../temp";
-
-/** @TEMP test ids, @TODO replace these with aria-labels if at all possible and use the single source of truth */
-const __birthdayMenu__ = "birthday-menu";
-/** @TEMP */
 
 describe("birthday badge", () => {
   beforeEach(() => {
@@ -15,19 +12,20 @@ describe("birthday badge", () => {
     });
     cy.signIn();
   });
-  it("should check for birthday menu rerendering on midnight", () => {
+
+  it("updates the birthday menu at midnight", () => {
     const time =
       DateTime.fromISO(__testDate__)
         .plus({ day: 1 })
         .startOf("day")
         .toMillis() - DateTime.fromISO(__testDate__).toMillis();
     cy.visit(PrivateRoutes.Root);
-    cy.getAttrWith("data-testid", __birthdayMenu__)
+    cy.getAttrWith("aria-label", i18n.t(AdminAria.BirthdayMenu) as string)
       .children()
       .eq(1)
       .should("have.text", 0);
     cy.tick(time);
-    cy.getAttrWith("data-testid", __birthdayMenu__)
+    cy.getAttrWith("aria-label", i18n.t(AdminAria.BirthdayMenu) as string)
       .children()
       .eq(1)
       .should("have.text", 1);

--- a/packages/e2e/integration/customer_profile_links_spec.ts
+++ b/packages/e2e/integration/customer_profile_links_spec.ts
@@ -1,0 +1,147 @@
+import i18n, {
+  ActionButton,
+  AdminAria,
+  BirthdayMenu,
+  CustomerFormTitle,
+  OrganizationLabel,
+} from "@eisbuk/translations";
+import { DateTime } from "luxon";
+import { getSlotTimespan, PrivateRoutes } from "temp";
+
+import { customers } from "../__testData__/customers.json";
+import { slots } from "../__testData__/slots.json";
+
+const { saul } = customers;
+
+describe("Test customer avatars linking to the respective customer profiles", () => {
+  it("links to the customer profile when clicking on a customer in /athletes page (and redirects back on 'back' click)", () => {
+    cy.initAdminApp().then((organization) => {
+      // We'll be needing the customer data for each test
+      return cy.updateFirestore(organization, ["customers.json", "slots.json"]);
+    });
+    cy.signIn();
+
+    // Click on saul's avatar in the athletes page
+    cy.visit(PrivateRoutes.Athletes);
+    cy.contains(saul.name).click();
+
+    // Check that we're in the customer profile page
+    cy.contains(
+      i18n.t(CustomerFormTitle.AthleteProfile, {
+        name: saul.name,
+        surname: saul.surname,
+      }) as string
+    );
+
+    // Click the 'back' button
+    cy.clickButton(i18n.t(ActionButton.Back));
+
+    // Check that we're back in the athletes page (by checking every customer being available on the screen)
+    Object.values(customers).forEach(({ name, surname }) => {
+      cy.contains(name);
+      cy.contains(surname);
+    });
+  });
+
+  it("links to the customer profile when clicking on a customer in attendance (\"/\") page (and redirects back on 'back' click)", () => {
+    cy.initAdminApp().then((organization) => {
+      // We'll be needing the customer data for each test
+      return cy.updateFirestore(organization, ["customers.json", "slots.json"]);
+    });
+
+    cy.signIn();
+    // Set clock to "2022-01-01" as there is a test slot on that date
+    cy.setClock(DateTime.fromISO("2022-01-01").toMillis()).then(() =>
+      cy.visit(PrivateRoutes.Root)
+    );
+
+    // Add saul as having attended the slot
+    cy.getAttrWith(
+      "aria-label",
+      i18n.t(AdminAria.AddAttendedCustomers) as string
+    ).click();
+    cy.contains(saul.name).click();
+
+    // Close the modal and click on saul to open his profile
+    cy.getAttrWith("aria-label", i18n.t(AdminAria.CloseModal)).click();
+    cy.contains(saul.name).click();
+
+    // Check that we're in the customer profile page
+    cy.contains(
+      i18n.t(CustomerFormTitle.AthleteProfile, {
+        name: saul.name,
+        surname: saul.surname,
+      }) as string
+    );
+
+    // Click the 'back' button
+    cy.clickButton(i18n.t(ActionButton.Back));
+
+    // Check that we're back on the attendance page (by querying for slot interval, displayed on attendance card)
+    cy.contains(getSlotTimespan(slots["slot-1"].intervals));
+  });
+
+  it("links to the customer profile when clicking on a customer on birthday menu (and redirects back to the given page on 'back' click)", () => {
+    let organization = "";
+    cy.initAdminApp().then((org) => {
+      // Update `organization` variable so we can use it in the test
+      organization = org;
+      // We'll be needing the customer data for each test
+      return cy.updateFirestore(org, ["customers.json", "slots.json"]);
+    });
+    cy.signIn();
+
+    // We wish to see saul in the birthday menu
+    cy.setClock(DateTime.fromISO(saul.birthday).toMillis()).then(() =>
+      // We're using Admin preferences page to test redirecting from and to
+      cy.visit(PrivateRoutes.AdminPreferences)
+    );
+
+    // Clicking on saul in the birthday menu should redirect to saul's customer profile
+    cy.getAttrWith(
+      "aria-label",
+      i18n.t(AdminAria.BirthdayMenu) as string
+    ).click();
+    cy.contains(saul.name).click();
+
+    // Check that we're in the customer profile page
+    cy.contains(
+      i18n.t(CustomerFormTitle.AthleteProfile, {
+        name: saul.name,
+        surname: saul.surname,
+      }) as string
+    );
+
+    // Click the 'back' button
+    cy.clickButton(i18n.t(ActionButton.Back));
+
+    // Check that we're back on the attendance page (by querying for slot interval, displayed on attendance card)
+    cy.contains(
+      i18n.t(OrganizationLabel.SettingsTitle, { organization }) as string
+    );
+
+    // Check again for saul in the birthday menu dialog
+    cy.getAttrWith(
+      "aria-label",
+      i18n.t(AdminAria.BirthdayMenu) as string
+    ).click();
+    cy.contains(i18n.t(BirthdayMenu.ShowAll) as string).click();
+    cy.contains(saul.name).click();
+
+    // Check that we're in the customer profile page
+    cy.contains(
+      i18n.t(CustomerFormTitle.AthleteProfile, {
+        name: saul.name,
+        surname: saul.surname,
+      }) as string
+    );
+
+    // Click the 'back' button
+    cy.clickButton(i18n.t(ActionButton.Back));
+
+    // Check that we're back on the attendance page (by querying for slot interval, displayed on attendance card)
+    cy.contains(
+      i18n.t(OrganizationLabel.SettingsTitle, { organization }) as string
+    );
+  });
+});

--- a/packages/e2e/temp.ts
+++ b/packages/e2e/temp.ts
@@ -3,10 +3,13 @@
  * This should be replaced with single-source-of-truth
  */
 
+import { SlotInterface, SlotInterval } from "@eisbuk/shared";
+
 /** */
 export enum Routes {
   Login = "/login",
   Unauthorized = "/unautorized",
+  SelfRegister = "/self_register",
   CustomerArea = "/customer_area",
   AttendancePrintable = "/attendance_printable",
   Debug = "/debug",
@@ -23,6 +26,7 @@ export enum CustomerRoute {
 export enum PrivateRoutes {
   Root = "/",
   Athletes = "/athletes",
+  NewAthlete = "/athletes/new",
   Slots = "/slots",
   AdminPreferences = "/admin_preferences",
 }
@@ -55,3 +59,31 @@ export const defaultUser = {
 
 export const __dayWithSlots__ = "day-with-slots";
 export const __dayWithBookedSlots__ = "day-with-booked-slots";
+
+/**
+ * Calculates the `startTime` of earliset interval and the `endTime` of latest interval,
+ * @param intervals a record of all intervals
+ * @returns a string representation of slot's timespan: `${startTime} - ${endTime}`
+ */
+export const getSlotTimespan = (
+  intervals: SlotInterface["intervals"]
+): string => {
+  // calculate single { startTime, endTime } object
+  const { startTime, endTime } = Object.values(intervals).reduce(
+    (acc, interval) => {
+      const startTime =
+        !acc.startTime || acc.startTime > interval.startTime
+          ? interval.startTime
+          : acc.startTime;
+      const endTime =
+        !acc.endTime || acc.endTime < interval.endTime
+          ? interval.endTime
+          : acc.endTime;
+
+      return { startTime, endTime };
+    },
+    {} as SlotInterval
+  );
+  // return time string
+  return `${startTime} - ${endTime}`;
+};

--- a/packages/translations/src/dict/en.json
+++ b/packages/translations/src/dict/en.json
@@ -121,6 +121,7 @@
   },
 
   "OrganizationLabel": {
+    "SettingsTitle": "{{ organization }} Settings",
     "EmailNameFrom": "Email Name From",
     "EmailFrom": "Email From",
     "EmailTemplate": "Email Template",
@@ -280,7 +281,10 @@
     "CopiedSlotsDayBadge": "Copied slots on {{ date, EEEE d MMMM }}",
     "PasteSlots": "Paste copied slots on {{ date, EEEE d MMMM }}",
     "CreateSlots": "Create new slots on",
-    "EnableEdit": "Enable Edit"
+    "EnableEdit": "Enable Edit",
+    "AddAttendedCustomers": "Add attended customers",
+    "CloseModal": "Close the modal",
+    "BirthdayMenu": "See upcomming birthdays"
   },
 
   "SlotFormAria": {

--- a/packages/translations/src/dict/it.json
+++ b/packages/translations/src/dict/it.json
@@ -121,6 +121,7 @@
   },
 
   "OrganizationLabel": {
+    "SettingsTitle": "{{ organization }} Impostazioni",
     "EmailNameFrom": "Nome Email Da",
     "EmailFrom": "Email Da",
     "EmailTemplate": "Modello Di Email",
@@ -276,11 +277,14 @@
     "ToggleSlotOperations": "Visualizza pulsanti per modificare gli slot.",
     "CopySlotsWeek": "Copia slot dalla settimana {{ weekStart, EEEE d MMMM }} a {{ weekEnd, EEEE d MMMM }}",
     "CopySlotsDay": "Copia slot da {{ date, EEEE d MMMM }}",
-    "CopiedSlotsWeekBadge": "Slot copiati {{ weekStart, EEEE d MMMM }}}} - {{ weekEnd, EEEE d MMMM }}}}",
+    "CopiedSlotsWeekBadge": "Slot copiati {{ weekStart, EEEE d MMMM }}} - {{ weekEnd, EEEE d MMMM }}}}",
     "CopiedSlotsDayBadge": "Slot copiati {{ date, EEEE d MMMM }}}}",
     "PasteSlots": "Incolla slot {{ date, EEEE d MMMM }}}}",
     "CreateSlots": "Crea nuovo slot",
-    "EnableEdit": "Abilita la modifica"
+    "EnableEdit": "Abilita la modifica",
+    "AddAttendedCustomers": "Aggiungi clienti presenti",
+    "CloseModal": "Close the modal",
+    "BirthdayMenu": "See upcomming birthdays"
   },
 
   "SlotFormAria": {

--- a/packages/translations/src/translations.ts
+++ b/packages/translations/src/translations.ts
@@ -141,6 +141,7 @@ export enum ValidationMessage {
   InvalidRegistrationCode = "Validations.InvalidRegistrationCode",
 }
 export enum OrganizationLabel {
+  SettingsTitle = "OrganizationLabel.SettingsTitle",
   EmailNameFrom = "OrganizationLabel.EmailNameFrom",
   EmailFrom = "OrganizationLabel.EmailFrom",
   EmailTemplate = "OrganizationLabel.EmailTemplate",
@@ -309,6 +310,9 @@ export enum AdminAria {
   PasteSlots = "AdminAria.PasteSlots",
   CreateSlots = "AdminAria.CreateSlots",
   EnableEdit = "AdminAria.EnableEdit",
+  AddAttendedCustomers = "AdminAria.AddAttendedCustomers",
+  CloseModal = "AdminAria.CloseModal",
+  BirthdayMenu = "AdminAria.BirthdayMenu",
 }
 
 export enum SlotFormAria {


### PR DESCRIPTION
* Clicking on a customer is BirthdayMenu (and BirthdayMenuDialog) links to customer profile
* Clicking on a customer in AttendanceCard links to customer profile
* Clicking on 'back' in customer profile links back to the previouse page (rather than /athletes page)
* The behaviour is tested using cypress tests
* Replaces some test-ids with aria labels (birthday menu, attendance card related)