### PR TITLE
Improve sentry release naming

### DIFF
--- a/.github/workflow.templates/build.yml
+++ b/.github/workflow.templates/build.yml
@@ -47,7 +47,7 @@ jobs:
           REACT_APP_SENTRY_ENVIRONMENT: staging
           REACT_APP_SENTRY_RELEASE: ${{ github.sha }}
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v4
       -  #@ check_secrets()
       - name: Create Sentry release
         uses: getsentry/action-release@v1

--- a/.github/workflow.templates/build.yml
+++ b/.github/workflow.templates/build.yml
@@ -27,8 +27,8 @@ jobs:
       -  #@ rush_add_path()
       -  #@ rush_update()
       -  #@ rush_build()
-      - name: Generate name for sentry release
-        run: echo "SENTRY_RELEASE=$(date +%Y-%m-%d)-${{ github.sha }}" >> $GITHUB_ENV
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
       - name: Build app
         run: |
           cd packages/client && NODE_OPTIONS="--max-old-space-size=8192" rushx build:prod | tee build.output
@@ -47,9 +47,7 @@ jobs:
           REACT_APP_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
           REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_IGORICE_DSN }}
           REACT_APP_SENTRY_ENVIRONMENT: staging
-          REACT_APP_SENTRY_RELEASE: ${{ env.SENTRY_RELEASE }}
-      - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v4
+          REACT_APP_SENTRY_RELEASE: ${{ env.GITHUB_REF_SLUG_URL }}
       -  #@ check_secrets()
       - name: Create Sentry release
         uses: getsentry/action-release@v1
@@ -62,7 +60,7 @@ jobs:
         with:
           environment: staging
           sourcemaps: ./packages/client/dist/assets
-          version: ${{ env.SENTRY_RELEASE }}
+          version: ${{ env.GITHUB_REF_SLUG_URL }}
           set_commits: skip
       - name: Deploy preview channel
         id: deploy

--- a/.github/workflow.templates/build.yml
+++ b/.github/workflow.templates/build.yml
@@ -27,6 +27,8 @@ jobs:
       -  #@ rush_add_path()
       -  #@ rush_update()
       -  #@ rush_build()
+      - name: Generate name for sentry release
+        run: echo "SENTRY_RELEASE=$(date +%Y-%m-%d)-${{ github.sha }}" >> $GITHUB_ENV
       - name: Build app
         run: |
           cd packages/client && NODE_OPTIONS="--max-old-space-size=8192" rushx build:prod | tee build.output
@@ -45,7 +47,7 @@ jobs:
           REACT_APP_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
           REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_IGORICE_DSN }}
           REACT_APP_SENTRY_ENVIRONMENT: staging
-          REACT_APP_SENTRY_RELEASE: ${{ github.sha }}
+          REACT_APP_SENTRY_RELEASE: ${{ env.SENTRY_RELEASE }}
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
       -  #@ check_secrets()
@@ -60,6 +62,8 @@ jobs:
         with:
           environment: staging
           sourcemaps: ./packages/client/dist/assets
+          version: ${{ env.SENTRY_RELEASE }}
+          set_commits: skip
       - name: Deploy preview channel
         id: deploy
         if: steps.has_secret.outputs.HAS_SECRETS

--- a/.github/workflow.templates/deploy-production.yml
+++ b/.github/workflow.templates/deploy-production.yml
@@ -26,8 +26,10 @@ jobs:
       -  #@ rush_add_path()
       -  #@ rush_update()
       -  #@ rush_build()
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
       - name: Generate name for sentry release
-        run: echo "SENTRY_RELEASE=$(date +%Y-%m-%d)-${{ github.sha }}" >> $GITHUB_ENV
+        run: echo "SENTRY_RELEASE=$(date +%Y-%m-%d)-${{ env.GITHUB_SHA_SHORT }}" >> $GITHUB_ENV
       - name: Build app
         run: cd packages/client && rushx build:prod
         env:

