### PR TITLE
Bump all mentions of Node.js versions to 18.x.x

### DIFF
--- a/.github/workflow.templates/build.yml
+++ b/.github/workflow.templates/build.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "18"
       -  #@ cache_node()
       -  #@ rush_add_path()
       -  #@ rush_update()
@@ -90,7 +90,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "18"
       -  #@ cache_node()
       -  #@ rush_add_path()
       -  #@ rush_update()
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "18"
       -  #@ cache_node()
       -  #@ rush_add_path()
       -  #@ rush_update()
@@ -153,7 +153,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "18"
       -  #@ cache_cypress()
       -  #@ rush_add_path()
       -  #@ rush_update()
@@ -234,7 +234,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "18"
       -  #@ cache_node()
       -  #@ rush_add_path()
       -  #@ rush_update()

--- a/.github/workflow.templates/cypress-matrix.yml
+++ b/.github/workflow.templates/cypress-matrix.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "18"
       -  #@ cache_cypress()
       -  #@ rush_add_path()
       -  #@ rush_update()

--- a/.github/workflow.templates/deploy-production.yml
+++ b/.github/workflow.templates/deploy-production.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "18"
       -  #@ cache_node()
       -  #@ rush_add_path()
       -  #@ rush_update()

--- a/.github/workflow.templates/storybook.lib.yml
+++ b/.github/workflow.templates/storybook.lib.yml
@@ -15,7 +15,7 @@ steps:
       fetch-depth: 0
   - uses: actions/setup-node@v2
     with:
-      node-version: "16"
+      node-version: "18"
   -  #@ cache_node()
   -  #@ rush_add_path()
   -  #@ rush_update()

--- a/.github/workflow.templates/storybook.yml
+++ b/.github/workflow.templates/storybook.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: "16"
+          node-version: "18"
       -  #@ cache_node()
       -  #@ rush_add_path()
       -  #@ rush_update()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: "16"
+        node-version: "18"
     - name: Cache node modules and firebase emulators
       uses: actions/cache@v2
       with:
@@ -94,7 +94,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: "16"
+        node-version: "18"
     - name: Cache node modules and firebase emulators
       uses: actions/cache@v2
       with:
@@ -170,7 +170,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: "16"
+        node-version: "18"
     - name: Cache node modules and firebase emulators
       uses: actions/cache@v2
       with:
@@ -199,7 +199,7 @@ jobs:
       uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: "16"
+        node-version: "18"
     - name: Cache node modules, firebase emulators and cypress
       uses: actions/cache@v2
       with:
@@ -304,7 +304,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: "16"
+        node-version: "18"
     - name: Cache node modules and firebase emulators
       uses: actions/cache@v2
       with:
@@ -331,7 +331,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-node@v2
       with:
-        node-version: "16"
+        node-version: "18"
     - name: Cache node modules and firebase emulators
       uses: actions/cache@v2
       with:
@@ -393,7 +393,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-node@v2
       with:
-        node-version: "16"
+        node-version: "18"
     - name: Cache node modules and firebase emulators
       uses: actions/cache@v2
       with:

--- a/.github/workflows/cypress-matrix.yml
+++ b/.github/workflows/cypress-matrix.yml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: "16"
+        node-version: "18"
     - name: Cache node modules, firebase emulators and cypress
       uses: actions/cache@v2
       with:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: "16"
+        node-version: "18"
     - name: Cache node modules and firebase emulators
       uses: actions/cache@v2
       with:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -12,7 +12,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-node@v2
       with:
-        node-version: "16"
+        node-version: "18"
     - name: Cache node modules and firebase emulators
       uses: actions/cache@v2
       with:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
       '@grpc/grpc-js': ^1.6.2
       '@types/inquirer': ^8.2.1
       '@types/jest': ^27.4.1
-      '@types/node': ^16.11.10
+      '@types/node': ^18.16.0
       '@types/uuid': ^8.3.2
       '@typescript-eslint/eslint-plugin': ^5.20.0
       '@typescript-eslint/parser': ^5.20.0
@@ -42,7 +42,7 @@ importers:
       '@grpc/grpc-js': 1.8.0
       '@types/inquirer': 8.2.5
       '@types/jest': 27.5.2
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.47.1_73a824a44ba50ab5a46891e6909ec6c2
       '@typescript-eslint/parser': 5.47.1_eslint@8.30.0+typescript@4.6.4
@@ -100,7 +100,7 @@ importers:
       '@types/jest': ^27.4.1
       '@types/lodash': ^4.14.170
       '@types/luxon': ^2.0.5
