### PR TITLE
Create a 'testId' constructor function:

### DIFF
--- a/packages/client/src/components/atoms/SlotOperationButtons/CopyButton.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/CopyButton.tsx
@@ -6,11 +6,7 @@ import { Copy } from "@eisbuk/svg";
 
 import { useTranslation, SlotsAria } from "@eisbuk/translations";
 
-import {
-  __copiedSlotsBadgeId__,
-  __copyDayButtonId__,
-  __copyWeekButtonId__,
-} from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import { ButtonContextType } from "@/enums/components";
 
@@ -101,15 +97,14 @@ export const CopyButton: React.FC = () => {
   };
 
   const testIdLookup = {
-    [ButtonContextType.Day]: `${__copyDayButtonId__}${date}`,
-    [ButtonContextType.Week]: __copyWeekButtonId__,
+    [ButtonContextType.Day]: testId("copy-day-button", { date }),
+    [ButtonContextType.Week]: testId("copy-week-button"),
   };
   return (
     <CopiedSlotsBadge
       displayBadge={Boolean(displayBadge)}
       contextType={contextType}
       date={date}
-      data-testid={__copiedSlotsBadgeId__}
     >
       <SlotOperationButton
         onClick={onCopy}
@@ -139,8 +134,8 @@ const CopiedSlotsBadge: React.FC<{
   };
 
   const testIdLookup = {
-    [ButtonContextType.Day]: `${__copiedSlotsBadgeId__}${date}`,
-    [ButtonContextType.Week]: __copiedSlotsBadgeId__,
+    [ButtonContextType.Day]: testId("copied-slots-day-badge", { date }),
+    [ButtonContextType.Week]: testId("copied-slots-week-badge"),
   };
 
   return (

--- a/packages/client/src/components/atoms/SlotOperationButtons/DeleteButton.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/DeleteButton.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from "react-redux";
 
 import { Trash } from "@eisbuk/svg";
 
-import { __deleteButtonId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import { ButtonContextType } from "@/enums/components";
 
@@ -101,7 +101,7 @@ export const DeleteButton: React.FC = () => {
   return (
     <SlotOperationButton
       onClick={handleDelete}
-      data-testid={__deleteButtonId__}
+      data-testid={testId("delete-button")}
       className={disableDelete ? "!text-gray-400" : ""}
       disabled={buttonsDisabled}
     >

--- a/packages/client/src/components/atoms/SlotOperationButtons/EditSlotButton.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/EditSlotButton.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 
 import { Pencil } from "@eisbuk/svg";
 
-import { __editSlotButtonId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import { ButtonContextType } from "@/enums/components";
 
@@ -66,7 +66,7 @@ export const EditSlotButton: React.FC = () => {
   return (
     <SlotOperationButton
       onClick={openForm}
-      data-testid={__editSlotButtonId__}
+      data-testid={testId("edit-slot-button")}
       disabled={disabled}
     >
       <Pencil />

--- a/packages/client/src/components/atoms/SlotOperationButtons/NewSlotButton.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/NewSlotButton.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from "react";
 import { useTranslation, SlotsAria } from "@eisbuk/translations";
 import { PlusCircle } from "@eisbuk/svg";
 
-import { __newSlotButtonId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import { ButtonContextType } from "@/enums/components";
 
@@ -68,7 +68,7 @@ export const NewSlotButton: React.FC = () => {
   return (
     <SlotOperationButton
       onClick={openForm}
-      data-testid={__newSlotButtonId__}
+      data-testid={testId("new-slot-button")}
       aria-label={t(SlotsAria.CreateSlot, { date })}
       disabled={disabled}
     >

--- a/packages/client/src/components/atoms/SlotOperationButtons/PasteButton.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/PasteButton.tsx
@@ -17,7 +17,7 @@ import {
 
 import { pasteSlotsDay, pasteSlotsWeek } from "@/store/actions/copyPaste";
 
-import { __pasteButtonId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 interface Props {
   onPaste?: () => void;
@@ -100,7 +100,7 @@ export const PasteButton: React.FC<Props> = ({ onPaste }) => {
     <SlotOperationButton
       onClick={handlePaste}
       disabled={disableButton}
-      data-testid={__pasteButtonId__}
+      data-testid={testId("paste-button")}
       aria-label={ariaLabel}
     >
       <ClipboardList />

--- a/packages/client/src/components/atoms/SlotOperationButtons/__tests__/CopyButton.test.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/__tests__/CopyButton.test.tsx
@@ -7,10 +7,7 @@ import { describe, vi, expect, test, afterEach } from "vitest";
 import { screen, render, cleanup } from "@testing-library/react";
 import { DateTime } from "luxon";
 
-import {
-  __copyDayButtonId__,
-  __copyWeekButtonId__,
-} from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import {
   __noDateCopy,
@@ -59,7 +56,7 @@ describe("SlotOperationButtons", () => {
           <CopyButton />
         </SlotOperationButtons>
       );
-      screen.getByTestId(`${__copyDayButtonId__}${testDate}`).click();
+      screen.getByTestId(testId("copy-day-button", { date: testDate })).click();
       // test dispatch being called with the result of `newCopySlotDay` mocked implementation
       expect(mockDispatch).toHaveBeenCalledWith(
         mockCopyDayImplementation(testDate)
@@ -83,7 +80,7 @@ describe("SlotOperationButtons", () => {
           <CopyButton />
         </SlotOperationButtons>
       );
-      screen.getByTestId(__copyWeekButtonId__).click();
+      screen.getByTestId(testId("copy-week-button")).click();
       // test dispatch being called with the result of `newCopySlotWeek` mocked implementation
       expect(mockDispatch).toHaveBeenCalledWith(mockCopyWeekImplementation());
     });
@@ -94,8 +91,12 @@ describe("SlotOperationButtons", () => {
 
     test("should not render the button and should log error to console if not under 'SlotOperationButtons' context", () => {
       render(<CopyButton />);
-      const weekButtonOnScreen = screen.queryByTestId(__copyWeekButtonId__);
-      const dayButtonOnScreen = screen.queryByTestId(__copyWeekButtonId__);
+      const weekButtonOnScreen = screen.queryByTestId(
+        testId("copy-week-button")
+      );
+      const dayButtonOnScreen = screen.queryByTestId(
+        testId("copy-week-button")
+      );
       expect(weekButtonOnScreen).toEqual(null);
       expect(dayButtonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(__slotButtonNoContextError);
@@ -107,8 +108,12 @@ describe("SlotOperationButtons", () => {
           <CopyButton />
         </SlotOperationButtons>
       );
-      const weekButtonOnScreen = screen.queryByTestId(__copyWeekButtonId__);
-      const dayButtonOnScreen = screen.queryByTestId(__copyWeekButtonId__);
+      const weekButtonOnScreen = screen.queryByTestId(
+        testId("copy-week-button")
+      );
+      const dayButtonOnScreen = screen.queryByTestId(
+        testId("copy-week-button")
+      );
       expect(weekButtonOnScreen).toEqual(null);
       expect(dayButtonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(
@@ -122,8 +127,12 @@ describe("SlotOperationButtons", () => {
           <CopyButton />
         </SlotOperationButtons>
       );
-      const weekButtonOnScreen = screen.queryByTestId(__copyWeekButtonId__);
-      const dayButtonOnScreen = screen.queryByTestId(__copyWeekButtonId__);
+      const weekButtonOnScreen = screen.queryByTestId(
+        testId("copy-week-button")
+      );
+      const dayButtonOnScreen = screen.queryByTestId(
+        testId("copy-week-button")
+      );
       expect(weekButtonOnScreen).toEqual(null);
       expect(dayButtonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(__noDateCopy);

--- a/packages/client/src/components/atoms/SlotOperationButtons/__tests__/DeleteButton.test.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/__tests__/DeleteButton.test.tsx
@@ -7,7 +7,7 @@ import { describe, vi, expect, test, beforeEach } from "vitest";
 import { screen, render, cleanup } from "@testing-library/react";
 import { DateTime } from "luxon";
 
-import { __deleteButtonId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 import { baseSlot } from "@eisbuk/testing/slots";
 
 import { ButtonContextType } from "@/enums/components";
@@ -79,7 +79,7 @@ describe("SlotOperationButtons", () => {
         </SlotOperationButtons>
       );
       // initiate delete
-      screen.getByTestId(__deleteButtonId__).click();
+      screen.getByTestId(testId("delete-button")).click();
       const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
       expect(dispatchCallPayload.component).toEqual("DeleteSlotDialog");
       expect(dispatchCallPayload.props).toEqual(baseSlot);
@@ -96,7 +96,7 @@ describe("SlotOperationButtons", () => {
         </SlotOperationButtons>
       );
       // initiate delete
-      screen.getByTestId(__deleteButtonId__).click();
+      screen.getByTestId(testId("delete-button")).click();
       const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
       expect(dispatchCallPayload.component).toEqual("DeleteSlotDisabledDialog");
       expect(dispatchCallPayload.props).toEqual(baseSlot);
@@ -112,7 +112,7 @@ describe("SlotOperationButtons", () => {
         </SlotOperationButtons>
       );
       // initiate delete
-      screen.getByTestId(__deleteButtonId__).click();
+      screen.getByTestId(testId("delete-button")).click();
       // create a dummy delete slots week action object with proper values
       const mockDayDelAction = mockDelDayImplementation(testDate);
       // test (using mocking tactics explained above) if `deleteSlotsDay`
@@ -130,7 +130,7 @@ describe("SlotOperationButtons", () => {
         </SlotOperationButtons>
       );
       // initiate delete
-      screen.getByTestId(__deleteButtonId__).click();
+      screen.getByTestId(testId("delete-button")).click();
       // create a dummy delete slot action object with proper values
       const mockWeekDelAction = mockDelWeekImplementation(testDate);
       // test (using mocking tactics explained above) if `deleteSlotsWeek`
@@ -144,7 +144,7 @@ describe("SlotOperationButtons", () => {
 
     test("should not render the button and should log error to console if not within 'SlotOperationButtons' context", () => {
       render(<DeleteButton />);
-      const buttonOnScreen = screen.queryByTestId(__deleteButtonId__);
+      const buttonOnScreen = screen.queryByTestId(testId("delete-button"));
       expect(buttonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(__slotButtonNoContextError);
     });
@@ -155,7 +155,7 @@ describe("SlotOperationButtons", () => {
           <DeleteButton />
         </SlotOperationButtons>
       );
-      const buttonOnScreen = screen.queryByTestId(__deleteButtonId__);
+      const buttonOnScreen = screen.queryByTestId(testId("delete-button"));
       expect(buttonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(__noSlotToDelete);
     });
@@ -166,7 +166,7 @@ describe("SlotOperationButtons", () => {
           <DeleteButton />
         </SlotOperationButtons>
       );
-      const buttonOnScreen = screen.queryByTestId(__deleteButtonId__);
+      const buttonOnScreen = screen.queryByTestId(testId("delete-button"));
       expect(buttonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(__noDateDelete);
     });

--- a/packages/client/src/components/atoms/SlotOperationButtons/__tests__/EditSlotButton.test.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/__tests__/EditSlotButton.test.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import { describe, vi, expect, test, afterEach } from "vitest";
 import { screen, render, cleanup } from "@testing-library/react";
 
-import { __editSlotButtonId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 import { baseSlot } from "@eisbuk/testing/slots";
 
 import { ButtonContextType } from "@/enums/components";
@@ -41,7 +41,7 @@ describe("SlotOperationButtons", () => {
           <EditSlotButton />
         </SlotOperationButtons>
       );
-      screen.getByTestId(__editSlotButtonId__).click();
+      screen.getByTestId(testId("edit-slot-button")).click();
       const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
       expect(dispatchCallPayload.component).toEqual("SlotFormDialog");
       expect(dispatchCallPayload.props).toEqual({
@@ -56,7 +56,7 @@ describe("SlotOperationButtons", () => {
 
     test("should not render the button and should log error to console if not within 'SlotOperationButtons' context", () => {
       render(<EditSlotButton />);
-      const buttonOnScreen = screen.queryByTestId(__editSlotButtonId__);
+      const buttonOnScreen = screen.queryByTestId(testId("edit-slot-button"));
       expect(buttonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(__slotButtonNoContextError);
     });
@@ -67,7 +67,7 @@ describe("SlotOperationButtons", () => {
           <EditSlotButton />
         </SlotOperationButtons>
       );
-      const buttonOnScreen = screen.queryByTestId(__editSlotButtonId__);
+      const buttonOnScreen = screen.queryByTestId(testId("edit-slot-button"));
       expect(buttonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(__noSlotProvidedError);
     });
@@ -81,7 +81,7 @@ describe("SlotOperationButtons", () => {
           <EditSlotButton />
         </SlotOperationButtons>
       );
-      const buttonOnScreen = screen.queryByTestId(__editSlotButtonId__);
+      const buttonOnScreen = screen.queryByTestId(testId("edit-slot-button"));
       expect(buttonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(
         __editSlotButtonWrongContextError

--- a/packages/client/src/components/atoms/SlotOperationButtons/__tests__/NewSlotButton.test.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/__tests__/NewSlotButton.test.tsx
@@ -7,7 +7,7 @@ import { describe, vi, expect, test, afterEach } from "vitest";
 import { screen, render, cleanup } from "@testing-library/react";
 import { DateTime } from "luxon";
 
-import { __newSlotButtonId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import { ButtonContextType } from "@/enums/components";
 
@@ -46,7 +46,7 @@ describe("SlotOperationButtons", () => {
           <NewSlotButton />
         </SlotOperationButtons>
       );
-      screen.getByTestId(__newSlotButtonId__).click();
+      screen.getByTestId(testId("new-slot-button")).click();
       const dispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
       expect(dispatchCallPayload.component).toEqual("SlotFormDialog");
       expect(dispatchCallPayload.props).toEqual({
@@ -60,7 +60,7 @@ describe("SlotOperationButtons", () => {
 
     test("should not render the button and should log error to console if not within 'SlotOperationButtons' context", () => {
       render(<NewSlotButton />);
-      const buttonOnScreen = screen.queryByTestId(__newSlotButtonId__);
+      const buttonOnScreen = screen.queryByTestId(testId("new-slot-button"));
       expect(buttonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(__slotButtonNoContextError);
     });
@@ -71,7 +71,7 @@ describe("SlotOperationButtons", () => {
           <NewSlotButton />
         </SlotOperationButtons>
       );
-      const buttonOnScreen = screen.queryByTestId(__newSlotButtonId__);
+      const buttonOnScreen = screen.queryByTestId(testId("new-slot-button"));
       expect(buttonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(
         __newSlotButtonWrongContextError
@@ -84,7 +84,7 @@ describe("SlotOperationButtons", () => {
           <NewSlotButton />
         </SlotOperationButtons>
       );
-      const buttonOnScreen = screen.queryByTestId(__newSlotButtonId__);
+      const buttonOnScreen = screen.queryByTestId(testId("new-slot-button"));
       expect(buttonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(__noDateProvidedError);
     });

--- a/packages/client/src/components/atoms/SlotOperationButtons/__tests__/PasteButton.test.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/__tests__/PasteButton.test.tsx
@@ -7,7 +7,7 @@ import { describe, vi, expect, test, afterEach } from "vitest";
 import { screen, render, cleanup } from "@testing-library/react";
 import { DateTime } from "luxon";
 
-import { __pasteButtonId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import { ButtonContextType } from "@/enums/components";
 
@@ -61,7 +61,7 @@ describe.skip("SlotOperationButtons", () => {
           <PasteButton />
         </SlotOperationButtons>
       );
-      screen.getByTestId(__pasteButtonId__).click();
+      screen.getByTestId(testId("paste-button")).click();
       // test dispatch being called with the result of `newPasteSlotDay` mocked implementation
       expect(mockDispatch).toHaveBeenCalledWith(
         mockPasteDayImplementation(dummyDate)
@@ -87,7 +87,7 @@ describe.skip("SlotOperationButtons", () => {
           <PasteButton />
         </SlotOperationButtons>
       );
-      screen.getByTestId(__pasteButtonId__).click();
+      screen.getByTestId(testId("paste-button")).click();
       // test dispatch being called with the result of `newPasteSlotWeek` mocked implementation
       expect(mockDispatch).toHaveBeenCalledWith(
         mockPasteWeekImplementation(dummyDate)
@@ -103,7 +103,7 @@ describe.skip("SlotOperationButtons", () => {
           <PasteButton />
         </SlotOperationButtons>
       );
-      const buttonOnScreen = screen.getByTestId(__pasteButtonId__);
+      const buttonOnScreen = screen.getByTestId(testId("paste-button"));
       expect(buttonOnScreen).toHaveProperty("disabled", true);
     });
   });
@@ -113,7 +113,7 @@ describe.skip("SlotOperationButtons", () => {
 
     test("should not render the button and should log error to console if not within 'SlotOperationButtons' context", () => {
       render(<PasteButton />);
-      const buttonOnScreen = screen.queryByTestId(__pasteButtonId__);
+      const buttonOnScreen = screen.queryByTestId(testId("paste-button"));
       expect(buttonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(__slotButtonNoContextError);
     });
@@ -124,7 +124,7 @@ describe.skip("SlotOperationButtons", () => {
           <PasteButton />
         </SlotOperationButtons>
       );
-      const buttonOnScreen = screen.queryByTestId(__pasteButtonId__);
+      const buttonOnScreen = screen.queryByTestId(testId("paste-button"));
       expect(buttonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(
         __pasteButtonWrongContextError
@@ -137,7 +137,7 @@ describe.skip("SlotOperationButtons", () => {
           <PasteButton />
         </SlotOperationButtons>
       );
-      const buttonOnScreen = screen.queryByTestId(__pasteButtonId__);
+      const buttonOnScreen = screen.queryByTestId(testId("paste-button"));
       expect(buttonOnScreen).toEqual(null);
       expect(spyConsoleError).toHaveBeenCalledWith(__noDatePaste);
     });

--- a/packages/client/src/components/atoms/SlotOperationButtons/__tests__/SlotOperationButtons.test.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/__tests__/SlotOperationButtons.test.tsx
@@ -9,14 +9,7 @@ import { DateTime } from "luxon";
 
 import { SlotInterface, luxon2ISODate } from "@eisbuk/shared";
 
-import {
-  __copyDayButtonId__,
-  __copyWeekButtonId__,
-  __editSlotButtonId__,
-  __deleteButtonId__,
-  __newSlotButtonId__,
-  __pasteButtonId__,
-} from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import { ButtonContextType } from "@/enums/components";
 
@@ -53,8 +46,8 @@ describe("SlotOperationButtons", () => {
           <DeleteButton />
         </SlotOperationButtons>
       );
-      screen.getByTestId(__editSlotButtonId__);
-      screen.getByTestId(__deleteButtonId__);
+      screen.getByTestId(testId("edit-slot-button"));
+      screen.getByTestId(testId("delete-button"));
     });
     test("should render whitelisted buttons 'contextType=\"day\"' without error with all appropriate buttons passed in", () => {
       render(
@@ -68,10 +61,10 @@ describe("SlotOperationButtons", () => {
           <DeleteButton />
         </SlotOperationButtons>
       );
-      screen.getByTestId(__newSlotButtonId__);
-      screen.getByTestId(`${__copyDayButtonId__}${dummyDate}`);
-      screen.getByTestId(__pasteButtonId__);
-      screen.getByTestId(__deleteButtonId__);
+      screen.getByTestId(testId("new-slot-button"));
+      screen.getByTestId(testId("copy-day-button", { date: dummyDate }));
+      screen.getByTestId(testId("paste-button"));
+      screen.getByTestId(testId("delete-button"));
     });
 
     test("should render whitelisted buttons 'contextType=\"week\"' without error with all appropriate buttons passed in", () => {
@@ -85,9 +78,9 @@ describe("SlotOperationButtons", () => {
           <DeleteButton />
         </SlotOperationButtons>
       );
-      screen.getByTestId(__copyWeekButtonId__);
-      screen.getByTestId(__pasteButtonId__);
-      screen.getByTestId(__deleteButtonId__);
+      screen.getByTestId(testId("copy-week-button"));
+      screen.getByTestId(testId("paste-button"));
+      screen.getByTestId(testId("delete-button"));
     });
   });
 

--- a/packages/client/src/controllers/SlotCard/__tests__/SlotCard.test.tsx
+++ b/packages/client/src/controllers/SlotCard/__tests__/SlotCard.test.tsx
@@ -8,11 +8,7 @@ import { cleanup, screen, render } from "@testing-library/react";
 
 import SlotCard from "../SlotCardController";
 
-import {
-  __deleteButtonId__,
-  __editSlotButtonId__,
-  __slotCardId__,
-} from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 import { baseSlot } from "@eisbuk/testing/slots";
 
 const mockDispatch = vi.fn();
@@ -70,7 +66,7 @@ describe("SlotCard", () => {
     });
 
     test("should open slot form on edit slot click", () => {
-      screen.getByTestId(__editSlotButtonId__).click();
+      screen.getByTestId(testId("edit-slot-button")).click();
       const mockDispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
       expect(mockDispatchCallPayload.component).toEqual("SlotFormDialog");
       expect(mockDispatchCallPayload.props).toEqual({
@@ -80,7 +76,7 @@ describe("SlotCard", () => {
     });
 
     test("should initiate delete-slot flow on delete button click", () => {
-      screen.getByTestId(__deleteButtonId__).click();
+      screen.getByTestId(testId("delete-button")).click();
       const mockDispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
       expect(mockDispatchCallPayload.component).toEqual("DeleteSlotDialog");
       expect(mockDispatchCallPayload.props).toEqual(baseSlot);
@@ -90,7 +86,7 @@ describe("SlotCard", () => {
       cleanup();
       render(<SlotCard {...baseSlot} enableEdit disableDelete />);
       vi.clearAllMocks();
-      screen.getByTestId(__deleteButtonId__).click();
+      screen.getByTestId(testId("delete-button")).click();
       const mockDispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
       expect(mockDispatchCallPayload.component).toEqual(
         "DeleteSlotDisabledDialog"
@@ -104,13 +100,13 @@ describe("SlotCard", () => {
 
     test("should fire 'onClick' function if provided", () => {
       render(<SlotCard {...baseSlot} enableEdit onClick={mockOnClick} />);
-      screen.getByTestId(__slotCardId__).click();
+      screen.getByTestId(testId("slot-card")).click();
       expect(mockOnClick).toHaveBeenCalledTimes(1);
     });
 
     test("should not explode on click if no 'onClick' handler has been provided", () => {
       render(<SlotCard {...baseSlot} enableEdit />);
-      screen.getByTestId(__slotCardId__).click();
+      screen.getByTestId(testId("slot-card")).click();
     });
   });
 });

--- a/packages/client/src/features/modal/components/SendICSDialog/SendICSDialog.tsx
+++ b/packages/client/src/features/modal/components/SendICSDialog/SendICSDialog.tsx
@@ -12,7 +12,7 @@ import i18n, {
 } from "@eisbuk/translations";
 import { Customer } from "@eisbuk/shared";
 
-import { __emailInput__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import { BaseModalProps } from "../../types";
 
@@ -59,7 +59,7 @@ const SendICSDialog: React.FC<SendICSDialogProps> = ({
           <Field
             name="email"
             type="email"
-            data-testid={__emailInput__}
+            data-testid={testId("input-dialog-email-input")}
             component={TextInput}
           />
         </ActionDialog>

--- a/packages/client/src/features/modal/components/SendICSDialog/__tests__/SendICSDialog.test.tsx
+++ b/packages/client/src/features/modal/components/SendICSDialog/__tests__/SendICSDialog.test.tsx
@@ -9,7 +9,7 @@ import userEvent from "@testing-library/user-event";
 
 import i18n, { ActionButton } from "@eisbuk/translations";
 
-import { __emailInput__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import SendICSDialog from "../SendICSDialog";
 
@@ -55,7 +55,7 @@ describe("SendICSDialog", () => {
     test("should send the ICS file to the email provided", async () => {
       const email = "test-email@email.com";
 
-      const emailInput = screen.getByTestId(__emailInput__);
+      const emailInput = screen.getByTestId(testId("input-dialog-email-input"));
       userEvent.clear(emailInput);
       userEvent.type(emailInput, email);
 

--- a/packages/client/src/pages/customers/index.tsx
+++ b/packages/client/src/pages/customers/index.tsx
@@ -13,7 +13,7 @@ import {
 import { Plus } from "@eisbuk/svg";
 import { useFirestoreSubscribe } from "@eisbuk/react-redux-firebase-firestore";
 
-import { __addAthleteId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import Layout from "@/controllers/Layout";
 
@@ -65,7 +65,7 @@ const AthletesPage: React.FC = () => {
 
           <Link to={PrivateRoutes.NewAthlete}>
             <button
-              data-testid={__addAthleteId__}
+              data-testid={testId("add-athlete")}
               aria-label={t(ActionButton.AddAthlete)}
               className="fixed right-10 bottom-10 rounded-full bg-cyan-600 shadow-lg h-14 w-14 p-3 text-white"
             >

--- a/packages/e2e/integration/athlete_management_spec.ts
+++ b/packages/e2e/integration/athlete_management_spec.ts
@@ -5,7 +5,7 @@ import i18n, {
   ValidationMessage,
 } from "@eisbuk/translations";
 
-import { PrivateRoutes, __addAthleteId__, __birthdayInputId__ } from "../temp";
+import { PrivateRoutes } from "../temp";
 
 import { customers } from "../__testData__/customers.json";
 import { customers as saulWithExtendedDate } from "../__testData__/saul_with_extended_date.json";
@@ -23,7 +23,7 @@ describe("Athlete form", () => {
 
   it("fills in the customer form and submits it", () => {
     cy.visit(PrivateRoutes.Athletes);
-    cy.getByTestId(__addAthleteId__).click();
+    cy.getByTestId("add-athlete").click();
 
     cy.fillInCustomerData(saul);
     // The phone number for saul is wrong, so we'll fix it
@@ -40,7 +40,7 @@ describe("Athlete form", () => {
 
   it("allows customer form submission with minimal fields", () => {
     cy.visit(PrivateRoutes.Athletes);
-    cy.getByTestId(__addAthleteId__).click();
+    cy.getByTestId("add-athlete").click();
 
     cy.getAttrWith("name", "name").type(saul.name);
     cy.getAttrWith("name", "surname").type(saul.surname);
@@ -56,7 +56,7 @@ describe("Athlete form", () => {
 
   it("doesn't allow invalid date input format", () => {
     cy.visit(PrivateRoutes.Athletes);
-    cy.getByTestId(__addAthleteId__).click();
+    cy.getByTestId("add-athlete").click();
 
     cy.fillInCustomerData({
       ...saul,
@@ -71,7 +71,7 @@ describe("Athlete form", () => {
 
   it("doesn't allow invalid phone input format", () => {
     cy.visit(PrivateRoutes.Athletes);
-    cy.getByTestId(__addAthleteId__).click();
+    cy.getByTestId("add-athlete").click();
 
     // test phone number for edge cases
     cy.getAttrWith("name", "phone").clearAndType("foo 2222 868");
@@ -100,22 +100,22 @@ describe("Athlete form", () => {
 
   it("replaces different date separators ('.' and '-') with '/'", () => {
     cy.visit(PrivateRoutes.Athletes);
-    cy.getByTestId(__addAthleteId__).click();
+    cy.getByTestId("add-athlete").click();
 
     cy.fillInCustomerData(saul);
 
     // dashes
-    cy.getByTestId(__birthdayInputId__).first().clearAndType("12-12-1990");
+    cy.getByTestId("birthday-input").first().clearAndType("12-12-1990");
 
     // dots
     cy.getAttrWith("value", "12/12/1990");
-    cy.getByTestId(__birthdayInputId__).first().clearAndType("12.12.1990");
+    cy.getByTestId("birthday-input").first().clearAndType("12.12.1990");
     cy.getAttrWith("value", "12/12/1990");
   });
 
   it("handles edge (passable) cases of input", () => {
     cy.visit(PrivateRoutes.Athletes);
-    cy.getByTestId(__addAthleteId__).click();
+    cy.getByTestId("add-athlete").click();
 
     const archer = {
       ...saul,
@@ -142,7 +142,7 @@ describe("Athlete form", () => {
 
   it("prefills the number field of the first athlete", () => {
     cy.visit(PrivateRoutes.Athletes);
-    cy.getByTestId(__addAthleteId__).click();
+    cy.getByTestId("add-athlete").click();
     cy.getAttrWith("name", "subscriptionNumber").should("have.value", "1");
   });
 
@@ -158,7 +158,7 @@ describe("Athlete form", () => {
     // button too early we'll get a default value of 1
     cy.contains("Saul"); // I will only speak in the presence of my lawyer!
     cy.contains("Goodman");
-    cy.getByTestId(__addAthleteId__).click();
+    cy.getByTestId("add-athlete").click();
     cy.getAttrWith("name", "subscriptionNumber").should("have.value", "42");
   });
 });

--- a/packages/e2e/integration/athlete_self_update.ts
+++ b/packages/e2e/integration/athlete_self_update.ts
@@ -6,7 +6,7 @@ import i18n, {
   ValidationMessage,
 } from "@eisbuk/translations";
 
-import { Routes, __birthdayInputId__ } from "../temp";
+import { Routes } from "../temp";
 
 import { customers } from "../__testData__/customers.json";
 
@@ -90,11 +90,11 @@ describe("athlete profile", () => {
 
   it("replaces different date separators ('.' and '-') with '/'", () => {
     // dashes
-    cy.getByTestId(__birthdayInputId__).clearAndType("12-12-1990");
-    cy.getByTestId(__birthdayInputId__).should("contain.value", "12/12/1990");
+    cy.getByTestId("birthday-input").clearAndType("12-12-1990");
+    cy.getByTestId("birthday-input").should("contain.value", "12/12/1990");
 
     // dots
-    cy.getByTestId(__birthdayInputId__).clearAndType("12.12.1990");
+    cy.getByTestId("birthday-input").clearAndType("12.12.1990");
     cy.getAttrWith("value", "12/12/1990");
   });
 

--- a/packages/e2e/integration/attendance_spec.ts
+++ b/packages/e2e/integration/attendance_spec.ts
@@ -3,12 +3,7 @@ import { DateTime } from "luxon";
 
 import { Customer, SlotInterface } from "@eisbuk/shared";
 
-import {
-  PrivateRoutes,
-  __addCustomIntervalId__,
-  __customIntervalInputId__,
-  __primaryIntervalId__,
-} from "../temp";
+import { PrivateRoutes } from "../temp";
 
 import { customers } from "../__testData__/customers.json";
 import { attendance } from "../__testData__/attendance.json";
@@ -132,7 +127,7 @@ describe("AddAttendedCustomersDialog", () => {
       const intervals = ["09:00-11:00", "09:00-10:00", "10:00-11:00"];
 
       // The initial interval (booked by gus) is the last interval of the slot
-      cy.getByTestId(__primaryIntervalId__).contains(intervals[2]);
+      cy.getByTestId("primary-interval").contains(intervals[2]);
       // With the last slot attended, the next button should be disabled
       cy.getAttrWith("aria-label", i18n.t(AttendanceAria.NextInterval)).should(
         "be.disabled"
@@ -143,13 +138,13 @@ describe("AddAttendedCustomersDialog", () => {
         "aria-label",
         i18n.t(AttendanceAria.PreviousInterval)
       ).click();
-      cy.getByTestId(__primaryIntervalId__).contains(intervals[1]);
+      cy.getByTestId("primary-interval").contains(intervals[1]);
 
       cy.getAttrWith(
         "aria-label",
         i18n.t(AttendanceAria.PreviousInterval)
       ).click();
-      cy.getByTestId(__primaryIntervalId__).contains(intervals[0]);
+      cy.getByTestId("primary-interval").contains(intervals[0]);
 
       // On the first interval, the previous button should be disabled
       cy.getAttrWith(
@@ -159,10 +154,10 @@ describe("AddAttendedCustomersDialog", () => {
 
       // Revert back to the last interval
       cy.getAttrWith("aria-label", i18n.t(AttendanceAria.NextInterval)).click();
-      cy.getByTestId(__primaryIntervalId__).contains(intervals[1]);
+      cy.getByTestId("primary-interval").contains(intervals[1]);
 
       cy.getAttrWith("aria-label", i18n.t(AttendanceAria.NextInterval)).click();
-      cy.getByTestId(__primaryIntervalId__).contains(intervals[2]);
+      cy.getByTestId("primary-interval").contains(intervals[2]);
     });
 
     it("adds a new interval to the slot and marks alhlete's attendance with it using 'Custom interval' input", () => {
@@ -172,11 +167,11 @@ describe("AddAttendedCustomersDialog", () => {
       // Show custom interval input (for Gus as the first athlete in the list)
       cy.clickButton(i18n.t(ActionButton.CustomInterval));
 
-      cy.getByTestId(__customIntervalInputId__).type(newInterval);
-      cy.getByTestId(__addCustomIntervalId__).click();
+      cy.getByTestId("custom-interval-input").type(newInterval);
+      cy.getByTestId("add-custom-interval").click();
 
       // The input should no-longer be shown (the button should be show instead)
-      cy.getByTestId(__customIntervalInputId__).should("not.exist");
+      cy.getByTestId("custom-interval-input").should("not.exist");
       cy.get(`button:contains(${i18n.t(ActionButton.CustomInterval)})`);
 
       // We verify the attendance has been updated by checking for the interval string being there (even though the input was removed)

--- a/packages/e2e/integration/booking_spec_admin.ts
+++ b/packages/e2e/integration/booking_spec_admin.ts
@@ -9,7 +9,7 @@ import i18n, {
   NotificationMessage,
 } from "@eisbuk/translations";
 
-import { Routes, __notificationToastId__ } from "../temp";
+import { Routes } from "../temp";
 
 import { customers } from "../__testData__/customers.json";
 import { slots } from "../__testData__/slots.json";
@@ -64,7 +64,7 @@ describe("Booking flow", () => {
         force: true,
       });
     // Check that the booking was successful
-    cy.getByTestId(__notificationToastId__).contains(
+    cy.getByTestId("notification-toast").contains(
       i18n.t(NotificationMessage.BookingSuccess, {
         date: DateTime.fromISO("2022-01-01"),
         interval: "09:00-11:00",

--- a/packages/e2e/integration/booking_spec_non_admin.ts
+++ b/packages/e2e/integration/booking_spec_non_admin.ts
@@ -12,7 +12,7 @@ import i18n, {
   CustomerNavigationLabel,
 } from "@eisbuk/translations";
 
-import { Routes, __notificationToastId__ } from "../temp";
+import { Routes } from "../temp";
 
 import { customers } from "../__testData__/customers.json";
 import { customers as saulWithExtendedDate } from "../__testData__/saul_with_extended_date.json";
@@ -108,7 +108,7 @@ describe("Booking flow", () => {
           force: true,
         });
 
-      cy.getByTestId(__notificationToastId__).contains(
+      cy.getByTestId("notification-toast").contains(
         i18n.t(NotificationMessage.BookingSuccess, {
           date: testDateLuxon,
           interval: "09:00-11:00",
@@ -135,7 +135,7 @@ describe("Booking flow", () => {
         .click({
           force: true,
         });
-      cy.getByTestId(__notificationToastId__).contains(
+      cy.getByTestId("notification-toast").contains(
         i18n.t(NotificationMessage.BookingSuccess, {
           date: DateTime.fromISO("2022-01-01"),
           interval: "09:00-11:00",
@@ -198,7 +198,7 @@ describe("Booking flow", () => {
         force: true,
       });
 
-      cy.getByTestId(__notificationToastId__).contains(
+      cy.getByTestId("notification-toast").contains(
         i18n.t(NotificationMessage.BookingSuccess, {
           date: testDateLuxon,
           interval: "09:00-11:00",

--- a/packages/e2e/integration/copy_button_spec.ts
+++ b/packages/e2e/integration/copy_button_spec.ts
@@ -3,12 +3,7 @@ import { DateTime } from "luxon";
 import { SlotInterface } from "@eisbuk/shared";
 import i18n, { AdminAria, SlotsAria } from "@eisbuk/translations";
 
-import {
-  PrivateRoutes,
-  __copyWeekButtonId__,
-  __copiedSlotsBadgeId__,
-  __copyDayButtonId__,
-} from "../temp";
+import { PrivateRoutes } from "../temp";
 
 import { slots } from "../__testData__/slots.json";
 
@@ -36,42 +31,51 @@ describe("Slots copy button - copied slots badge", () => {
 
   it("shows the week copied badge only if in 'week' context and the week in clipboard is the currently observed week", () => {
     // The badge should not be shown as there are no slots copied yet.
-    cy.getByTestId(__copiedSlotsBadgeId__).getAttrWith("aria-hidden", "true");
+    cy.getByTestId("copied-slots-week-badge").getAttrWith(
+      "aria-hidden",
+      "true"
+    );
 
     // Copy the slots for the current week
-    cy.getByTestId(__copyWeekButtonId__).click({ force: true });
+    cy.getByTestId("copy-week-button").click({ force: true });
 
     // The badge should now be shown as the copied slots belong to the current week.
-    cy.getByTestId(__copiedSlotsBadgeId__).getAttrWith("aria-hidden", "false");
+    cy.getByTestId("copied-slots-week-badge").getAttrWith(
+      "aria-hidden",
+      "false"
+    );
 
     // Go to the next week
     cy.getAttrWith("aria-label", i18n.t(AdminAria.SeeFutureDates)).click();
 
     // The badge should not be shown anymore as the copied slots belong to the previous week.
-    cy.getByTestId(__copiedSlotsBadgeId__).getAttrWith("aria-hidden", "true");
+    cy.getByTestId("copied-slots-week-badge").getAttrWith(
+      "aria-hidden",
+      "true"
+    );
   });
 
   it("shows the day copied badge only if in 'day' context and the day in clipboard is the corresponding day", () => {
     const date = testDateLuxon;
 
     // The badge should not be shown as there are no slots copied yet.
-    cy.getByTestId(`${__copiedSlotsBadgeId__}${date}`).getAttrWith(
+    cy.getByTestId("copied-slots-day-badge", { date }).getAttrWith(
       "aria-hidden",
       "true"
     );
 
     // Copy the slots for the current day
-    cy.getByTestId(`${__copyDayButtonId__}${date}`).click({ force: true });
+    cy.getByTestId("copy-day-button", { date }).click({ force: true });
 
     // The badge should now be shown as the copied slots belong to the current day.
-    cy.getByTestId(`${__copiedSlotsBadgeId__}${date}`).getAttrWith(
+    cy.getByTestId("copied-slots-day-badge", { date }).getAttrWith(
       "aria-hidden",
       "false"
     );
 
     // Check different date slot (the badge should not be shown)
-    cy.getByTestId(
-      `${__copiedSlotsBadgeId__}${date.plus({ days: 1 })}`
-    ).getAttrWith("aria-hidden", "true");
+    cy.getByTestId("copied-slots-day-badge", {
+      date: date.plus({ days: 1 }),
+    }).getAttrWith("aria-hidden", "true");
   });
 });

--- a/packages/e2e/support/commands.ts
+++ b/packages/e2e/support/commands.ts
@@ -1,7 +1,7 @@
 import { Customer } from "@eisbuk/shared";
 import i18n, { ActionButton } from "@eisbuk/translations";
 
-import { __addAthleteId__ } from "../temp";
+import { TestID, testId, TestIDMetaLookup, TestIDWithMeta } from "../temp";
 
 /**
  * As painful as the node resolution is nowadays, it was easier to simply extract the type
@@ -43,7 +43,11 @@ declare global {
        * @param {string} testId Element data-testid attribute
        * @returns {Chainable<Element>} a `PromiseLike` yielding found `Element`
        */
-      getByTestId: (testId: string) => Chainable<JQuery<HTMLElement>>;
+      getByTestId<I extends TestIDWithMeta>(
+        testId: I,
+        meta: TestIDMetaLookup[I]
+      ): Chainable<JQuery<HTMLElement>>;
+      getByTestId(testId: TestID): Chainable<JQuery<HTMLElement>>;
       /**
        * @param {number} millis milliseconds from UNIX epoch, such as it's received from `Date.now()`.
        */
@@ -114,8 +118,8 @@ export default (): void => {
     return cy.get(`[${attr}${glob}="${label}"]`);
   });
 
-  Cypress.Commands.add("getByTestId", (testId) => {
-    return cy.get(`[data-testid="${testId}"]`);
+  Cypress.Commands.add("getByTestId", (...params) => {
+    return cy.get(`[data-testid="${testId(...params)}"]`);
   });
 
   Cypress.Commands.add("setClock", (millis) =>
@@ -172,7 +176,7 @@ export default (): void => {
       // use force as button will be detached after click
       .click({ force: true });
     // open new form
-    cy.getByTestId(__addAthleteId__).click();
+    cy.getByTestId("add-athlete").click();
   });
   // #region CustomerForm
 

--- a/packages/testing/src/testIds/index.ts
+++ b/packages/testing/src/testIds/index.ts
@@ -1,97 +1,145 @@
-// #region SlotCard
-export const __slotCardId__ = "slot-card";
-// #endregion SlotCard
+import { DateTime } from "luxon";
 
-// #region SlotForm
-export const __slotFormId__ = "slot-form-title";
-export const __cancelFormId__ = "form-cancel-button";
-export const __confirmFormId__ = "form-confirm-button";
+type TestIDList = [
+  // #region SlotCard
+  "slot-card",
+  // #endregion SlotCard
 
-export const __deleteIntervalId__ = "delete-interval-button";
-export const __startTimeInputId__ = "start-time-input";
-export const __startTimeErrorId__ = "start-time-error";
-export const __endTimeInputId__ = "end-time-input";
-export const __endTimeErrorId__ = "end-time-error";
+  // #region SlotForm
+  "slot-form-title",
+  "form-cancel-button",
+  "form-confirm-button",
 
-export const __incrementId__ = "increment-button";
-export const __decrementId__ = "decrement-button";
+  "delete-interval-button",
+  "start-time-input",
+  "start-time-error",
+  "end-time-input",
+  "end-time-error",
 
-export const __selectTypeId__ = "select-type-field";
-export const __selectcategoriesId__ = "select-categories-field";
-export const __timeIntervalFieldId__ = "time-interval-field";
-// #endregion SlotForm
+  "increment-button",
+  "decrement-button",
 
-// #region ConfirmDialog
-export const __confirmDialogYesId__ = "confirm-dialog-yes-button";
-export const __confirmDialogNoId__ = "confirm-dialog-no-button";
-// #endregion ConfirmDialog
+  "select-type-field",
+  "select-categories-field",
+  "time-interval-field",
+  // #endregion SlotForm
 
-// #region ConfirmDialog
-export const __inputDialogSubmitId__ = "input-dialog-submit-button";
-export const __emailInput__ = "input-dialog-email-input";
-// #endregion ConfirmDialog
+  // #region ConfirmDialog
+  "confirm-dialog-yes-button",
+  "confirm-dialog-no-button",
+  // #endregion ConfirmDialog
 
-// #region SlotOperationButtons
-export const __newSlotButtonId__ = "new-slot-button";
-export const __editSlotButtonId__ = "edit-slot-button";
-export const __copyButtonId__ = "copy-button";
-export const __copyDayButtonId__ = "copy-day-button";
-export const __copyWeekButtonId__ = "copy-week-button";
-export const __pasteButtonId__ = "paste-button";
-export const __deleteButtonId__ = "delete-button";
-export const __copiedSlotsBadgeId__ = "copied-slots-badge";
-// #endregion SlotOperationButtons
+  // #region ConfirmDialog
+  "input-dialog-submit-button",
+  "input-dialog-email-input",
+  // #endregion ConfirmDialog
 
-// #region SlotAlerts
-export const __noSlotsDateId__ = "no-slots-date";
-// #endregion SlotAlerts
+  // #region SlotOperationButtons
+  "new-slot-button",
+  "edit-slot-button",
+  // "copy-button",
+  "copy-week-button",
+  "paste-button",
+  "delete-button",
+  "copied-slots-week-badge",
+  // #endregion SlotOperationButtons
 
-// #region DateNavigation
-export const __dateNavNextId__ = "date-navigation-next-page";
-export const __dateNavPrevId__ = "date-navigation-previous-page";
-// #endregion DateNavigation
+  // #region SlotAlerts
+  "no-slots-date",
+  // #endregion SlotAlerts
 
-// #region DateSwitcher
-export const __calendarMenuId__ = "calendar-menu";
-export const __pickedDay__ = "picked-day";
-export const __dayWithSlots__ = "day-with-slots";
-export const __dayWithBookedSlots__ = "day-with-booked-slots";
-// #endregion DateSwitcher
+  // #region DateNavigation
+  "date-navigation-next-page",
+  "date-navigation-previous-page",
+  // #endregion DateNavigation
 
-// #region BookingCard
-export const __bookingCardId__ = "booking-interval-card";
-// #endregion BookingCard
+  // #region DateSwitcher
+  "calendar-menu",
+  "picked-day",
+  "day-with-slots",
+  "day-with-booked-slots",
+  // #endregion DateSwitcher
 
-// #region CustomerList
-export const __customerListId__ = "customer-list";
-// #endregion CustomerList
+  // #region BookingCard
+  "booking-interval-card",
+  // #endregion BookingCard
 
-// #region CustomerGrid
-export const __customerGridId__ = "customer-grid";
-export const __customerDialogId__ = "customer-dialog";
-// #endregion CustomerGrid
+  // #region CustomerList
+  "customer-list",
+  // #endregion CustomerList
 
-// #region DebugMenu
-export const __debugButtonId__ = "debug-button";
-export const __create100Athletes__ = "create-athletes";
-// #endregion DebugMenu
+  // #region CustomerGrid
+  "customer-grid",
+  "customer-dialog",
+  // #endregion CustomerGrid
 
-// #region Notifications
-export const __notificationButton__ = "notification-button";
-export const __notificationToastId__ = "notification-toast";
-// #endregion Notifications
+  // #region DebugMenu
+  "debug-button",
+  "create-athletes",
+  // #endregion DebugMenu
 
-// #region ActionButton
-export const __addAthleteId__ = "add-athlete";
-// #endregion ActionButton
+  // #region Notifications
+  "notification-button",
+  "notification-toast",
+  // #endregion Notifications
 
-// #region AthleteForm
-export const __birthdayInputId__ = "birthday-input";
-// #endregion AthleteForm
+  // #region ActionButton
+  "add-athlete",
+  // #endregion ActionButton
 
-// #region AttendanceIntervals
-export const __primaryIntervalId__ = "primary-interval";
-export const __customIntervalInputId__ = "custom-interval-input";
-export const __cancelCustomIntervalId__ = "cancel-custom-interval";
-export const __addCustomIntervalId__ = "add-custom-interval";
-// #endregion AttendanceIntervals
+  // #region AthleteForm
+  "birthday-input",
+  // #endregion AthleteForm
+
+  // #region AttendanceIntervals
+  "primary-interval",
+  "custom-interval-input",
+  "cancel-custom-interval",
+  "add-custom-interval"
+  // #endregion AttendanceIntervals
+];
+export type TestID = TestIDList[number];
+
+// #region test-id-with-metadata
+/** A lookup of all test ids which require metadata and their corresponding metadata interface */
+export interface TestIDMetaLookup {
+  "copy-day-button": { date: DateTime };
+  "copied-slots-day-badge": { date: DateTime };
+}
+export type TestIDWithMeta = keyof TestIDMetaLookup;
+
+/** A lookup of test ids (requring metadata) and handlers - processing their metadata and returning a constructed test id */
+const applyMetaLookup: {
+  [key in TestIDWithMeta]: (meta: TestIDMetaLookup[key]) => string;
+} = {
+  "copy-day-button": (meta) => `copy-day-button-${meta.date.toISODate()}`,
+  "copied-slots-day-badge": (meta) =>
+    `copied-slots-day-badge-${meta.date.toISODate()}`,
+};
+
+/** A type guard/predicate function checking if the `id` is of type `TestID` (without meta) or `TestIDWithMeta` */
+const hasMeta = (id: TestID | TestIDWithMeta): id is TestIDWithMeta =>
+  Boolean(applyMetaLookup[id as TestIDWithMeta]);
+
+/** Constructs a test id by applying its metadata in a correct manner */
+const applyMeta = <I extends TestIDWithMeta>(
+  id: I,
+  meta: TestIDMetaLookup[I]
+): string => applyMetaLookup[id](meta);
+// #endregion test-id-with-metadata
+
+export function testId<I extends TestIDWithMeta>(
+  id: I,
+  meta: TestIDMetaLookup[I]
+): string;
+export function testId(id: TestID): string;
+/** */
+export function testId<I extends TestID | TestIDWithMeta>(
+  id: I,
+  meta?: I extends TestIDWithMeta ? TestIDMetaLookup[I] : never
+): string {
+  if (hasMeta(id)) {
+    return applyMeta(id, meta!);
+  }
+  return id;
+}

--- a/packages/ui/src/AttendanceCard/CustomIntervalInput.tsx
+++ b/packages/ui/src/AttendanceCard/CustomIntervalInput.tsx
@@ -9,11 +9,7 @@ import {
   useTranslation,
   ValidationMessage,
 } from "@eisbuk/translations";
-import {
-  __addCustomIntervalId__,
-  __cancelCustomIntervalId__,
-  __customIntervalInputId__,
-} from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 const validationSchema = Yup.object().shape({
   interval: Yup.string()
@@ -91,14 +87,14 @@ const CustomIntervalInput: React.FC<{
               value={value}
               onChange={onChange}
               placeholder="08:00-09:00"
-              data-testid={__customIntervalInputId__}
+              data-testid={testId("custom-interval-input")}
             />
             <button
               type="reset"
               aria-label={t(AttendanceAria.CancelCustomInterval)}
               onClick={() => setShowInput(false)}
               className="flex-shrink-0 text-red-400 h-6 w-6 rounded"
-              data-testid={__cancelCustomIntervalId__}
+              data-testid={testId("cancel-custom-interval")}
             >
               <XCircle />
             </button>
@@ -106,7 +102,7 @@ const CustomIntervalInput: React.FC<{
               type="submit"
               aria-label={t(AttendanceAria.AddCustomInterval)}
               className="flex-shrink-0 text-lime-400 h-6 w-6 rounded"
-              data-testid={__addCustomIntervalId__}
+              data-testid={testId("add-custom-interval")}
             >
               <CheckCircle />
             </button>

--- a/packages/ui/src/AttendanceCard/IntervalUI.tsx
+++ b/packages/ui/src/AttendanceCard/IntervalUI.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useCallback } from "react";
 
-import { __primaryIntervalId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 interface Props {
   attendedInterval: string | null;
@@ -99,7 +99,7 @@ const IntervalUI: React.FC<Props> = ({ attendedInterval, bookedInterval }) => {
       <span
         ref={primaryRef}
         className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-black text-xl select-none cursor-default whitespace-nowrap"
-        data-testid={__primaryIntervalId__}
+        data-testid={testId("primary-interval")}
       >
         {primaryInterval}
       </span>

--- a/packages/ui/src/CustomerGrid/CustomerGrid.tsx
+++ b/packages/ui/src/CustomerGrid/CustomerGrid.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Customer, CustomerFull } from "@eisbuk/shared";
 
-import { __customerGridId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import CustomerGridItem from "./CustomerGridItem";
 
@@ -25,7 +25,7 @@ const CustomerGrid: React.FC<CustomerGridProps> = ({
     <div {...props}>
       <div
         className="w-full h-full flex gap-4 flex-wrap justify-start"
-        data-testid={__customerGridId__}
+        data-testid={testId("customer-grid")}
       >
         {customers?.map(
           (customer, i) =>

--- a/packages/ui/src/CustomerList/CustomerList.tsx
+++ b/packages/ui/src/CustomerList/CustomerList.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { CustomerFull, Customer } from "@eisbuk/shared";
 import { useTranslation, CustomerLabel } from "@eisbuk/translations";
 
-import { __customerListId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import CustomerListItem from "./CustomerListItem";
 
@@ -35,7 +35,7 @@ const CustomerList: React.FC<Props> = ({
             </th>
           </tr>
         </thead>
-        <tbody data-testid={__customerListId__}>
+        <tbody data-testid={testId("customer-list")}>
           {customers?.map(
             (customer, i) =>
               (filterRegex.test(customer.name) ||

--- a/packages/ui/src/Forms/CustomerForm/SectionPersonalDetails.tsx
+++ b/packages/ui/src/Forms/CustomerForm/SectionPersonalDetails.tsx
@@ -10,7 +10,7 @@ import i18n, {
 import { User, Cake, Mail, Phone } from "@eisbuk/svg";
 import { isValidPhoneNumber } from "@eisbuk/shared";
 
-import { __birthdayInputId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import FormSection from "../FormSection";
 import FormField, { FormFieldVariant, FormFieldWitdh } from "../FormField";
@@ -62,7 +62,7 @@ const SectionPersonalDetails: React.FC<SectionProps> = ({
         variant={FormFieldVariant.Date}
         width={FormFieldWitdh.MD}
         label={t(CustomerLabel.Birthday)}
-        data-testid={__birthdayInputId__}
+        data-testid={testId("birthday-input")}
         Icon={Cake}
       />
 

--- a/packages/ui/src/Forms/SlotForm/TimeIntervalField.tsx
+++ b/packages/ui/src/Forms/SlotForm/TimeIntervalField.tsx
@@ -4,12 +4,7 @@ import { Field, useField } from "formik";
 import { useTranslation, SlotFormAria } from "@eisbuk/translations";
 import { Trash } from "@eisbuk/svg";
 
-import {
-  __deleteIntervalId__,
-  __endTimeInputId__,
-  __startTimeInputId__,
-  __timeIntervalFieldId__,
-} from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import TimePickerField from "./TimePickerField";
 import IconButton from "../../IconButton";
@@ -40,7 +35,7 @@ const TimeIntervalField: React.FC<Props> = ({ onDelete, dark, name }) => {
 
   return (
     <div
-      data-testid={__timeIntervalFieldId__}
+      data-testid={testId("time-interval-field")}
       className={`relative w-full px-4 py-3 flex items-center justify-between gap-x-8 ${colorClass}`}
     >
       <div className="w-full flex flex-col gap-x-8 gap-y-4 sm:flex-row sm:justify-evenly">
@@ -48,7 +43,7 @@ const TimeIntervalField: React.FC<Props> = ({ onDelete, dark, name }) => {
           key="startTime"
           name={`${name}.startTime`}
           label={t("SlotForm.StartTime")}
-          data-testid={__startTimeInputId__}
+          data-testid={testId("start-time-input")}
           aria-label={t(SlotFormAria.IntervalStart)}
           component={TimePickerField}
           error={Boolean(error)}
@@ -57,7 +52,7 @@ const TimeIntervalField: React.FC<Props> = ({ onDelete, dark, name }) => {
           key="endTime"
           name={`${name}.endTime`}
           label={t("SlotForm.EndTime")}
-          data-testid={__endTimeInputId__}
+          data-testid={testId("end-time-input")}
           aria-label={t(SlotFormAria.IntervalEnd)}
           component={TimePickerField}
           error={Boolean(error)}
@@ -65,7 +60,7 @@ const TimeIntervalField: React.FC<Props> = ({ onDelete, dark, name }) => {
       </div>
       <IconButton
         className="!w-14 !h-10 py-1.5 bg-cyan-700 active:bg-cyan-600 text-white"
-        data-testid={__deleteIntervalId__}
+        data-testid={testId("delete-interval-button")}
         aria-label={t(SlotFormAria.DeleteInterval)}
         color="primary"
         onClick={onDelete}

--- a/packages/ui/src/Forms/SlotForm/TimePickerField.tsx
+++ b/packages/ui/src/Forms/SlotForm/TimePickerField.tsx
@@ -4,7 +4,7 @@ import { useField } from "formik";
 
 import { Plus, Minus } from "@eisbuk/svg";
 
-import { __decrementId__, __incrementId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import TextInput, { TextInputFieldProps } from "../../TextInput";
 import IconButton from "../../IconButton";
@@ -67,7 +67,7 @@ const TimePickerField: React.FC<TextInputFieldProps> = ({ ...props }) => {
       <IconButton
         className="w-8 h-6 rounded-md bg-cyan-700 text-white !px-1.5 !py-1 flex-shrink-0 hover:bg-cyan-700 active:bg-cyan-600"
         onClick={handleClick(-1)}
-        data-testid={__decrementId__}
+        data-testid={testId("decrement-button")}
       >
         <Minus />
       </IconButton>
@@ -80,7 +80,7 @@ const TimePickerField: React.FC<TextInputFieldProps> = ({ ...props }) => {
       <IconButton
         className="w-8 h-6 rounded-md bg-cyan-700 text-white !px-1.5 !py-1 flex-shrink-0 hover:bg-cyan-700 active:bg-cyan-600"
         onClick={handleClick(1)}
-        data-testid={__incrementId__}
+        data-testid={testId("increment-button")}
       >
         <Plus />
       </IconButton>

--- a/packages/ui/src/Forms/SlotForm/__tests__/SlotForm.test.tsx
+++ b/packages/ui/src/Forms/SlotForm/__tests__/SlotForm.test.tsx
@@ -26,10 +26,7 @@ import i18n, {
   DateFormat,
 } from "@eisbuk/translations";
 
-import {
-  __timeIntervalFieldId__,
-  __deleteIntervalId__,
-} from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import { defaultInterval, defaultSlotFormValues } from "../data";
 
@@ -74,7 +71,7 @@ describe("SlotForm", () => {
         screen.getByText(i18n.t(CategoryLabel[label]) as string);
       });
       // intervals field
-      screen.getByTestId(__timeIntervalFieldId__);
+      screen.getByTestId(testId("time-interval-field"));
     });
 
     test("should render a deprecated categories for backwards compatibility, but disable them for selection", () => {
@@ -115,19 +112,25 @@ describe("SlotForm", () => {
     });
 
     test("should render one field for empty form", () => {
-      const intervalFields = screen.queryAllByTestId(__timeIntervalFieldId__);
+      const intervalFields = screen.queryAllByTestId(
+        testId("time-interval-field")
+      );
       expect(intervalFields.length).toEqual(1);
     });
 
     test("should create a new interval field on 'Add New' button click", () => {
       screen.getByText(i18n.t(SlotFormLabel.AddInterval) as string).click();
-      const intervalFields = screen.queryAllByTestId(__timeIntervalFieldId__);
+      const intervalFields = screen.queryAllByTestId(
+        testId("time-interval-field")
+      );
       expect(intervalFields.length).toEqual(2);
     });
 
     test("should delete an interval field on 'Delete' button click", () => {
-      act(() => screen.getByTestId(__deleteIntervalId__).click());
-      const intervalFields = screen.queryAllByTestId(__timeIntervalFieldId__);
+      act(() => screen.getByTestId(testId("delete-interval-button")).click());
+      const intervalFields = screen.queryAllByTestId(
+        testId("time-interval-field")
+      );
       expect(intervalFields.length).toEqual(0);
     });
   });
@@ -241,7 +244,7 @@ describe("SlotForm", () => {
         />
       );
       // delete first interval
-      screen.getAllByTestId(__deleteIntervalId__)[0].click();
+      screen.getAllByTestId(testId("delete-interval-button"))[0].click();
       // trigger submit
       screen.getByText(i18n.t(ActionButton.Save) as string).click();
       await waitFor(() =>

--- a/packages/ui/src/Forms/SlotForm/__tests__/SlotIntervals.test.tsx
+++ b/packages/ui/src/Forms/SlotForm/__tests__/SlotIntervals.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { describe, afterEach, vi, test, expect } from "vitest";
 import { cleanup, screen } from "@testing-library/react";
 
-import { __timeIntervalFieldId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import SlotIntervals from "../SlotIntervals";
 
@@ -22,7 +22,9 @@ describe("SlotForm", () => {
 
     test("should render intervals from initial values", () => {
       renderWithFormik(<SlotIntervals />, { initialValues });
-      const intervalFields = screen.queryAllByTestId(__timeIntervalFieldId__);
+      const intervalFields = screen.queryAllByTestId(
+        testId("time-interval-field")
+      );
       expect(intervalFields.length).toEqual(2);
     });
 

--- a/packages/ui/src/Forms/SlotForm/__tests__/TimeIntervalField.test.tsx
+++ b/packages/ui/src/Forms/SlotForm/__tests__/TimeIntervalField.test.tsx
@@ -3,7 +3,7 @@ import { describe, afterEach, vi, test, expect } from "vitest";
 import { screen, cleanup } from "@testing-library/react";
 import * as formik from "formik";
 
-import { __deleteIntervalId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import TimeIntervalField from "../TimeIntervalField";
 
@@ -43,7 +43,7 @@ describe("'SlotForm',", () => {
       renderWithFormik(
         <TimeIntervalField {...baseProps} onDelete={mockDelete} />
       );
-      screen.getByTestId(__deleteIntervalId__).click();
+      screen.getByTestId(testId("delete-interval-button")).click();
       expect(mockDelete).toHaveBeenCalled();
     });
   });

--- a/packages/ui/src/Forms/SlotForm/__tests__/TimePickerField.test.tsx
+++ b/packages/ui/src/Forms/SlotForm/__tests__/TimePickerField.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Field } from "formik";
 
-import { __decrementId__, __incrementId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import TimePickerField from "../TimePickerField";
 
@@ -57,9 +57,9 @@ describe("SlotForm,", () => {
 
     test('should increment/decrement time by an hour on"+"/"-" button click', () => {
       renderWithFormik(<Field component={TimePickerField} name="time" />);
-      screen.getByTestId(__incrementId__).click();
+      screen.getByTestId(testId("increment-button")).click();
       expect(mockSetValue).toHaveBeenCalledWith("09:00");
-      screen.getByTestId(__decrementId__).click();
+      screen.getByTestId(testId("decrement-button")).click();
       // we're testing change being called with one hour decrement from initial 'value' as 'value' doesn't due to mocking
       expect(mockSetValue).toHaveBeenCalledWith("07:00");
     });
@@ -68,7 +68,7 @@ describe("SlotForm,", () => {
       renderWithFormik(
         <Field component={TimePickerField} name="time" value="invalid_string" />
       );
-      screen.getByTestId(__incrementId__).click();
+      screen.getByTestId(testId("increment-button")).click();
       await waitFor(() => expect(mockSetValue).toHaveBeenCalledWith("09:00"));
     });
   });

--- a/packages/ui/src/NotificationToast/NotificationToast.tsx
+++ b/packages/ui/src/NotificationToast/NotificationToast.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { __notificationToastId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import { Close } from "@eisbuk/svg";
 
@@ -32,7 +32,7 @@ const NotificationToast: React.FC<NotificationToastProps> = ({
       className: [...baseClasses, colorClassLookup[variant], className].join(
         " "
       ),
-      "data-testid": __notificationToastId__,
+      "data-testid": testId("notification-toast"),
     },
     [
       <span

--- a/packages/ui/src/SlotCard/SlotCard.tsx
+++ b/packages/ui/src/SlotCard/SlotCard.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { SlotInterface, SlotInterval, SlotType } from "@eisbuk/shared";
 import i18n, { CategoryLabel } from "@eisbuk/translations";
 
-import { __slotCardId__ } from "@eisbuk/testing/testIds";
+import { testId } from "@eisbuk/testing/testIds";
 
 import SlotTypeIcon from "../SlotTypeIcon";
 
@@ -62,7 +62,7 @@ const SlotCard: React.FC<SlotCardProps> = ({
       } ${type === SlotType.Ice ? "outline-cyan-500" : "outline-yellow-600"} ${
         canClick ? "cursor-pointer" : "cursor-normal"
       } ${className}`}
-      data-testid={__slotCardId__}
+      data-testid={testId("slot-card")}
       onClick={onClick}
     >
       <div className="mb-4 pt-2 grid grid-cols-5 gap-x-6 gap-y-2">


### PR DESCRIPTION
* Export a type safe 'testId' function from the '@eisbuk/testing/testIds' instead of test id strings
* The constructor accepst metadata for certain test ids and constructs a consistent string from inputs
* Replace test id usage across the packages

Finalises #750 (point 2)