--- a/.github/workflow.templates/deploy-production.yml
+++ b/.github/workflow.templates/deploy-production.yml
@@ -26,6 +26,8 @@ jobs:
       -  #@ rush_add_path()
       -  #@ rush_update()
       -  #@ rush_build()
+      - name: Generate name for sentry release
+        run: echo "SENTRY_RELEASE=$(date +%Y-%m-%d)-${{ github.sha }}" >> $GITHUB_ENV
       - name: Build app
         run: cd packages/client && rushx build:prod
         env:
@@ -38,11 +40,7 @@ jobs:
           REACT_APP_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
           REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_IGORICE_DSN }}
           REACT_APP_SENTRY_ENVIRONMENT: production
-          REACT_APP_SENTRY_RELEASE: ${{ github.sha }}
-      - name: Deploy to firebase
-        run: rush deploy:production
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}
+          REACT_APP_SENTRY_RELEASE: ${{ env.SENTRY_RELEASE }}
       - name: Create Sentry release
         uses: getsentry/action-release@v1
         env:
@@ -53,3 +51,8 @@ jobs:
         with:
           environment: production
           sourcemaps: "./packages/client/dist/assets"
+          version: ${{ env.SENTRY_RELEASE }}
+      - name: Deploy to firebase
+        run: rush deploy:production
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,8 @@ jobs:
       run: rush update
     - name: Build packages
       run: rush build
-    - name: Generate name for sentry release
-      run: echo "SENTRY_RELEASE=$(date +%Y-%m-%d)-${{ github.sha }}" >> $GITHUB_ENV
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v4
     - name: Build app
       run: |
         cd packages/client && NODE_OPTIONS="--max-old-space-size=8192" rushx build:prod | tee build.output
@@ -50,9 +50,7 @@ jobs:
         REACT_APP_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
         REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_IGORICE_DSN }}
         REACT_APP_SENTRY_ENVIRONMENT: staging
-        REACT_APP_SENTRY_RELEASE: ${{ env.SENTRY_RELEASE }}
-    - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v4
+        REACT_APP_SENTRY_RELEASE: ${{ env.GITHUB_REF_SLUG_URL }}
     - name: Check if secrets are available
       id: has_secret
       if: success() || failure()
@@ -68,7 +66,7 @@ jobs:
       with:
         environment: staging
         sourcemaps: ./packages/client/dist/assets
-        version: ${{ env.SENTRY_RELEASE }}
+        version: ${{ env.GITHUB_REF_SLUG_URL }}
         set_commits: skip
     - name: Deploy preview channel
       id: deploy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         REACT_APP_SENTRY_ENVIRONMENT: staging
         REACT_APP_SENTRY_RELEASE: ${{ github.sha }}
     - name: Inject slug/short variables
-      uses: rlespinasse/github-slug-action@v3.x
+      uses: rlespinasse/github-slug-action@v4
     - name: Check if secrets are available
       id: has_secret
       if: success() || failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
       run: rush update
     - name: Build packages
       run: rush build
+    - name: Generate name for sentry release
+      run: echo "SENTRY_RELEASE=$(date +%Y-%m-%d)-${{ github.sha }}" >> $GITHUB_ENV
     - name: Build app
       run: |
         cd packages/client && NODE_OPTIONS="--max-old-space-size=8192" rushx build:prod | tee build.output
@@ -48,7 +50,7 @@ jobs:
         REACT_APP_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
         REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_IGORICE_DSN }}
         REACT_APP_SENTRY_ENVIRONMENT: staging
-        REACT_APP_SENTRY_RELEASE: ${{ github.sha }}
+        REACT_APP_SENTRY_RELEASE: ${{ env.SENTRY_RELEASE }}
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v4
     - name: Check if secrets are available
@@ -66,6 +68,8 @@ jobs:
       with:
         environment: staging
         sourcemaps: ./packages/client/dist/assets
