### PR TITLE
Some copy/paste related fixes:

### DIFF
--- a/.github/workflow.templates/storybook.yml
+++ b/.github/workflow.templates/storybook.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         if: steps.has_secret.outputs.HAS_SECRETS
+        # We expect this to fail with `Command failed with ENOENT: pnpm --version`
+        continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMAUI_PROJECT_TOKEN }}

--- a/.github/workflow.templates/storybook.yml
+++ b/.github/workflow.templates/storybook.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         if: steps.has_secret.outputs.HAS_SECRETS
-        # We expect this to fail with `Command failed with ENOENT: pnpm --version`
+        #! We expect this to fail with `Command failed with ENOENT: pnpm --version`
         continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -37,6 +37,7 @@ jobs:
     - name: Publish to Chromatic
       uses: chromaui/action@v1
       if: steps.has_secret.outputs.HAS_SECRETS
+      continue-on-error: true
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         projectToken: ${{ secrets.CHROMAUI_PROJECT_TOKEN }}

--- a/.github/workflows/vitest-matrix.yml
+++ b/.github/workflows/vitest-matrix.yml
@@ -27,7 +27,7 @@ jobs:
         - 5
         - 6
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
         fetch-depth: 1
@@ -35,7 +35,7 @@ jobs:
       with:
         node-version: "18"
     - name: Cache node modules and firebase emulators
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.rush

--- a/packages/client/src/utils/firestore/compat.ts
+++ b/packages/client/src/utils/firestore/compat.ts
@@ -94,12 +94,14 @@ export const doc = (
   return match(node, {
     [FirestoreEnv.Client]: ({ instance }) =>
       FirestoreDocVariant.client({
-        // Even though 'doc' (aliased as 'clientDoc' here) works on both firestore and collection instanceerences,
+        // Even though 'doc' (aliased as 'clientDoc' here) works on both firestore and collection references,
         // it doesn't work well on unions because of slightly different type overloads, hence the typecast.
-        instance: clientDoc(
-          instance as ClientFirestore,
-          pathSegments.join("/")
-        ),
+        instance: docPath.length
+          ? clientDoc(
+              instance as ClientCollectionReference,
+              docPath.length ? docPath : undefined
+            )
+          : clientDoc(instance as ClientCollectionReference),
       }),
     [FirestoreEnv.Server]: ({ instance }) =>
       FirestoreDocVariant.server({
@@ -235,7 +237,7 @@ export const writeBatch = (db: FirestoreVariant) =>
           }
           return batch.set(doc.instance, data);
         },
-        commit: batch.commit,
+        commit: batch.commit.bind(batch),
       };
     },
     [FirestoreEnv.Server]: ({ instance }) => {
@@ -248,7 +250,7 @@ export const writeBatch = (db: FirestoreVariant) =>
           }
           return batch.set(doc.instance, data);
         },
-        commit: batch.commit,
+        commit: batch.commit.bind(batch),
       };
     },
   });

--- a/packages/client/src/utils/firestore/compat.ts
+++ b/packages/client/src/utils/firestore/compat.ts
@@ -97,10 +97,7 @@ export const doc = (
         // Even though 'doc' (aliased as 'clientDoc' here) works on both firestore and collection references,
         // it doesn't work well on unions because of slightly different type overloads, hence the typecast.
         instance: docPath.length
-          ? clientDoc(
-              instance as ClientCollectionReference,
-              docPath.length ? docPath : undefined
-            )
+          ? clientDoc(instance as ClientCollectionReference, docPath)
           : clientDoc(instance as ClientCollectionReference),
       }),
     [FirestoreEnv.Server]: ({ instance }) =>


### PR DESCRIPTION
* In firestore compat `doc` function, client variant: if doc path is not provided (we wish a new server-assigned id), pass only the parent node (to prevent empty path crashes)
* In firestore compat `batch` function, bind `this` to returned `commit` methods (for both client and server variant)

Fixes #797 