### PR TITLE
Feature/db sanity check 3

### DIFF
--- a/packages/client/src/pages/debug/index.tsx
+++ b/packages/client/src/pages/debug/index.tsx
@@ -161,12 +161,12 @@ const DebugPage: React.FC = () => {
               onClick={() =>
                 createFunctionCaller(
                   functions,
-                  CloudFunction.DBSanityCheck
+                  CloudFunction.DBSlotAttendanceCheck
                 )().then(console.log)
               }
               color={ButtonColor.Primary}
             >
-              DB Sanity Check
+              DB Slot / Attendance Check
             </DebugPageButton>
           </div>
 

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     // but there's no toll for tests that don't need it.
     testTimeout: __isCI__ ? 15000 : 10000,
     setupFiles: ["./vitest.setup.ts"],
+    maxConcurrency: 3,
   },
   resolve: {
     alias: {

--- a/packages/functions/src/checks/https.ts
+++ b/packages/functions/src/checks/https.ts
@@ -43,10 +43,10 @@ export const dbSlotAttendanceAutofix = functions
         SanityCheckKind.SlotAttendance
       );
 
-      const latestReport = await checker.getLatestReport();
-      const report = latestReport.attendanceFixes
-        ? await checker.checkAndWrite()
-        : latestReport;
+      const report = await checker
+        .getLatestReport()
+        // If report doesn't exist, or the latest report had already been fixed, get the new report
+        .then((r) => (!r || r.attendanceFixes ? checker.checkAndWrite() : r));
 
       const attendanceFixes = await attendanceSlotMismatchAutofix(
         db,

--- a/packages/functions/src/checks/https.ts
+++ b/packages/functions/src/checks/https.ts
@@ -44,19 +44,17 @@ export const dbSlotAttendanceAutofix = functions
       );
 
       const latestReport = await checker.getLatestReport();
-      const report = latestReport.fixedAt
+      const report = latestReport.attendanceFixes
         ? await checker.checkAndWrite()
         : latestReport;
 
-      try {
-        await attendanceSlotMismatchAutofix(db, organization, report);
-        await checker.writeReport({
-          ...report,
-          fixedAt: new Date().toISOString(),
-        });
-        return { success: true };
-      } catch (error) {
-        return { success: false, error };
-      }
+      const attendanceFixes = await attendanceSlotMismatchAutofix(
+        db,
+        organization,
+        report
+      );
+      checker.writeReport({ ...report, attendanceFixes });
+
+      return attendanceFixes;
     }
   );