+        version: ${{ env.SENTRY_RELEASE }}
+        set_commits: skip
     - name: Deploy preview channel
       id: deploy
       if: steps.has_secret.outputs.HAS_SECRETS

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -34,6 +34,8 @@ jobs:
       run: rush update
     - name: Build packages
       run: rush build
+    - name: Generate name for sentry release
+      run: echo "SENTRY_RELEASE=$(date +%Y-%m-%d)-${{ github.sha }}" >> $GITHUB_ENV
     - name: Build app
       run: cd packages/client && rushx build:prod
       env:
@@ -46,11 +48,7 @@ jobs:
         REACT_APP_FIREBASE_MEASUREMENT_ID: ${{ secrets.FIREBASE_MEASUREMENT_ID }}
         REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_IGORICE_DSN }}
         REACT_APP_SENTRY_ENVIRONMENT: production
-        REACT_APP_SENTRY_RELEASE: ${{ github.sha }}
-    - name: Deploy to firebase
-      run: rush deploy:production
-      env:
-        FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}
+        REACT_APP_SENTRY_RELEASE: ${{ env.SENTRY_RELEASE }}
     - name: Create Sentry release
       uses: getsentry/action-release@v1
       env:
@@ -61,3 +59,8 @@ jobs:
       with:
         environment: production
         sourcemaps: ./packages/client/dist/assets
+        version: ${{ env.SENTRY_RELEASE }}
+    - name: Deploy to firebase
+      run: rush deploy:production
+      env:
+        FIREBASE_TOKEN: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EISBUK }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -34,8 +34,10 @@ jobs:
       run: rush update
     - name: Build packages
       run: rush build
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v4
     - name: Generate name for sentry release
-      run: echo "SENTRY_RELEASE=$(date +%Y-%m-%d)-${{ github.sha }}" >> $GITHUB_ENV
+      run: echo "SENTRY_RELEASE=$(date +%Y-%m-%d)-${{ env.GITHUB_SHA_SHORT }}" >> $GITHUB_ENV
     - name: Build app
       run: cd packages/client && rushx build:prod
       env:

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -63,7 +63,7 @@
     "test:triggers": "bash -c '(trap \"kill 0\" SIGINT; ../functions/build_scripts/watch.js & firebase -c ../../firebase-testing.json  emulators:exec --project eisbuk -- \" vitest dataTriggers\")'",
     "test:rules": "bash -c '(trap \"kill 0\" SIGINT; ../functions/build_scripts/watch.js & firebase -c ../../firebase-testing.json  emulators:exec --project eisbuk -- \" vitest firestoreRules\")'",
     "test:integrations": "bash -c '(trap \"kill 0\" SIGINT; ../functions/build_scripts/watch.js & firebase -c ../../firebase-testing.json  emulators:exec --project eisbuk -- \" vitest integrations\")'",
-    "test:emulators:ci": "CI=true VITEST_JUNIT_SUITE_NAME=\"Client tests\" bash -c '(trap \"kill 0\" SIGINT; ../functions/build_scripts/watch.js & firebase -c ../../firebase-testing.json  emulators:exec --project eisbuk -- \" vitest run --coverage --reporter=junit --reporter=html --outputFile.junit=junit.xml/\")' || true # We always exit with code 0: a subsequent CI step will fail if a test fails.",
+    "test:emulators:ci": "CI=true VITEST_JUNIT_SUITE_NAME=\"Client tests\" bash -c '(trap \"kill 0\" SIGINT; ../functions/build_scripts/watch.js & firebase -c ../../firebase-testing.json  emulators:exec --project eisbuk -- \" vitest run --coverage --reporter=junit --reporter=html --outputFile.junit=junit.xml\")' || true # We always exit with code 0: a subsequent CI step will fail if a test fails.",
     "test:quicktest": "echo Running tests with no emulators support && vitest --ui",
     "test": "echo 'Running all tests; using emulators.' && rushx test:emulators:ui",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
This PR changes the way sentry release are named. Namely:

* the branch name will now be used for staging releases, instead of the sha
* for production releases the date and short sha will be concatenated to form the release name