-      '@types/node': ^16.11.10
+      '@types/node': ^18.16.0
       '@types/react': ^17.0.13
       '@types/react-dom': ^17.0.8
       '@types/react-redux': ^7.1.24
@@ -246,7 +246,7 @@ importers:
       '@types/jest': 27.5.2
       '@types/lodash': 4.14.191
       '@types/luxon': 2.4.0
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
       '@types/react-redux': 7.1.24
@@ -294,7 +294,7 @@ importers:
       tailwindcss: 3.0.24_ts-node@10.9.1
       tiny-warning: 1.0.3
       ts-jest: 27.1.5_8e6b70a4b2454e7116ad20afc08d3435
-      ts-node: 10.9.1_ab6db587b966a7d579f1daa8a8f53233
+      ts-node: 10.9.1_3e7333282302b617200754f0c9e7162a
       typescript: 4.6.4
       vite: 2.9.15
       vite-plugin-environment: 1.1.3_vite@2.9.15
@@ -314,7 +314,7 @@ importers:
       '@firebase/functions': ^0.7.10
       '@google-cloud/firestore': ^4.13.2
       '@types/luxon': ^2.0.5
-      '@types/node': ^16.11.10
+      '@types/node': ^18.16.0
       '@types/uuid': ^8.3.2
       '@typescript-eslint/eslint-plugin': ^5.20.0
       '@typescript-eslint/parser': ^5.20.0
@@ -347,7 +347,7 @@ importers:
       '@firebase/app-types': 0.7.0
       '@google-cloud/firestore': 4.15.1
       '@types/luxon': 2.4.0
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.47.1_73a824a44ba50ab5a46891e6909ec6c2
       '@typescript-eslint/parser': 5.47.1_eslint@8.30.0+typescript@4.6.4
@@ -381,7 +381,7 @@ importers:
       '@google-cloud/firestore': ^4.13.2
       '@grpc/grpc-js': ^1.6.2
       '@types/jest': ^27.4.1
-      '@types/node': ^16.11.10
+      '@types/node': ^18.16.0
       '@typescript-eslint/eslint-plugin': ^5.20.0
       '@typescript-eslint/parser': ^5.20.0
       eslint: ^8.13.0
@@ -412,7 +412,7 @@ importers:
       '@firebase/app-types': 0.7.0
       '@grpc/grpc-js': 1.8.0
       '@types/jest': 27.5.2
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       '@typescript-eslint/eslint-plugin': 5.47.1_73a824a44ba50ab5a46891e6909ec6c2
       '@typescript-eslint/parser': 5.47.1_eslint@8.30.0+typescript@4.6.4
       eslint: 8.30.0
@@ -438,7 +438,7 @@ importers:
       '@google-cloud/firestore': ^4.13.2
       '@types/lodash': ^4.14.170
       '@types/luxon': ^2.0.5
-      '@types/node': ^16.11.10
+      '@types/node': ^18.16.0
       '@types/nodemailer': ~6.4.4
       '@types/uuid': ^8.3.2
       '@typescript-eslint/eslint-plugin': ^5.20.0
@@ -488,7 +488,7 @@ importers:
       nodemailer: 6.7.8
       p-retry: 4.6.2
       retry: 0.13.1
-      ts-node: 10.9.1_ab6db587b966a7d579f1daa8a8f53233
+      ts-node: 10.9.1_3e7333282302b617200754f0c9e7162a
       unix-timestamp: 0.2.0
       uri-js: 4.4.1
       uuid: 8.3.2
@@ -497,7 +497,7 @@ importers:
       '@firebase/app-types': 0.7.0
       '@types/lodash': 4.14.191
       '@types/luxon': 2.4.0
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       '@types/nodemailer': 6.4.7
       '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.47.1_73a824a44ba50ab5a46891e6909ec6c2
@@ -527,7 +527,7 @@ importers:
       '@testing-library/react': ^12.1.3
       '@types/jest': ^27.4.1
       '@types/luxon': ^2.0.5
-      '@types/node': ^16.11.10
+      '@types/node': ^18.16.0
       '@types/react': ^17.0.13
       '@types/react-dom': ^17.0.8
       '@types/react-redux': ^7.1.24
@@ -567,7 +567,7 @@ importers:
       '@testing-library/react': 12.1.5_react-dom@16.14.0+react@16.14.0
       '@types/jest': 27.5.2
       '@types/luxon': 2.4.0
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
       '@types/react-redux': 7.1.24
@@ -603,7 +603,7 @@ importers:
       '@google-cloud/firestore': ^4.13.2
       '@types/jest': ^27.4.1
       '@types/luxon': ^2.0.5
