### PR TITLE
Disable deleting intervals dialog

### DIFF
--- a/packages/client/src/components/atoms/SlotOperationButtons/DeleteButton.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/DeleteButton.tsx
@@ -41,7 +41,7 @@ export const DeleteButton: React.FC = () => {
 
   const { openWithProps: openDeleteSlotDialog } = useDeleteSlotModal();
   const { openWithProps: openDeleteSlotDisabledDialog } =
-    useDeleteSlotDieabledModal();
+    useDeleteSlotDisabledModal();
 
   // prevent component from rendering and log error to console (but don't throw)
   // if not rendered within the `SlotOperationButtons` context
@@ -111,6 +111,6 @@ export const DeleteButton: React.FC = () => {
 };
 
 const useDeleteSlotModal = createModal("DeleteSlotDialog");
-const useDeleteSlotDieabledModal = createModal("DeleteSlotDisabledDialog");
+const useDeleteSlotDisabledModal = createModal("DeleteSlotDisabledDialog");
 
 export default DeleteButton;

--- a/packages/client/src/components/atoms/SlotOperationButtons/EditSlotButton.tsx
+++ b/packages/client/src/components/atoms/SlotOperationButtons/EditSlotButton.tsx
@@ -38,6 +38,9 @@ export const EditSlotButton: React.FC = () => {
       : {}
   );
 
+  const { openWithProps: openDeleteIntervalDisabledDialog } =
+    useDeleteIntervalDisabledModal();
+
   const { openWithProps: openSlotForm } = useSlotFormModal();
 
   // prevent component from rendering and log error to console (but don't throw)
@@ -62,6 +65,7 @@ export const EditSlotButton: React.FC = () => {
       date: slot.date,
       slotToEdit: slot,
       slotAttendances,
+      openDeleteIntervalDisabledDialog,
     });
   };
 
@@ -84,5 +88,8 @@ export const EditSlotButton: React.FC = () => {
 };
 
 const useSlotFormModal = createModal("SlotFormDialog");
+const useDeleteIntervalDisabledModal = createModal(
+  "DeleteIntervalDisabledDialog"
+);
 
 export default EditSlotButton;

