### PR TITLE
Hide the '/debug' page for non-admin users:

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -3,17 +3,19 @@ import { Provider as ReduxProvider } from "react-redux";
 import { BrowserRouter, useHistory } from "react-router-dom";
 import { getAuth } from "@firebase/auth";
 
+import { __isDev__ } from "./lib/constants";
+
 import { store } from "@/store";
 
 import AppContent from "@/AppContent";
 
 import { Modal } from "@/features/modal/components";
+import { NotificationsProvider } from "./features/notifications/context";
+import { closeAllModals } from "./features/modal/actions";
 
 import useConnectAuthToStore from "@/react-redux-firebase-auth/hooks/useConnectAuthToStore";
 
-import { NotificationsProvider } from "./features/notifications/context";
-
-import { closeAllModals } from "./features/modal/actions";
+import { initDev } from "./lib/dev";
 
 const App: React.FC = () => {
   // connect auth to store to recieve firebase SDK's auth updates
@@ -29,6 +31,12 @@ const App: React.FC = () => {
     });
     return () => unlisten();
   }, [history]);
+
+  React.useEffect(() => {
+    if (__isDev__) {
+      window["initDev"] = initDev;
+    }
+  }, []);
 
   return (
     <ReduxProvider store={store}>

--- a/packages/client/src/AppContent.tsx
+++ b/packages/client/src/AppContent.tsx
@@ -121,7 +121,7 @@ const AppContent: React.FC = () => {
           component={ErrorBoundaryPage}
         />
         <Route path={Routes.SelfRegister} component={SelfRegister} exact />
-        <Route path={Routes.Debug} component={DebugPage} />
+        <PrivateRoute path={Routes.Debug} component={DebugPage} />
         <Route path={Routes.Deleted} component={Deleted} />
         <Route path={Routes.PrivacyPolicy} component={PrivacyPolicy} />
       </Switch>

--- a/packages/client/src/lib/dev.ts
+++ b/packages/client/src/lib/dev.ts
@@ -1,0 +1,32 @@
+import {
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+} from "@firebase/auth";
+
+import { CloudFunction } from "@eisbuk/shared/ui";
+
+import { __isDev__ } from "./constants";
+
+import { auth, functions } from "@/setup";
+
+import { createFunctionCaller } from "@/utils/firebase";
+
+/**
+ * Creates a new (dummy) organization in firestore
+ * and populates it with two dummy (admin) users
+ * @returns
+ */
+export const initDev = async (): Promise<void> => {
+  if (!__isDev__) {
+    throw new Error("This function is only available in development mode");
+  }
+  await createFunctionCaller(functions, CloudFunction.CreateOrganization, {
+    displayName: "EisBuk Dev",
+  })();
+  // Auth emulator is not currently accessible from within the functions
+  try {
+    await createUserWithEmailAndPassword(auth, "test@eisbuk.it", "test00");
+  } catch (e) {
+    await signInWithEmailAndPassword(auth, "test@eisbuk.it", "test00");
+  }
+};

--- a/packages/client/src/pages/debug/index.tsx
+++ b/packages/client/src/pages/debug/index.tsx
@@ -1,9 +1,4 @@
 import React from "react";
-import {
-  getAuth,
-  createUserWithEmailAndPassword,
-  signInWithEmailAndPassword,
-} from "@firebase/auth";
 
 import {
   Button,
@@ -21,25 +16,6 @@ import Layout from "@/controllers/Layout";
 import useTitle from "@/hooks/useTitle";
 
 import { createFunctionCaller } from "@/utils/firebase";
-
-const auth = getAuth();
-
-/**
- * Creates a new (dummy) organization in firestore
- * and populates it with two dummy (admin) users
- * @returns
- */
-export const createAdminTestUsers = async (): Promise<void> => {
-  await createFunctionCaller(functions, CloudFunction.CreateOrganization, {
-    displayName: "EisBuk Dev",
-  })();
-  // Auth emulator is not currently accessible from within the functions
-  try {
-    await createUserWithEmailAndPassword(auth, "test@eisbuk.it", "test00");
-  } catch (e) {
-    await signInWithEmailAndPassword(auth, "test@eisbuk.it", "test00");
-  }
-};
 
 const DebugPageButton: React.FC<Pick<ButtonProps, "color" | "onClick">> = ({
   color = ButtonColor.Primary,
@@ -60,15 +36,6 @@ const DebugPage: React.FC = () => {
     <Layout>
       <LayoutContent>
         <div className="py-8">
-          <div className="p-2">
-            <DebugPageButton
-              onClick={createAdminTestUsers}
-              color={ButtonColor.Secondary}
-            >
-              Create admin test users
-            </DebugPageButton>
-          </div>
-
           <div className="p-2">
             <DebugPageButton
               onClick={createFunctionCaller(


### PR DESCRIPTION
Fixes #872 
* create 'initDev' function and register to window (only in dev mode), in place of 'create admin test users' button on the '/debug' page
* make the '/debug' page a PrivateRoute (accessble only to admins)