-      '@types/node': ^16.11.10
+      '@types/node': ^18.16.0
       '@types/react': ^17.0.13
       '@typescript-eslint/eslint-plugin': ^5.20.0
       '@typescript-eslint/parser': ^5.20.0
@@ -626,7 +626,7 @@ importers:
       '@google-cloud/firestore': 4.15.1
       '@types/jest': 27.5.2
       '@types/luxon': 2.4.0
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       '@types/react': 17.0.52
       '@typescript-eslint/eslint-plugin': 5.47.1_73a824a44ba50ab5a46891e6909ec6c2
       '@typescript-eslint/parser': 5.47.1_eslint@8.30.0+typescript@4.6.4
@@ -682,7 +682,7 @@ importers:
     specifiers:
       '@eisbuk/shared': workspace:*
       '@types/luxon': ^2.0.5
-      '@types/node': ^16.11.10
+      '@types/node': ^18.16.0
       '@typescript-eslint/eslint-plugin': ^5.20.0
       '@typescript-eslint/parser': ^5.20.0
       eslint: ^8.13.0
@@ -710,7 +710,7 @@ importers:
       react-i18next: 11.18.6_i18next@21.10.0+react@16.14.0
     devDependencies:
       '@types/luxon': 2.4.0
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       '@typescript-eslint/eslint-plugin': 5.47.1_73a824a44ba50ab5a46891e6909ec6c2
       '@typescript-eslint/parser': 5.47.1_eslint@8.30.0+typescript@4.6.4
       eslint: 8.30.0
@@ -3981,14 +3981,14 @@ packages:
     engines: {node: ^8.13.0 || >=10.10.0}
     dependencies:
       '@grpc/proto-loader': 0.7.4
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
 
   /@grpc/grpc-js/1.7.3:
     resolution: {integrity: sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==}
     engines: {node: ^8.13.0 || >=10.10.0}
     dependencies:
       '@grpc/proto-loader': 0.7.4
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
     dev: false
 
   /@grpc/grpc-js/1.8.0:
@@ -3996,7 +3996,7 @@ packages:
     engines: {node: ^8.13.0 || >=10.10.0}
     dependencies:
       '@grpc/proto-loader': 0.7.4
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
 
   /@grpc/proto-loader/0.6.13:
     resolution: {integrity: sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==}
@@ -4082,7 +4082,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       chalk: 4.1.2
       jest-message-util: 27.5.1
       jest-util: 27.5.1
@@ -4103,7 +4103,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -4148,7 +4148,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.8.1
@@ -4185,7 +4185,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       jest-mock: 27.5.1
     dev: true
 
@@ -4195,7 +4195,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@sinonjs/fake-timers': 8.1.0
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
       jest-util: 27.5.1
@@ -4224,7 +4224,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -4331,7 +4331,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       '@types/yargs': 15.0.14
       chalk: 4.1.2
     dev: true
@@ -4342,7 +4342,7 @@ packages:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       '@types/yargs': 16.0.4
       chalk: 4.1.2
     dev: true