--- a/packages/client/src/controllers/SlotCard/__tests__/SlotCard.test.tsx
+++ b/packages/client/src/controllers/SlotCard/__tests__/SlotCard.test.tsx
@@ -71,10 +71,12 @@ describe("SlotCard", () => {
       screen.getByTestId(testId("edit-slot-button")).click();
       const mockDispatchCallPayload = mockDispatch.mock.calls[0][0].payload;
       expect(mockDispatchCallPayload.component).toEqual("SlotFormDialog");
-      expect(mockDispatchCallPayload.props).toEqual({
-        date: baseSlot.date,
-        slotToEdit: baseSlot,
-        slotAttendances: mockSelector,
+      expect.objectContaining({
+        [mockDispatchCallPayload.props]: expect.objectContaining({
+          date: baseSlot.date,
+          slotToEdit: baseSlot,
+          slotAttendances: mockSelector,
+        }),
       });
     });
 

--- a/packages/client/src/features/modal/components/DeleteIntervalDisabledDialog/DeleteIntervalDisabledDialog.tsx
+++ b/packages/client/src/features/modal/components/DeleteIntervalDisabledDialog/DeleteIntervalDisabledDialog.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { SlotInterval } from "@eisbuk/shared";
+
+import { ActionDialog } from "@eisbuk/ui";
+import i18n, { ActionButton, Prompt } from "@eisbuk/translations";
+
+import { BaseModalProps } from "../../types";
+
+const DeleteIntervalDialog: React.FC<BaseModalProps & SlotInterval> = ({
+  onClose,
+  className,
+  ...interval
+}) => {
+  const title = i18n.t(Prompt.DeleteIntervalDisabledTitle);
+
+  return (
+    <ActionDialog
+      onCancel={onClose}
+      {...{ title, className }}
+      cancelLabel={i18n.t(ActionButton.Dismiss)}
+    >
+      <p className="mb-8">{i18n.t(Prompt.DeleteIntervalDisabled)}</p>
+      <div className="w-fit p-1 rounded-md bg-white outline outline-2 outline-gray-300">
+        {interval.startTime}-{interval.startTime}
+      </div>
+    </ActionDialog>
+  );
+};
+
+export default DeleteIntervalDialog;

--- a/packages/client/src/features/modal/components/DeleteIntervalDisabledDialog/__tests__/DeleteSlotDisabledDialog.test.tsx
+++ b/packages/client/src/features/modal/components/DeleteIntervalDisabledDialog/__tests__/DeleteSlotDisabledDialog.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from "react";
+import { describe, vi, expect, test, afterEach, beforeEach } from "vitest";
+import { screen, render, cleanup } from "@testing-library/react";
+
+import i18n, { ActionButton } from "@eisbuk/translations";
+
+import DeleteIntervalDisabledDialog from "../DeleteIntervalDisabledDialog";
+
+import { intervals } from "@eisbuk/testing/slots";
+
+const mockOnClose = vi.fn();
+
+const mockDispatch = vi.fn();
+vi.mock("react-redux", () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+describe("DeleteIntervalDisabledDialog", () => {
+  beforeEach(() => {
+    render(
+      <DeleteIntervalDisabledDialog
+        {...intervals[0]}
+        onClose={mockOnClose}
+        onCloseAll={() => {}}
+      />
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    cleanup();
+  });
+
+  test("should call onClose on 'Dismiss' button click", () => {
+    screen.getByText(i18n.t(ActionButton.Dismiss) as string).click();
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/features/modal/components/DeleteIntervalDisabledDialog/index.ts
+++ b/packages/client/src/features/modal/components/DeleteIntervalDisabledDialog/index.ts
@@ -1,0 +1,3 @@
+import DeleteIntervalDisabledDialog from "./DeleteIntervalDisabledDialog";
+
+export default DeleteIntervalDisabledDialog;

--- a/packages/client/src/features/modal/components/index.ts
+++ b/packages/client/src/features/modal/components/index.ts
@@ -9,6 +9,7 @@ import DeleteCustomerDialog from "./DeleteCustomerDialog";
 import ExtendBookingDateDialog from "./ExtendBookingDateDialog";
 import DeleteSlotDialog from "./DeleteSlotDialog";
 import DeleteSlotDisabledDialog from "./DeleteSlotDisabledDialog";
+import DeleteIntervalDisabledDialog from "./DeleteIntervalDisabledDialog";
 import AddAttendedCustomersDialog from "./AddAttendedCustomersDialog";
 import SlotFormDialog from "./SlotFormDialog";
 import SendICSDialog from "./SendICSDialog";
@@ -24,6 +25,7 @@ export const componentWhitelist = {
   ExtendBookingDateDialog,
   DeleteSlotDialog,
   DeleteSlotDisabledDialog,
+  DeleteIntervalDisabledDialog,
   AddAttendedCustomersDialog,
   BirthdayDialog,
   SlotFormDialog,

--- a/packages/translations/src/dict/en.json
+++ b/packages/translations/src/dict/en.json
@@ -202,6 +202,8 @@
     "DeleteSlot": "Are you sure you want to delete the slot:",
     "DeleteSlotDisabledTitle": "Unable to delete",
     "DeleteSlotDisabled": "Unable to delete the slot, as it has already been booked by one or more athletes",
+    "DeleteIntervalDisabledTitle": "Unable to delete",
+    "DeleteIntervalDisabled": "Unable to delete the interval, as it has already been booked by one or more athletes",
 
     "NonReversible": "This action is non-reversible",
 

--- a/packages/translations/src/dict/it.json
+++ b/packages/translations/src/dict/it.json
@@ -203,6 +203,8 @@
     "DeleteSlot": "Sei sicuro di voler rimuovere lo slot:",
     "DeleteSlotDisabledTitle": "Impossibile rimuovere",
     "DeleteSlotDisabled": "Impossibile rimuovere lo slot: esistono prenotazioni per questo slot",
+    "DeleteIntervalDisabledTitle": "Impossibile rimuovere",
+    "DeleteIntervalDisabled": "Impossibile eliminare questo intervallo perché è già stato prenotato da uno o più atleti",
 
     "NonReversible": "Questa azione non è reversibile",
 

--- a/packages/translations/src/translations.ts
+++ b/packages/translations/src/translations.ts
@@ -215,6 +215,8 @@ export enum Prompt {
   DeleteSlot = "Prompt.DeleteSlot",
   DeleteSlotDisabledTitle = "Prompt.DeleteSlotDisabledTitle",
   DeleteSlotDisabled = "Prompt.DeleteSlotDisabled",
+  DeleteIntervalDisabledTitle = "Prompt.DeleteIntervalDisabledTitle",
+  DeleteIntervalDisabled = "Prompt.DeleteIntervalDisabled",
 
   NonReversible = "Prompt.NonReversible",
 

--- a/packages/ui/src/Forms/SlotForm/SlotForm.tsx
+++ b/packages/ui/src/Forms/SlotForm/SlotForm.tsx
@@ -87,6 +87,10 @@ export interface SlotFormProps {
    * Attendances of this slot
    */
   slotAttendances?: SlotAttendnace["attendances"];
+  /**
+   * function that opens dialog for deleting a disabled interval
+   */
+  openDeleteIntervalDisabledDialog: () => void;
 }
 
 const SlotForm: React.FC<SlotFormProps> = ({
@@ -96,6 +100,7 @@ const SlotForm: React.FC<SlotFormProps> = ({
   onSubmit = () => {},
   onClose = () => {},
   slotAttendances,
+  openDeleteIntervalDisabledDialog,
 }) => {
   const { t } = useTranslation();
 
@@ -225,7 +230,12 @@ const SlotForm: React.FC<SlotFormProps> = ({
                   t(errors.categories)}
               </p>
 
-              <SlotIntervals slotAttendances={slotAttendances} />
+              <SlotIntervals
+                slotAttendances={slotAttendances}
+                openDeleteIntervalDisabledDialog={
+                  openDeleteIntervalDisabledDialog
+                }
+              />
 
               <FormField
                 name="notes"

--- a/packages/ui/src/Forms/SlotForm/SlotIntervals.tsx
+++ b/packages/ui/src/Forms/SlotForm/SlotIntervals.tsx
@@ -15,8 +15,12 @@ import { defaultInterval } from "./data";
 
 interface SlotIntervalProps {
   slotAttendances?: SlotAttendnace["attendances"];
+  openDeleteIntervalDisabledDialog: (interval: SlotInterval) => void;
 }
-const SlotIntervals: React.FC<SlotIntervalProps> = ({ slotAttendances }) => {
+const SlotIntervals: React.FC<SlotIntervalProps> = ({
+  slotAttendances,
+  openDeleteIntervalDisabledDialog,
+}) => {
   const { t } = useTranslation();
 
   const [{ value: intervals }, , { setValue }] =
@@ -27,7 +31,16 @@ const SlotIntervals: React.FC<SlotIntervalProps> = ({ slotAttendances }) => {
     const newIntervals = [...intervals, defaultInterval];
     setValue(newIntervals);
   };
-  const deleteInterval = (index: number) => {
+
+  const deleteInterval = (
+    index: number,
+    disableUpdate: boolean,
+    interval: SlotInterval
+  ) => {
+    if (disableUpdate) {
+      openDeleteIntervalDisabledDialog(interval);
+      return;
+    }
     const filteredIntervals = intervals.filter((_, i) => i !== index);
     setValue(filteredIntervals);
   };
@@ -58,15 +71,20 @@ const SlotIntervals: React.FC<SlotIntervalProps> = ({ slotAttendances }) => {
       >
         {t(SlotFormLabel.Intervals)}
       </label>
-      {intervals?.map((interval, i) => (
-        <TimeIntervalField
-          key={i}
-          name={`intervals[${i}]`}
-          onDelete={() => deleteInterval(i)}
-          dark={i % 2 === 1}
-          disableUpdate={checkInterval(interval, bookedIntervals)}
-        />
-      ))}
+
+      {intervals?.map((interval, i) => {
+        const disableUpdate = checkInterval(interval, bookedIntervals);
+        return (
+          <TimeIntervalField
+            key={i}
+            name={`intervals[${i}]`}
+            onDelete={() => deleteInterval(i, disableUpdate, interval)}
+            dark={i % 2 === 1}
+            disableUpdate={disableUpdate}
+          />
+        );
+      })}
+
       <div className="flex justify-center items-center">
         <Button
           onClick={addInterval}

--- a/packages/ui/src/Forms/SlotForm/TimeIntervalField.tsx
+++ b/packages/ui/src/Forms/SlotForm/TimeIntervalField.tsx
@@ -82,11 +82,9 @@ const TimeIntervalField: React.FC<Props> = ({
         color="primary"
         onClick={onDelete}
         disableHover
-        disabled={disableUpdate}
       >
         <Trash />
       </IconButton>
-
       <FormError className="absolute bottom-2 left-1/2 -translate-x-1/2 whitespace-nowrap">
         {error}
       </FormError>

--- a/packages/ui/src/Forms/SlotForm/__tests__/SlotForm.test.tsx
+++ b/packages/ui/src/Forms/SlotForm/__tests__/SlotForm.test.tsx
@@ -39,6 +39,9 @@ const baseProps = {
   onClose: () => {},
   onSubmit: () => {},
 };
+const openDeleteIntervalDisabledDialogMock = vi
+  .fn()
+  .mockImplementation(() => {});
 
 describe("SlotForm", () => {
   afterEach(() => {
@@ -48,7 +51,14 @@ describe("SlotForm", () => {
 
   describe("Smoke test", () => {
     beforeEach(() => {
-      render(<SlotForm {...baseProps} />);
+      render(
+        <SlotForm
+          {...baseProps}
+          openDeleteIntervalDisabledDialog={
+            openDeleteIntervalDisabledDialogMock
+          }
+        />
+      );
     });
 
     test("should render \"New Slot\" title if no 'slotToEdit' passed in", () => {
@@ -85,6 +95,9 @@ describe("SlotForm", () => {
         <SlotForm
           {...baseProps}
           slotToEdit={{ ...baseSlot, date: differentDate }}
+          openDeleteIntervalDisabledDialog={
+            openDeleteIntervalDisabledDialogMock
+          }
         />
       );
       screen.getByText(i18n.t(SlotFormTitle.EditSlot) as string);
@@ -98,7 +111,14 @@ describe("SlotForm", () => {
 
   describe("Test interval fields", () => {
     beforeEach(() => {
-      render(<SlotForm {...baseProps} />);
+      render(
+        <SlotForm
+          {...baseProps}
+          openDeleteIntervalDisabledDialog={
+            openDeleteIntervalDisabledDialogMock
+          }
+        />
+      );
     });
 
     test("should render one field for empty form", () => {
@@ -132,6 +152,9 @@ describe("SlotForm", () => {
           {...baseProps}
           slotToEdit={{ ...baseSlot, intervals: createIntervals(13) }}
           slotAttendances={slotAttendances}
+          openDeleteIntervalDisabledDialog={
+            openDeleteIntervalDisabledDialogMock
+          }
         />
       );
       const intervalFields = screen.queryAllByTestId(
@@ -153,6 +176,9 @@ describe("SlotForm", () => {
           {...baseProps}
           onClose={mockOnClose}
           onSubmit={mockOnSubmit}
+          openDeleteIntervalDisabledDialog={
+            openDeleteIntervalDisabledDialogMock
+          }
         />
       );
 
@@ -207,7 +233,15 @@ describe("SlotForm", () => {
     });
 
     test("should call 'onClose' on cancel button click", () => {
-      render(<SlotForm {...baseProps} onClose={mockOnClose} />);
+      render(
+        <SlotForm
+          {...baseProps}
+          onClose={mockOnClose}
+          openDeleteIntervalDisabledDialog={
+            openDeleteIntervalDisabledDialogMock
+          }
+        />
+      );
       screen.getByText(i18n.t(ActionButton.Cancel) as string).click();
       expect(mockOnClose).toHaveBeenCalled();
     });
@@ -219,6 +253,9 @@ describe("SlotForm", () => {
           onClose={mockOnClose}
           onSubmit={mockOnSubmit}
           slotToEdit={baseSlot}
+          openDeleteIntervalDisabledDialog={
+            openDeleteIntervalDisabledDialogMock
+          }
         />
       );
       // trigger submit
@@ -248,6 +285,9 @@ describe("SlotForm", () => {
           onClose={mockOnClose}
           onSubmit={mockOnSubmit}
           slotToEdit={{ ...baseSlot, intervals }}
+          openDeleteIntervalDisabledDialog={
+            openDeleteIntervalDisabledDialogMock
+          }
         />
       );
       // delete first interval
@@ -265,7 +305,14 @@ describe("SlotForm", () => {
 
   describe("Test validation errors", () => {
     beforeEach(() => {
-      render(<SlotForm {...baseProps} />);
+      render(
+        <SlotForm
+          {...baseProps}
+          openDeleteIntervalDisabledDialog={
+            openDeleteIntervalDisabledDialogMock
+          }
+        />
+      );
     });
 
     test("should show error if no categories are selected", async () => {

--- a/packages/ui/src/Forms/SlotForm/__tests__/SlotIntervals.test.tsx
+++ b/packages/ui/src/Forms/SlotForm/__tests__/SlotIntervals.test.tsx
@@ -22,18 +22,36 @@ describe("SlotForm", () => {
     const interval3 = "13:00-13:50";
     const interval4 = "14:00-14:50";
     const initialValues = { intervals: [interval1, interval2] };
+    const openDeleteIntervalDisabledDialogMock = vi
+      .fn()
+      .mockImplementation(() => {});
 
     test("should render intervals from initial values", () => {
-      renderWithFormik(<SlotIntervals />, { initialValues });
+      renderWithFormik(
+        <SlotIntervals
+          openDeleteIntervalDisabledDialog={
+            openDeleteIntervalDisabledDialogMock
+          }
+        />,
+        { initialValues }
+      );
       const intervalFields = screen.queryAllByTestId(
         testId("time-interval-field")
       );
       expect(intervalFields.length).toEqual(2);
     });
     test("should render disabled intervals if they match attendance bookedIntervals", () => {
-      renderWithFormik(<SlotIntervals slotAttendances={slotAttendances} />, {
-        initialValues: { intervals: [interval3, interval4] },
-      });
+      renderWithFormik(
+        <SlotIntervals
+          slotAttendances={slotAttendances}
+          openDeleteIntervalDisabledDialog={
+            openDeleteIntervalDisabledDialogMock
+          }
+        />,
+        {
+          initialValues: { intervals: [interval3, interval4] },
+        }
+      );
       const startIntervalFields = screen.queryAllByTestId(
         testId("start-time-input")
       );
@@ -42,7 +60,13 @@ describe("SlotForm", () => {
     });
 
     test("should not explode if no intervals are present in initial value", () => {
-      renderWithFormik(<SlotIntervals />);
+      renderWithFormik(
+        <SlotIntervals
+          openDeleteIntervalDisabledDialog={
+            openDeleteIntervalDisabledDialogMock
+          }
+        />
+      );
     });
   });
 });

--- a/packages/ui/src/Forms/SlotForm/__tests__/TimeIntervalField.test.tsx
+++ b/packages/ui/src/Forms/SlotForm/__tests__/TimeIntervalField.test.tsx
@@ -46,7 +46,9 @@ describe("'SlotForm',", () => {
       screen.getByTestId(testId("delete-interval-button")).click();
       expect(mockDelete).toHaveBeenCalled();
     });
-    test("should disable deleting or updating intervals", () => {
+
+    /** @TODO might be a pointless test */
+    test("should fire delete function when disabled but only the dialog would show up", () => {
       const mockDelete = vi.fn();
       renderWithFormik(
         <TimeIntervalField
@@ -56,7 +58,7 @@ describe("'SlotForm',", () => {
         />
       );
       screen.getByTestId(testId("delete-interval-button")).click();
-      expect(mockDelete).not.toHaveBeenCalled();
+      expect(mockDelete).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
A dialog shows up when trying to delete a booked interval similar to that one for slots.
I don't love this because it's too complex and it's only for showing a message which could alternatively and more simply be a hover text.