--- a/packages/functions/src/checks/slotRelatedDocs.ts
+++ b/packages/functions/src/checks/slotRelatedDocs.ts
@@ -3,7 +3,9 @@ import admin from "firebase-admin";
 import {
   Collection,
   DateMismatchDoc,
+  FirestoreSchema,
   OrgSubCollection,
+  SanityCheckKind,
   SlotAttendnace,
   SlotInterface,
   SlotSanityCheckReport,
@@ -41,6 +43,9 @@ interface DateCheckPayload {
   entries: EntryDatePayload[];
 }
 
+/**
+ * A util used by slot related check cloud function used to find mismatch between slot and attendance entries.
+ */
 export const findSlotAttendanceMismatches = async (
   db: Firestore,
   organization: string
@@ -87,7 +92,7 @@ export const findSlotAttendanceMismatches = async (
   const unpairedEntries = normalisedEntries._reduce(collectUnpairedDocs, {});
   const dateMismatches = normalisedEntries._reduce(dateMismatchReducer, {});
 
-  return { id: timestamp, unpairedEntries, dateMismatches };
+  return { id: timestamp, unpairedEntries, dateMismatches, fixedAt: null };
 };
 
 const collectUnpairedDocs = (
@@ -187,3 +192,63 @@ export const attendanceSlotMismatchAutofix = async (
 
   return batch.commit();
 };
+
+const getSanityChecksRef = (
+  db: Firestore,
+  organization: string,
+  kind: SanityCheckKind
+) => db.collection(Collection.SanityChecks).doc(organization).collection(kind);
+
+const getLatestSanityCheck = async <K extends SanityCheckKind>(
+  db: Firestore,
+  organization: string,
+  kind: K
+): Promise<SanityCheckReport<K>> => {
+  return getSanityChecksRef(db, organization, kind)
+    .orderBy("id", "asc")
+    .limitToLast(1)
+    .get()
+    .then((snap) => snap.docs[0].data() as SanityCheckReport<K>);
+};
+
+const writeSanityCheckReport = async <K extends SanityCheckKind>(
+  db: Firestore,
+  organization: string,
+  kind: K,
+  report: SanityCheckReport<K>
+): Promise<SanityCheckReport<K>> => {
+  await getSanityChecksRef(db, organization, kind).doc(report.id).set(report);
+  return report;
+};
+
+interface SanityCheckerInterface<K extends SanityCheckKind> {
+  check(): Promise<SanityCheckReport<K>>;
+  writeReport: (report: SanityCheckReport<K>) => Promise<SanityCheckReport<K>>;
+  checkAndWrite: () => Promise<SanityCheckReport<K>>;
+  getLatestReport: () => Promise<SanityCheckReport<K>>;
+}
+
+export const newSanityChecker = <K extends SanityCheckKind>(
+  db: Firestore,
+  organization: string,
+  kind: K
+): SanityCheckerInterface<K> => {
+  const getLatestReport = () => getLatestSanityCheck<K>(db, organization, kind);
+  const writeReport = (report: SanityCheckReport<K>) =>
+    writeSanityCheckReport(db, organization, kind, report);
+
+  const check = (): Promise<SanityCheckReport<K>> =>
+    ({
+      [SanityCheckKind.SlotAttendance]: findSlotAttendanceMismatches(
+        db,
+        organization
+      ),
+    }[kind]);
+
+  const checkAndWrite = () => check().then(writeReport);
+
+  return { getLatestReport, writeReport, check, checkAndWrite };
+};
+
+type SanityCheckReport<K extends SanityCheckKind> =
+  FirestoreSchema["sanityChecks"][string][K];

--- a/packages/functions/src/checks/slotRelatedDocs.ts
+++ b/packages/functions/src/checks/slotRelatedDocs.ts
@@ -238,13 +238,16 @@ const getLatestSanityCheck = async <K extends SanityCheckKind>(
   db: Firestore,
   organization: string,
   kind: K
-): Promise<SanityCheckReport<K>> => {
-  return getSanityChecksRef(db, organization, kind)
+): Promise<SanityCheckReport<K> | undefined> =>
+  getSanityChecksRef(db, organization, kind)
     .orderBy("id", "asc")
     .limitToLast(1)
     .get()
-    .then((snap) => snap.docs[0].data() as SanityCheckReport<K>);
-};
+    .then((snap) =>
+      !snap.docs.length
+        ? undefined
+        : (snap.docs[0].data() as SanityCheckReport<K>)
+    );
 
 const writeSanityCheckReport = async <K extends SanityCheckKind>(
   db: Firestore,
@@ -260,7 +263,7 @@ interface SanityCheckerInterface<K extends SanityCheckKind> {
   check(): Promise<SanityCheckReport<K>>;
   writeReport: (report: SanityCheckReport<K>) => Promise<SanityCheckReport<K>>;
   checkAndWrite: () => Promise<SanityCheckReport<K>>;
-  getLatestReport: () => Promise<SanityCheckReport<K>>;
+  getLatestReport: () => Promise<SanityCheckReport<K> | undefined>;
 }
 
 export const newSanityChecker = <K extends SanityCheckKind>(

--- a/packages/shared/src/enums/firestore.ts
+++ b/packages/shared/src/enums/firestore.ts
@@ -17,6 +17,10 @@ export enum Collection {
    * All process delivery queues (such as email, SMS) are stored here, on per-organization basis
    */
   DeliveryQueues = "deliveryQueues",
+  /**
+   * Reports of sanity db sanity check runs.
+   */
+  SanityChecks = "sanityChecks",
 }
 
 export enum OrgSubCollection {
@@ -37,6 +41,11 @@ export enum DeliveryQueue {
   EmailQueue = "emailQueue",
   SMSQueue = "SMSQueue",
 }
+
+export enum SanityCheckKind {
+  SlotAttendance = "slotAttendance",
+}
+
 // endregion
 
 // region slots
@@ -54,5 +63,4 @@ export enum Category {
   /** @TODO Soon to be deprecated */
   // Adults = "adults",
 }
-
 // endregion

--- a/packages/shared/src/types/firestore.ts
+++ b/packages/shared/src/types/firestore.ts
@@ -6,6 +6,7 @@ import {
   OrgSubCollection,
   Collection,
   DeliveryQueue,
+  SanityCheckKind,
 } from "../enums/firestore";
 
 export interface PrivacyPolicyParams {
@@ -408,6 +409,8 @@ export interface SlotSanityCheckReport {
   unpairedEntries: Record<string, UnpairedDoc>;
   /** A record of docs for which the date is mismatched across collections (keyed by slot id) */
   dateMismatches: Record<string, DateMismatchDoc>;
+  /** A timestamp of autofix function having been ran */
+  fixedAt: string | null;
 }
 // #endregion sanityChecks
 
@@ -446,6 +449,11 @@ export interface FirestoreSchema {
   };
   [Collection.Secrets]: {
     [organization: string]: OrganizationSecrets;
+  };
+  [Collection.SanityChecks]: {
+    [organization: string]: {
+      [SanityCheckKind.SlotAttendance]: SlotSanityCheckReport;
+    };
   };
 }
 

--- a/packages/shared/src/types/firestore.ts
+++ b/packages/shared/src/types/firestore.ts
@@ -402,6 +402,20 @@ export type DateMismatchDoc = {
   [key in OrgSubCollection]: string;
 };
 
+export type SlotAttendanceUpdate = {
+  [K in keyof SlotAttendnace]?: {
+    before: SlotAttendnace[K];
+    after: SlotAttendnace[K];
+  };
+};
+
+export interface AttendanceAutofixReport {
+  timestamp: string;
+  created: Record<string, SlotAttendnace>;
+  deleted: Record<string, SlotAttendnace>;
+  updated: Record<string, SlotAttendanceUpdate>;
+}
+
 export interface SlotSanityCheckReport {
   /** ISO timestamp of the sanity check run */
   id: string;
@@ -409,8 +423,7 @@ export interface SlotSanityCheckReport {
   unpairedEntries: Record<string, UnpairedDoc>;
   /** A record of docs for which the date is mismatched across collections (keyed by slot id) */
   dateMismatches: Record<string, DateMismatchDoc>;
-  /** A timestamp of autofix function having been ran */
-  fixedAt: string | null;
+  attendanceFixes?: AttendanceAutofixReport;
 }
 // #endregion sanityChecks
 

--- a/packages/shared/src/ui/enums/misc.ts
+++ b/packages/shared/src/ui/enums/misc.ts
@@ -23,6 +23,6 @@ export enum CloudFunction {
   RemoveInvalidCustomerPhones = "removeInvalidCustomerPhones",
   ClearDeletedCustomersRegistrationAndCategories = "clearDeletedCustomersRegistrationAndCategories",
 
-  DBSanityCheck = "dbSanityCheck",
+  DBSlotAttendanceCheck = "dbSlotAttendanceCheck",
   DBSlotAttendanceAutofix = "dbSlotAttendanceAutofix",
 }


### PR DESCRIPTION
- updates slot / attendance sanity check to write the report in `sanityChecks/<organization>/slotAttendance/<timestamp>` (in firestore)
- updates slot / attendance autofix to read the latest report and use it to apply fixes
- autofix adds an autofix report to the check report