@@ -6725,22 +6725,22 @@ packages:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
     dependencies:
       '@types/connect': 3.4.35
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
 
   /@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
 
   /@types/cors/2.8.13:
     resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
 
   /@types/duplexify/3.6.1:
     resolution: {integrity: sha512-n0zoEj/fMdMOvqbHxmqnza/kXyoGgJmEpsXjpP+gEqE1Ye4yNqc7xWipKnUoMpWhMuzJQSfK2gMrwlElly7OGQ==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
 
   /@types/eslint-scope/3.7.4:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
@@ -6763,7 +6763,7 @@ packages:
   /@types/express-serve-static-core/4.17.31:
     resolution: {integrity: sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
 
@@ -6793,12 +6793,12 @@ packages:
     resolution: {integrity: sha512-l6NQsDDyQUVeoTynNpC9uRvCUint/gSUXQA2euwmTuWGvPY5LSDUu6tkCtJB2SvGQlJQzLaKqcGZP4//7EDveA==}
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
 
   /@types/graceful-fs/4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
     dev: true
 
   /@types/hast/2.3.4:
@@ -6864,7 +6864,7 @@ packages:
   /@types/jsonwebtoken/8.5.9:
     resolution: {integrity: sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
 
   /@types/linkify-it/3.0.2:
     resolution: {integrity: sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==}
@@ -6914,7 +6914,7 @@ packages:
   /@types/node-fetch/2.6.2:
     resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       form-data: 3.0.1
     dev: true
 
@@ -6924,11 +6924,15 @@ packages:
 
   /@types/node/16.18.11:
     resolution: {integrity: sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==}
+    dev: true
+
+  /@types/node/18.16.14:
+    resolution: {integrity: sha512-+ImzUB3mw2c5ISJUq0punjDilUQ5GnUim0ZRvchHIWJmOC0G+p0kzhXBqj6cDjK0QdPFwzrHWgrJp3RPvCG5qg==}
 
   /@types/nodemailer/6.4.7:
     resolution: {integrity: sha512-f5qCBGAn/f0qtRcd4SEn88c8Fp3Swct1731X4ryPKqS61/A3LmmzN8zaEz7hneJvpjFbUUgY7lru/B/7ODTazg==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -7021,7 +7025,7 @@ packages:
     resolution: {integrity: sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==}
     dependencies:
       '@types/mime': 3.0.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
 
   /@types/sinonjs__fake-timers/8.1.1:
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
@@ -7052,7 +7056,7 @@ packages:
   /@types/through/0.0.30:
     resolution: {integrity: sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
     dev: true
 
   /@types/uglify-js/3.17.1:
@@ -7080,7 +7084,7 @@ packages:
   /@types/webpack-sources/3.2.0:
     resolution: {integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       '@types/source-list-map': 0.1.2
       source-map: 0.7.4
     dev: true
@@ -7088,7 +7092,7 @@ packages:
   /@types/webpack/4.41.33:
     resolution: {integrity: sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       '@types/tapable': 1.0.8
       '@types/uglify-js': 3.17.1
       '@types/webpack-sources': 3.2.0
@@ -7116,7 +7120,7 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
     dev: true
     optional: true
 
@@ -12043,7 +12047,7 @@ packages:
       '@fastify/busboy': 1.1.0
       '@firebase/database-compat': 0.2.10
       '@firebase/database-types': 0.9.17
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       jsonwebtoken: 9.0.0
       jwks-rsa: 2.1.5
       node-forge: 1.3.1
@@ -12063,7 +12067,7 @@ packages:
     dependencies:
       '@firebase/database-compat': 0.1.8_d5374f824c46cb534fb1c5a88156e82b
       '@firebase/database-types': 0.7.3
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       dicer: 0.3.1
       jsonwebtoken: 8.5.1
       jwks-rsa: 2.1.5
@@ -14378,7 +14382,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -14531,7 +14535,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_ab6db587b966a7d579f1daa8a8f53233
+      ts-node: 10.9.1_3e7333282302b617200754f0c9e7162a
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -14574,7 +14578,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       jest-mock: 27.5.1
       jest-util: 27.5.1
       jsdom: 16.7.0
@@ -14592,7 +14596,7 @@ packages:
       '@jest/environment': 27.5.1
       '@jest/fake-timers': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       jest-mock: 27.5.1
       jest-util: 27.5.1
     dev: true
@@ -14608,7 +14612,7 @@ packages:
     dependencies:
       '@jest/types': 26.6.2
       '@types/graceful-fs': 4.1.5
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -14629,7 +14633,7 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/graceful-fs': 4.1.5
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.10
@@ -14651,7 +14655,7 @@ packages:
       '@jest/source-map': 27.5.1
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
@@ -14716,7 +14720,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
     dev: true
 
   /jest-pnp-resolver/1.2.3_jest-resolve@27.5.1:
@@ -14777,7 +14781,7 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.10
@@ -14834,7 +14838,7 @@ packages:
     resolution: {integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       graceful-fs: 4.2.10
     dev: true
 
@@ -14842,7 +14846,7 @@ packages:
     resolution: {integrity: sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       graceful-fs: 4.2.10
     dev: true
 
@@ -14891,7 +14895,7 @@ packages:
     engines: {node: '>= 10.14.2'}
     dependencies:
       '@jest/types': 26.6.2
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       chalk: 4.1.2
       graceful-fs: 4.2.10
       is-ci: 2.0.0
@@ -14903,7 +14907,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       chalk: 4.1.2
       ci-info: 3.7.0
       graceful-fs: 4.2.10
@@ -14928,7 +14932,7 @@ packages:
     dependencies:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       jest-util: 27.5.1
@@ -14939,7 +14943,7 @@ packages:
     resolution: {integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
@@ -14948,7 +14952,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -17686,7 +17690,7 @@ packages:
     dependencies:
       lilconfig: 2.0.6
       postcss: 8.4.20
-      ts-node: 10.9.1_ab6db587b966a7d579f1daa8a8f53233
+      ts-node: 10.9.1_3e7333282302b617200754f0c9e7162a
       yaml: 1.10.2
     dev: true
 
@@ -17998,7 +18002,7 @@ packages:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/long': 4.0.2
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       long: 4.0.0
 
   /protobufjs/6.11.3:
@@ -18017,7 +18021,7 @@ packages:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/long': 4.0.2
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       long: 4.0.0
 
   /protobufjs/7.1.2:
@@ -18035,7 +18039,7 @@ packages:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       long: 5.2.1
 
   /proxy-addr/2.0.7:
@@ -20614,7 +20618,7 @@ packages:
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-node/10.9.1_ab6db587b966a7d579f1daa8a8f53233:
+  /ts-node/10.9.1_3e7333282302b617200754f0c9e7162a:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -20633,7 +20637,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 16.18.11
+      '@types/node': 18.16.14
       acorn: 8.8.1
       acorn-walk: 8.2.0
       arg: 4.1.3

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "764f71e24ed4307d4ba813486d210168f2c29499",
+  "pnpmShrinkwrapHash": "39a35983499502affa050595d0b45c979b775797",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/backup-restore/package.json
+++ b/packages/backup-restore/package.json
@@ -28,7 +28,7 @@
     "@grpc/grpc-js": "^1.6.2",
     "@types/jest": "^27.4.1",
     "@types/inquirer": "^8.2.1",
-    "@types/node": "^16.11.10",
+    "@types/node": "^18.16.0",
     "@types/uuid": "^8.3.2",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -103,7 +103,7 @@
     "@types/jest": "^27.4.1",
     "@types/lodash": "^4.14.170",
     "@types/luxon": "^2.0.5",
-    "@types/node": "^16.11.10",
+    "@types/node": "^18.16.0",
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
     "@types/react-redux": "^7.1.24",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -17,7 +17,7 @@
     "@firebase/app-types": "^0.7.0",
     "@google-cloud/firestore": "^4.13.2",
     "@types/luxon": "^2.0.5",
-    "@types/node": "^16.11.10",
+    "@types/node": "^18.16.0",
     "@types/uuid": "^8.3.2",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",

--- a/packages/firestore-process-delivery/package.json
+++ b/packages/firestore-process-delivery/package.json
@@ -33,7 +33,7 @@
     "@firebase/app-types": "^0.7.0",
     "@grpc/grpc-js": "^1.6.2",
     "@types/jest": "^27.4.1",
-    "@types/node": "^16.11.10",
+    "@types/node": "^18.16.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",
     "eslint": "^8.13.0",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -14,7 +14,7 @@
     "watch": "node build_scripts/watch.js"
   },
   "engines": {
-    "node": "16"
+    "node": "18"
   },
   "main": "dist/index.js",
   "dependencies": {
@@ -43,7 +43,7 @@
     "@firebase/app-types": "^0.7.0",
     "@types/lodash": "^4.14.170",
     "@types/luxon": "^2.0.5",
-    "@types/node": "^16.11.10",
+    "@types/node": "^18.16.0",
     "@types/uuid": "^8.3.2",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",

--- a/packages/react-redux-firebase-firestore/package.json
+++ b/packages/react-redux-firebase-firestore/package.json
@@ -48,7 +48,7 @@
     "@typescript-eslint/parser": "^5.20.0",
     "@types/jest": "^27.4.1",
     "@types/luxon": "^2.0.5",
-    "@types/node": "^16.11.10",
+    "@types/node": "^18.16.0",
     "@types/react": "^17.0.13",
     "@types/react-dom": "^17.0.8",
     "@types/react-redux": "^7.1.24",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,7 +17,7 @@
     "@google-cloud/firestore": "^4.13.2",
     "@types/luxon": "^2.0.5",
     "@types/react": "^17.0.13",
-    "@types/node": "^16.11.10",
+    "@types/node": "^18.16.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",
     "eslint": "^8.13.0",

--- a/packages/translations/package.json
+++ b/packages/translations/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/luxon": "^2.0.5",
-    "@types/node": "^16.11.10",
+    "@types/node": "^18.16.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",
     "eslint": "^8.13.0",

--- a/rush.json
+++ b/rush.json
@@ -121,7 +121,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=12.13.0 <13.0.0 || >=14.15.0 <15.0.0 || >=16.13.0 <17.0.0",
+  "nodeSupportedVersionRange": ">=18.0.0 <19.0.0",
 
   /**
    * Odd-numbered major versions of Node.js are experimental.  Even-numbered releases


### PR DESCRIPTION
This should, hopefully, work without fault (as we've merely updated to newer, current LTS, version of Node.js) and should enable other updates: e.g. Vitest uses ArrayBuffer feature, which fails on older V8, which is supposedly fixed in the newer versions of Node