### PR TITLE
Fix/use unix timestamp for process delivery

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
       commander: ^8.3.0
       env-paths: ^2.2.1
       eslint: ^8.13.0
-      firebase-admin: ^11.0.1
+      firebase-admin: 11.8.0
       firestore-export-import: 1.3.6
       inquirer: ^8.0.0
       jest: ^27.5.1
@@ -31,7 +31,7 @@ importers:
       '@eisbuk/shared': link:../shared
       commander: 8.3.0
       env-paths: 2.2.1
-      firebase-admin: 11.11.1
+      firebase-admin: 11.8.0
       firestore-export-import: 1.3.6
       inquirer: 8.2.6
     devDependencies:
@@ -295,12 +295,12 @@ importers:
       '@eisbuk/shared': workspace:*
       '@eisbuk/testing': workspace:*
       '@eisbuk/translations': workspace:*
-      '@firebase/app': ~0.9.10
-      '@firebase/app-compat': ~0.2.10
+      '@firebase/app': 0.9.11
+      '@firebase/app-compat': 0.2.11
       '@firebase/app-types': ~0.9.0
-      '@firebase/auth': ~0.23.2
-      '@firebase/firestore': ~3.12.0
-      '@firebase/functions': ~0.9.4
+      '@firebase/auth': 0.23.2
+      '@firebase/firestore': 3.12.1
+      '@firebase/functions': 0.9.4
       '@google-cloud/firestore': ~6.5.0
       '@types/luxon': ^2.0.5
       '@types/node': ^18.16.0
@@ -317,18 +317,18 @@ importers:
       eslint-plugin-react: ~7.32.2
       eslint-plugin-react-hooks: ~4.6.0
       eslint-plugin-unused-imports: ~2.0.0
-      firebase-admin: ^11.0.1
+      firebase-admin: 11.8.0
       luxon: ^2.0.5
       mocha: ^8.2.1
       mochawesome: ^7.0.1
       typescript: ~5.0.4
       uuid: ^8.3.2
     dependencies:
-      '@firebase/app': 0.9.25
-      '@firebase/app-compat': 0.2.25
-      '@firebase/auth': 0.23.2_@firebase+app@0.9.25
-      '@firebase/firestore': 3.12.2_@firebase+app@0.9.25
-      '@firebase/functions': 0.9.4_@firebase+app@0.9.25
+      '@firebase/app': 0.9.11
+      '@firebase/app-compat': 0.2.11
+      '@firebase/auth': 0.23.2_@firebase+app@0.9.11
+      '@firebase/firestore': 3.12.1_@firebase+app@0.9.11
+      '@firebase/functions': 0.9.4_@firebase+app@0.9.11
     devDependencies:
       '@cypress/code-coverage': 3.12.18_cypress@13.2.0
       '@eisbuk/shared': link:../shared
@@ -351,7 +351,7 @@ importers:
       eslint-plugin-react: 7.32.2_eslint@8.56.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.56.0
       eslint-plugin-unused-imports: 2.0.0_bfa254f02d2e75c28def279c13e71ac1
-      firebase-admin: 11.11.1
+      firebase-admin: 11.8.0
       luxon: 2.5.2
       mocha: 8.4.0
       mochawesome: 7.1.3_mocha@8.4.0
@@ -366,63 +366,63 @@ importers:
       '@babel/core': 7.x
       '@babel/plugin-transform-runtime': ^7.12.10
       '@babel/preset-typescript': ^7.14.5
-      '@firebase/app-compat': ~0.2.10
+      '@firebase/app-compat': 0.2.11
       '@firebase/app-types': ~0.9.0
       '@google-cloud/firestore': ~6.5.0
       '@grpc/grpc-js': ^1.6.2
-      '@types/jest': ^27.4.1
       '@types/node': ^18.16.0
       '@typescript-eslint/eslint-plugin': ~5.59.0
       '@typescript-eslint/parser': ~5.59.0
+      '@vitest/ui': ~0.31.4
       eslint: ^8.13.0
       eslint-config-google: ^0.14.0
       eslint-import-resolver-typescript: ~3.5.5
       eslint-plugin-import: ~2.27.5
       eslint-plugin-promise: ~6.1.1
       eslint-plugin-unused-imports: ~2.0.0
-      firebase: ~9.22.0
-      firebase-admin: ^11.0.1
+      firebase: 9.22.1
+      firebase-admin: 11.8.0
       firebase-functions: ^3.13.1
       firebase-functions-test: ^0.2.3
-      jest: ^27.5.1
       mocha: ^8.2.1
       typescript: ~5.0.4
       vite: ~4.3.1
       vite-plugin-environment: ^1.1.0
+      vitest: ~0.31.3
     dependencies:
-      '@firebase/app-compat': 0.2.25
+      '@firebase/app-compat': 0.2.11
       '@google-cloud/firestore': 6.5.0
-      firebase: 9.22.2
-      firebase-admin: 11.11.1
-      firebase-functions: 3.24.1_firebase-admin@11.11.1
+      firebase: 9.22.1
+      firebase-admin: 11.8.0
+      firebase-functions: 3.24.1_firebase-admin@11.8.0
     devDependencies:
       '@babel/core': 7.23.7
       '@babel/plugin-transform-runtime': 7.23.7_@babel+core@7.23.7
       '@babel/preset-typescript': 7.23.3_@babel+core@7.23.7
       '@firebase/app-types': 0.9.0
       '@grpc/grpc-js': 1.9.14
-      '@types/jest': 27.5.2
       '@types/node': 18.19.8
       '@typescript-eslint/eslint-plugin': 5.59.11_15db5b0353da39dbffe8aa8538bdc191
       '@typescript-eslint/parser': 5.59.11_eslint@8.56.0+typescript@5.0.4
+      '@vitest/ui': 0.31.4_vitest@0.31.4
       eslint: 8.56.0
       eslint-config-google: 0.14.0_eslint@8.56.0
       eslint-import-resolver-typescript: 3.5.5_04f761f5210e6fcaa607caa6df343dfc
       eslint-plugin-import: 2.27.5_eslint@8.56.0
       eslint-plugin-promise: 6.1.1_eslint@8.56.0
       eslint-plugin-unused-imports: 2.0.0_bfa254f02d2e75c28def279c13e71ac1
-      firebase-functions-test: 0.2.3_1ce1f55c40c1be72e6bb5781b03694cc
-      jest: 27.5.1
+      firebase-functions-test: 0.2.3_5ef68b09cbc0943fd313b6615767619b
       mocha: 8.4.0
       typescript: 5.0.4
       vite: 4.3.9_@types+node@18.19.8
       vite-plugin-environment: 1.1.3_vite@4.3.9
+      vitest: 0.31.4_@vitest+ui@0.31.4
 
   ../../packages/functions:
     specifiers:
       '@eisbuk/firestore-process-delivery': workspace:*
       '@eisbuk/shared': workspace:*
-      '@firebase/app-compat': ~0.2.10
+      '@firebase/app-compat': 0.2.11
       '@firebase/app-types': ~0.9.0
       '@google-cloud/firestore': ~6.5.0
       '@sentry-internal/tracing': ~7.93.0
@@ -451,8 +451,8 @@ importers:
       eslint-plugin-promise: ~6.1.1
       eslint-plugin-unused-imports: ~2.0.0
       fast-deep-equal: ~3.1.3
-      firebase: ~9.22.0
-      firebase-admin: ^11.0.1
+      firebase: 9.22.1
+      firebase-admin: 11.8.0
       firebase-functions: ^3.13.1
       firebase-functions-test: ^0.2.3
       https-proxy-agent: ~7.0.2
@@ -473,7 +473,7 @@ importers:
     dependencies:
       '@eisbuk/firestore-process-delivery': link:../firestore-process-delivery
       '@eisbuk/shared': link:../shared
-      '@firebase/app-compat': 0.2.25
+      '@firebase/app-compat': 0.2.11
       '@google-cloud/firestore': 6.5.0
       '@sentry-internal/tracing': 7.93.0
       '@sentry/core': 7.93.0
@@ -485,9 +485,9 @@ importers:
       ajv-errors: 3.0.0_ajv@8.11.2
       debug: 4.3.4
       fast-deep-equal: 3.1.3
-      firebase: 9.22.2
-      firebase-admin: 11.11.1
-      firebase-functions: 3.24.1_firebase-admin@11.11.1
+      firebase: 9.22.1
+      firebase-admin: 11.8.0
+      firebase-functions: 3.24.1_firebase-admin@11.8.0
       https-proxy-agent: 7.0.2
       json-schema-traverse: 1.0.0
       lodash: 4.17.21
@@ -518,7 +518,7 @@ importers:
       eslint-plugin-import: 2.27.5_eslint@8.56.0
       eslint-plugin-promise: 6.1.1_eslint@8.56.0
       eslint-plugin-unused-imports: 2.0.0_bfa254f02d2e75c28def279c13e71ac1
-      firebase-functions-test: 0.2.3_1ce1f55c40c1be72e6bb5781b03694cc
+      firebase-functions-test: 0.2.3_5ef68b09cbc0943fd313b6615767619b
       mocha: 8.4.0
       tsconfig-paths: 3.15.0
       typescript: 5.0.4
@@ -557,9 +557,9 @@ importers:
   ../../packages/react-redux-firebase-firestore:
     specifiers:
       '@eisbuk/shared': workspace:*
-      '@firebase/app': ~0.9.10
-      '@firebase/auth': ~0.23.2
-      '@firebase/firestore': ~3.12.0
+      '@firebase/app': 0.9.11
+      '@firebase/auth': 0.23.2
+      '@firebase/firestore': 3.12.1
       '@firebase/rules-unit-testing': ~2.0.7
       '@testing-library/dom': ^8.13.0
       '@testing-library/jest-dom': ^5.16.2
@@ -582,8 +582,8 @@ importers:
       eslint-plugin-react: ~7.32.2
       eslint-plugin-react-hooks: ~4.6.0
       eslint-plugin-unused-imports: ~2.0.0
-      firebase: ~9.22.0
-      firebase-tools: ^12.2.1
+      firebase: 9.22.1
+      firebase-tools: 12.2.1
       jest: ^27.5.1
       luxon: ^2.0.5
       p-retry: ^4.6.1
@@ -597,10 +597,10 @@ importers:
       vite: ~4.3.1
     devDependencies:
       '@eisbuk/shared': link:../shared
-      '@firebase/app': 0.9.25
-      '@firebase/auth': 0.23.2_@firebase+app@0.9.25
-      '@firebase/firestore': 3.12.2_@firebase+app@0.9.25
-      '@firebase/rules-unit-testing': 2.0.7_firebase@9.22.2
+      '@firebase/app': 0.9.11
+      '@firebase/auth': 0.23.2_@firebase+app@0.9.11
+      '@firebase/firestore': 3.12.1_@firebase+app@0.9.11
+      '@firebase/rules-unit-testing': 2.0.7_firebase@9.22.1
       '@testing-library/dom': 8.20.1
       '@testing-library/jest-dom': 5.17.0
       '@testing-library/react': 12.1.5_react-dom@16.14.0+react@16.14.0
@@ -622,8 +622,8 @@ importers:
       eslint-plugin-react: 7.32.2_eslint@8.56.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.56.0
       eslint-plugin-unused-imports: 2.0.0_bfa254f02d2e75c28def279c13e71ac1
-      firebase: 9.22.2
-      firebase-tools: 12.9.1
+      firebase: 9.22.1
+      firebase-tools: 12.2.1
       jest: 27.5.1
       luxon: 2.5.2
       p-retry: 4.6.2
@@ -3171,20 +3171,6 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /@firebase/analytics-compat/0.2.6_87ce4696d37bf2b221712087441a4b69:
-    resolution: {integrity: sha512-4MqpVLFkGK7NJf/5wPEEP7ePBJatwYpyjgJ+wQHQGHfzaCDgntOnl9rL2vbVGGKCnRqWtZDIWhctB86UWXaX2Q==}
-    peerDependencies:
-      '@firebase/app-compat': 0.x
-    dependencies:
-      '@firebase/analytics': 0.10.0_@firebase+app@0.9.12
-      '@firebase/analytics-types': 0.8.0
-      '@firebase/app-compat': 0.2.12
-      '@firebase/component': 0.6.4
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@firebase/app'
-
   /@firebase/analytics-compat/0.2.6_9b67a1d042516d42d2477f528b7782df:
     resolution: {integrity: sha512-4MqpVLFkGK7NJf/5wPEEP7ePBJatwYpyjgJ+wQHQGHfzaCDgntOnl9rL2vbVGGKCnRqWtZDIWhctB86UWXaX2Q==}
     peerDependencies:
@@ -3198,7 +3184,6 @@ packages:
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@firebase/app'
-    dev: false
 
   /@firebase/analytics-types/0.8.0:
     resolution: {integrity: sha512-iRP+QKI2+oz3UAh4nPEq14CsEjrjD6a5+fuypjScisAh9kXKFvdJOZJDwk7kikLvWVLGEs9+kIUS4LPQV7VZVw==}
@@ -3214,34 +3199,6 @@ packages:
       '@firebase/logger': 0.4.0
       '@firebase/util': 1.9.3
       tslib: 2.6.2
-    dev: false
-
-  /@firebase/analytics/0.10.0_@firebase+app@0.9.12:
-    resolution: {integrity: sha512-Locv8gAqx0e+GX/0SI3dzmBY5e9kjVDtD+3zCFLJ0tH2hJwuCAiL+5WkHuxKj92rqQj/rvkBUCfA1ewlX2hehg==}
-    peerDependencies:
-      '@firebase/app': 0.x
-    dependencies:
-      '@firebase/app': 0.9.12
-      '@firebase/component': 0.6.4
-      '@firebase/installations': 0.6.4_@firebase+app@0.9.12
-      '@firebase/logger': 0.4.0
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-
-  /@firebase/app-check-compat/0.3.7_87ce4696d37bf2b221712087441a4b69:
-    resolution: {integrity: sha512-cW682AxsyP1G+Z0/P7pO/WT2CzYlNxoNe5QejVarW2o5ZxeWSSPAiVEwpEpQR/bUlUmdeWThYTMvBWaopdBsqw==}
-    peerDependencies:
-      '@firebase/app-compat': 0.x
-    dependencies:
-      '@firebase/app-check': 0.8.0_@firebase+app@0.9.12
-      '@firebase/app-check-types': 0.5.0
-      '@firebase/app-compat': 0.2.12
-      '@firebase/component': 0.6.4
-      '@firebase/logger': 0.4.0
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@firebase/app'
 
   /@firebase/app-check-compat/0.3.7_9b67a1d042516d42d2477f528b7782df:
     resolution: {integrity: sha512-cW682AxsyP1G+Z0/P7pO/WT2CzYlNxoNe5QejVarW2o5ZxeWSSPAiVEwpEpQR/bUlUmdeWThYTMvBWaopdBsqw==}
@@ -3257,7 +3214,6 @@ packages:
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@firebase/app'
-    dev: false
 
   /@firebase/app-check-interop-types/0.2.0:
     resolution: {integrity: sha512-+3PQIeX6/eiVK+x/yg8r6xTNR97fN7MahFDm+jiQmDjcyvSefoGuTTNQuuMScGyx3vYUBeZn+Cp9kC0yY/9uxQ==}
@@ -3279,18 +3235,6 @@ packages:
       '@firebase/logger': 0.4.0
       '@firebase/util': 1.9.3
       tslib: 2.6.2
-    dev: false
-
-  /@firebase/app-check/0.8.0_@firebase+app@0.9.12:
-    resolution: {integrity: sha512-dRDnhkcaC2FspMiRK/Vbp+PfsOAEP6ZElGm9iGFJ9fDqHoPs0HOPn7dwpJ51lCFi1+2/7n5pRPGhqF/F03I97g==}
-    peerDependencies:
-      '@firebase/app': 0.x
-    dependencies:
-      '@firebase/app': 0.9.12
-      '@firebase/component': 0.6.4
-      '@firebase/logger': 0.4.0
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
 
   /@firebase/app-compat/0.2.11:
     resolution: {integrity: sha512-IzjLh3Z9F4gPo+Ft7lNVxeKlYfKI6fseUmiLaySidcx/Sdro1vOzoBMOr+5OVVpVVMSib9BZ3QtBKZkPZk+Ucw==}
@@ -3300,26 +3244,6 @@ packages:
       '@firebase/logger': 0.4.0
       '@firebase/util': 1.9.3
       tslib: 2.6.2
-    dev: false
-
-  /@firebase/app-compat/0.2.12:
-    resolution: {integrity: sha512-3EfputoACcXvgi2uN9RUQVDYSmRSR4R4TWJW9Wvs4hTib2I26ldvVhDHaheQq90IwGYrRa+TTWuzr4a5dCRkVQ==}
-    dependencies:
-      '@firebase/app': 0.9.12
-      '@firebase/component': 0.6.4
-      '@firebase/logger': 0.4.0
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-
-  /@firebase/app-compat/0.2.25:
-    resolution: {integrity: sha512-B/JtCp1FsTuzlh1tIGQpYM2AXps21/zlzpFsk5LRsROOTRhBcR2N45AyaONPFD06C0yS0Tw19foxADzHyOSC3A==}
-    dependencies:
-      '@firebase/app': 0.9.25
-      '@firebase/component': 0.6.4
-      '@firebase/logger': 0.4.0
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-    dev: false
 
   /@firebase/app-types/0.9.0:
     resolution: {integrity: sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q==}
@@ -3332,42 +3256,6 @@ packages:
       '@firebase/util': 1.9.3
       idb: 7.1.1
       tslib: 2.6.2
-    dev: false
-
-  /@firebase/app/0.9.12:
-    resolution: {integrity: sha512-VsE/WHZU8M9BCnHMbOi3FqIVIsoG4FlEehjp+XCDNE0zxn4BGgnpLdBu6/r9Bg565b1ND7dm6LSVRtewmeRb3w==}
-    dependencies:
-      '@firebase/component': 0.6.4
-      '@firebase/logger': 0.4.0
-      '@firebase/util': 1.9.3
-      idb: 7.1.1
-      tslib: 2.6.2
-
-  /@firebase/app/0.9.25:
-    resolution: {integrity: sha512-fX22gL5USXhOK21Hlh3oTeOzQZ6th6S2JrjXNEpBARmwzuUkqmVGVdsOCIFYIsLpK0dQE3o8xZnLrRg5wnzZ/g==}
-    dependencies:
-      '@firebase/component': 0.6.4
-      '@firebase/logger': 0.4.0
-      '@firebase/util': 1.9.3
-      idb: 7.1.1
-      tslib: 2.6.2
-
-  /@firebase/auth-compat/0.4.2_6799c90e92a20ab804ed82c8c384a8c5:
-    resolution: {integrity: sha512-Q30e77DWXFmXEt5dg5JbqEDpjw9y3/PcP9LslDPR7fARmAOTIY9MM6HXzm9KC+dlrKH/+p6l8g9ifJiam9mc4A==}
-    peerDependencies:
-      '@firebase/app-compat': 0.x
-    dependencies:
-      '@firebase/app-compat': 0.2.12
-      '@firebase/auth': 0.23.2_@firebase+app@0.9.12
-      '@firebase/auth-types': 0.12.0_793e2099263feb91fc499272013e33e3
-      '@firebase/component': 0.6.4
-      '@firebase/util': 1.9.3
-      node-fetch: 2.6.7
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@firebase/app'
-      - '@firebase/app-types'
-      - encoding
 
   /@firebase/auth-compat/0.4.2_7d1162a6c6c3aadb498d4d57fc97cfb3:
     resolution: {integrity: sha512-Q30e77DWXFmXEt5dg5JbqEDpjw9y3/PcP9LslDPR7fARmAOTIY9MM6HXzm9KC+dlrKH/+p6l8g9ifJiam9mc4A==}
@@ -3385,7 +3273,6 @@ packages:
       - '@firebase/app'
       - '@firebase/app-types'
       - encoding
-    dev: false
 
   /@firebase/auth-interop-types/0.2.1:
     resolution: {integrity: sha512-VOaGzKp65MY6P5FI84TfYKBXEPi6LmOCSMMzys6o2BN2LOsqy7pCuZCup7NYnfbk5OkkQKzvIfHOzTm0UDpkyg==}
@@ -3405,35 +3292,6 @@ packages:
       '@firebase/app': 0.x
     dependencies:
       '@firebase/app': 0.9.11
-      '@firebase/component': 0.6.4
-      '@firebase/logger': 0.4.0
-      '@firebase/util': 1.9.3
-      node-fetch: 2.6.7
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /@firebase/auth/0.23.2_@firebase+app@0.9.12:
-    resolution: {integrity: sha512-dM9iJ0R6tI1JczuGSxXmQbXAgtYie0K4WvKcuyuSTCu9V8eEDiz4tfa1sO3txsfvwg7nOY3AjoCyMYEdqZ8hdg==}
-    peerDependencies:
-      '@firebase/app': 0.x
-    dependencies:
-      '@firebase/app': 0.9.12
-      '@firebase/component': 0.6.4
-      '@firebase/logger': 0.4.0
-      '@firebase/util': 1.9.3
-      node-fetch: 2.6.7
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - encoding
-
-  /@firebase/auth/0.23.2_@firebase+app@0.9.25:
-    resolution: {integrity: sha512-dM9iJ0R6tI1JczuGSxXmQbXAgtYie0K4WvKcuyuSTCu9V8eEDiz4tfa1sO3txsfvwg7nOY3AjoCyMYEdqZ8hdg==}
-    peerDependencies:
-      '@firebase/app': 0.x
-    dependencies:
-      '@firebase/app': 0.9.25
       '@firebase/component': 0.6.4
       '@firebase/logger': 0.4.0
       '@firebase/util': 1.9.3
@@ -3489,23 +3347,6 @@ packages:
       - '@firebase/app'
       - '@firebase/app-types'
       - encoding
-    dev: false
-
-  /@firebase/firestore-compat/0.3.11_6799c90e92a20ab804ed82c8c384a8c5:
-    resolution: {integrity: sha512-jPhySBBp6+Vt750WmeCK4it/NV9YHQEX+jJ7Va8wHOhVejy0zUhL5TsLF6Bz3hCjb4Dxn6XVgvuSqiuqY16yWw==}
-    peerDependencies:
-      '@firebase/app-compat': 0.x
-    dependencies:
-      '@firebase/app-compat': 0.2.12
-      '@firebase/component': 0.6.4
-      '@firebase/firestore': 3.12.2_@firebase+app@0.9.12
-      '@firebase/firestore-types': 2.5.1_793e2099263feb91fc499272013e33e3
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@firebase/app'
-      - '@firebase/app-types'
-      - encoding
 
   /@firebase/firestore-types/2.5.1_793e2099263feb91fc499272013e33e3:
     resolution: {integrity: sha512-xG0CA6EMfYo8YeUxC8FeDzf6W3FX1cLlcAGBYV6Cku12sZRI81oWcu61RSKM66K6kUENP+78Qm8mvroBcm1whw==}
@@ -3533,58 +3374,6 @@ packages:
       tslib: 2.6.2
     transitivePeerDependencies:
       - encoding
-    dev: false
-
-  /@firebase/firestore/3.12.2_@firebase+app@0.9.12:
-    resolution: {integrity: sha512-6EDIJ2V4hlUkPvAb1uH5DAz65ZvhStIM1oYGSUx6mt2UdEDu/0CAVS7xYBY6niTyM/+2r6XBW3hYG/1x1V27vg==}
-    engines: {node: '>=10.10.0'}
-    peerDependencies:
-      '@firebase/app': 0.x
-    dependencies:
-      '@firebase/app': 0.9.12
-      '@firebase/component': 0.6.4
-      '@firebase/logger': 0.4.0
-      '@firebase/util': 1.9.3
-      '@firebase/webchannel-wrapper': 0.10.1
-      '@grpc/grpc-js': 1.7.3
-      '@grpc/proto-loader': 0.6.13
-      node-fetch: 2.6.7
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - encoding
-
-  /@firebase/firestore/3.12.2_@firebase+app@0.9.25:
-    resolution: {integrity: sha512-6EDIJ2V4hlUkPvAb1uH5DAz65ZvhStIM1oYGSUx6mt2UdEDu/0CAVS7xYBY6niTyM/+2r6XBW3hYG/1x1V27vg==}
-    engines: {node: '>=10.10.0'}
-    peerDependencies:
-      '@firebase/app': 0.x
-    dependencies:
-      '@firebase/app': 0.9.25
-      '@firebase/component': 0.6.4
-      '@firebase/logger': 0.4.0
-      '@firebase/util': 1.9.3
-      '@firebase/webchannel-wrapper': 0.10.1
-      '@grpc/grpc-js': 1.7.3
-      '@grpc/proto-loader': 0.6.13
-      node-fetch: 2.6.7
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - encoding
-
-  /@firebase/functions-compat/0.3.5_87ce4696d37bf2b221712087441a4b69:
-    resolution: {integrity: sha512-uD4jwgwVqdWf6uc3NRKF8cSZ0JwGqSlyhPgackyUPe+GAtnERpS4+Vr66g0b3Gge0ezG4iyHo/EXW/Hjx7QhHw==}
-    peerDependencies:
-      '@firebase/app-compat': 0.x
-    dependencies:
-      '@firebase/app-compat': 0.2.12
-      '@firebase/component': 0.6.4
-      '@firebase/functions': 0.10.0_@firebase+app@0.9.12
-      '@firebase/functions-types': 0.6.0
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@firebase/app'
-      - encoding
 
   /@firebase/functions-compat/0.3.5_9b67a1d042516d42d2477f528b7782df:
     resolution: {integrity: sha512-uD4jwgwVqdWf6uc3NRKF8cSZ0JwGqSlyhPgackyUPe+GAtnERpS4+Vr66g0b3Gge0ezG4iyHo/EXW/Hjx7QhHw==}
@@ -3600,7 +3389,6 @@ packages:
     transitivePeerDependencies:
       - '@firebase/app'
       - encoding
-    dev: false
 
   /@firebase/functions-types/0.6.0:
     resolution: {integrity: sha512-hfEw5VJtgWXIRf92ImLkgENqpL6IWpYaXVYiRkFY1jJ9+6tIhWM7IzzwbevwIIud/jaxKVdRzD7QBWfPmkwCYw==}
@@ -3611,23 +3399,6 @@ packages:
       '@firebase/app': 0.x
     dependencies:
       '@firebase/app': 0.9.11
-      '@firebase/app-check-interop-types': 0.3.0
-      '@firebase/auth-interop-types': 0.2.1
-      '@firebase/component': 0.6.4
-      '@firebase/messaging-interop-types': 0.2.0
-      '@firebase/util': 1.9.3
-      node-fetch: 2.6.7
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /@firebase/functions/0.10.0_@firebase+app@0.9.12:
-    resolution: {integrity: sha512-2U+fMNxTYhtwSpkkR6WbBcuNMOVaI7MaH3cZ6UAeNfj7AgEwHwMIFLPpC13YNZhno219F0lfxzTAA0N62ndWzA==}
-    peerDependencies:
-      '@firebase/app': 0.x
-    dependencies:
-      '@firebase/app': 0.9.12
       '@firebase/app-check-interop-types': 0.3.0
       '@firebase/auth-interop-types': 0.2.1
       '@firebase/component': 0.6.4
@@ -3655,38 +3426,6 @@ packages:
       - encoding
     dev: false
 
-  /@firebase/functions/0.9.4_@firebase+app@0.9.25:
-    resolution: {integrity: sha512-3H2qh6U+q+nepO5Hds+Ddl6J0pS+zisuBLqqQMRBHv9XpWfu0PnDHklNmE8rZ+ccTEXvBj6zjkPfdxt6NisvlQ==}
-    peerDependencies:
-      '@firebase/app': 0.x
-    dependencies:
-      '@firebase/app': 0.9.25
-      '@firebase/app-check-interop-types': 0.2.0
-      '@firebase/auth-interop-types': 0.2.1
-      '@firebase/component': 0.6.4
-      '@firebase/messaging-interop-types': 0.2.0
-      '@firebase/util': 1.9.3
-      node-fetch: 2.6.7
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /@firebase/installations-compat/0.2.4_6799c90e92a20ab804ed82c8c384a8c5:
-    resolution: {integrity: sha512-LI9dYjp0aT9Njkn9U4JRrDqQ6KXeAmFbRC0E7jI7+hxl5YmRWysq5qgQl22hcWpTk+cm3es66d/apoDU/A9n6Q==}
-    peerDependencies:
-      '@firebase/app-compat': 0.x
-    dependencies:
-      '@firebase/app-compat': 0.2.12
-      '@firebase/component': 0.6.4
-      '@firebase/installations': 0.6.4_@firebase+app@0.9.12
-      '@firebase/installations-types': 0.5.0_@firebase+app-types@0.9.0
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@firebase/app'
-      - '@firebase/app-types'
-
   /@firebase/installations-compat/0.2.4_7d1162a6c6c3aadb498d4d57fc97cfb3:
     resolution: {integrity: sha512-LI9dYjp0aT9Njkn9U4JRrDqQ6KXeAmFbRC0E7jI7+hxl5YmRWysq5qgQl22hcWpTk+cm3es66d/apoDU/A9n6Q==}
     peerDependencies:
@@ -3701,7 +3440,6 @@ packages:
     transitivePeerDependencies:
       - '@firebase/app'
       - '@firebase/app-types'
-    dev: false
 
   /@firebase/installations-types/0.5.0_@firebase+app-types@0.9.0:
     resolution: {integrity: sha512-9DP+RGfzoI2jH7gY4SlzqvZ+hr7gYzPODrbzVD82Y12kScZ6ZpRg/i3j6rleto8vTFC8n6Len4560FnV1w2IRg==}
@@ -3720,36 +3458,11 @@ packages:
       '@firebase/util': 1.9.3
       idb: 7.0.1
       tslib: 2.6.2
-    dev: false
-
-  /@firebase/installations/0.6.4_@firebase+app@0.9.12:
-    resolution: {integrity: sha512-u5y88rtsp7NYkCHC3ElbFBrPtieUybZluXyzl7+4BsIz4sqb4vSAuwHEUgCgCeaQhvsnxDEU6icly8U9zsJigA==}
-    peerDependencies:
-      '@firebase/app': 0.x
-    dependencies:
-      '@firebase/app': 0.9.12
-      '@firebase/component': 0.6.4
-      '@firebase/util': 1.9.3
-      idb: 7.0.1
-      tslib: 2.6.2
 
   /@firebase/logger/0.4.0:
     resolution: {integrity: sha512-eRKSeykumZ5+cJPdxxJRgAC3G5NknY2GwEbKfymdnXtnT0Ucm4pspfR6GT4MUQEDuJwRVbVcSx85kgJulMoFFA==}
     dependencies:
       tslib: 2.6.2
-
-  /@firebase/messaging-compat/0.2.4_87ce4696d37bf2b221712087441a4b69:
-    resolution: {integrity: sha512-lyFjeUhIsPRYDPNIkYX1LcZMpoVbBWXX4rPl7c/rqc7G+EUea7IEtSt4MxTvh6fDfPuzLn7+FZADfscC+tNMfg==}
-    peerDependencies:
-      '@firebase/app-compat': 0.x
-    dependencies:
-      '@firebase/app-compat': 0.2.12
-      '@firebase/component': 0.6.4
-      '@firebase/messaging': 0.12.4_@firebase+app@0.9.12
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@firebase/app'
 
   /@firebase/messaging-compat/0.2.4_9b67a1d042516d42d2477f528b7782df:
     resolution: {integrity: sha512-lyFjeUhIsPRYDPNIkYX1LcZMpoVbBWXX4rPl7c/rqc7G+EUea7IEtSt4MxTvh6fDfPuzLn7+FZADfscC+tNMfg==}
@@ -3763,7 +3476,6 @@ packages:
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@firebase/app'
-    dev: false
 
   /@firebase/messaging-interop-types/0.2.0:
     resolution: {integrity: sha512-ujA8dcRuVeBixGR9CtegfpU4YmZf3Lt7QYkcj693FFannwNuZgfAYaTmbJ40dtjB81SAu6tbFPL9YLNT15KmOQ==}
@@ -3780,35 +3492,6 @@ packages:
       '@firebase/util': 1.9.3
       idb: 7.0.1
       tslib: 2.6.2
-    dev: false
-
-  /@firebase/messaging/0.12.4_@firebase+app@0.9.12:
-    resolution: {integrity: sha512-6JLZct6zUaex4g7HI3QbzeUrg9xcnmDAPTWpkoMpd/GoSVWH98zDoWXMGrcvHeCAIsLpFMe4MPoZkJbrPhaASw==}
-    peerDependencies:
-      '@firebase/app': 0.x
-    dependencies:
-      '@firebase/app': 0.9.12
-      '@firebase/component': 0.6.4
-      '@firebase/installations': 0.6.4_@firebase+app@0.9.12
-      '@firebase/messaging-interop-types': 0.2.0
-      '@firebase/util': 1.9.3
-      idb: 7.0.1
-      tslib: 2.6.2
-
-  /@firebase/performance-compat/0.2.4_87ce4696d37bf2b221712087441a4b69:
-    resolution: {integrity: sha512-nnHUb8uP9G8islzcld/k6Bg5RhX62VpbAb/Anj7IXs/hp32Eb2LqFPZK4sy3pKkBUO5wcrlRWQa6wKOxqlUqsg==}
-    peerDependencies:
-      '@firebase/app-compat': 0.x
-    dependencies:
-      '@firebase/app-compat': 0.2.12
-      '@firebase/component': 0.6.4
-      '@firebase/logger': 0.4.0
-      '@firebase/performance': 0.6.4_@firebase+app@0.9.12
-      '@firebase/performance-types': 0.2.0
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@firebase/app'
 
   /@firebase/performance-compat/0.2.4_9b67a1d042516d42d2477f528b7782df:
     resolution: {integrity: sha512-nnHUb8uP9G8islzcld/k6Bg5RhX62VpbAb/Anj7IXs/hp32Eb2LqFPZK4sy3pKkBUO5wcrlRWQa6wKOxqlUqsg==}
@@ -3824,7 +3507,6 @@ packages:
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@firebase/app'
-    dev: false
 
   /@firebase/performance-types/0.2.0:
     resolution: {integrity: sha512-kYrbr8e/CYr1KLrLYZZt2noNnf+pRwDq2KK9Au9jHrBMnb0/C9X9yWSXmZkFt4UIdsQknBq8uBB7fsybZdOBTA==}
@@ -3840,34 +3522,6 @@ packages:
       '@firebase/logger': 0.4.0
       '@firebase/util': 1.9.3
       tslib: 2.6.2
-    dev: false
-
-  /@firebase/performance/0.6.4_@firebase+app@0.9.12:
-    resolution: {integrity: sha512-HfTn/bd8mfy/61vEqaBelNiNnvAbUtME2S25A67Nb34zVuCSCRIX4SseXY6zBnOFj3oLisaEqhVcJmVPAej67g==}
-    peerDependencies:
-      '@firebase/app': 0.x
-    dependencies:
-      '@firebase/app': 0.9.12
-      '@firebase/component': 0.6.4
-      '@firebase/installations': 0.6.4_@firebase+app@0.9.12
-      '@firebase/logger': 0.4.0
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-
-  /@firebase/remote-config-compat/0.2.4_87ce4696d37bf2b221712087441a4b69:
-    resolution: {integrity: sha512-FKiki53jZirrDFkBHglB3C07j5wBpitAaj8kLME6g8Mx+aq7u9P7qfmuSRytiOItADhWUj7O1JIv7n9q87SuwA==}
-    peerDependencies:
-      '@firebase/app-compat': 0.x
-    dependencies:
-      '@firebase/app-compat': 0.2.12
-      '@firebase/component': 0.6.4
-      '@firebase/logger': 0.4.0
-      '@firebase/remote-config': 0.4.4_@firebase+app@0.9.12
-      '@firebase/remote-config-types': 0.3.0
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@firebase/app'
 
   /@firebase/remote-config-compat/0.2.4_9b67a1d042516d42d2477f528b7782df:
     resolution: {integrity: sha512-FKiki53jZirrDFkBHglB3C07j5wBpitAaj8kLME6g8Mx+aq7u9P7qfmuSRytiOItADhWUj7O1JIv7n9q87SuwA==}
@@ -3883,7 +3537,6 @@ packages:
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@firebase/app'
-    dev: false
 
   /@firebase/remote-config-types/0.3.0:
     resolution: {integrity: sha512-RtEH4vdcbXZuZWRZbIRmQVBNsE7VDQpet2qFvq6vwKLBIQRQR5Kh58M4ok3A3US8Sr3rubYnaGqZSurCwI8uMA==}
@@ -3896,19 +3549,6 @@ packages:
       '@firebase/app': 0.9.11
       '@firebase/component': 0.6.4
       '@firebase/installations': 0.6.4_@firebase+app@0.9.11
-      '@firebase/logger': 0.4.0
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-    dev: false
-
-  /@firebase/remote-config/0.4.4_@firebase+app@0.9.12:
-    resolution: {integrity: sha512-x1ioTHGX8ZwDSTOVp8PBLv2/wfwKzb4pxi0gFezS5GCJwbLlloUH4YYZHHS83IPxnua8b6l0IXUaWd0RgbWwzQ==}
-    peerDependencies:
-      '@firebase/app': 0.x
-    dependencies:
-      '@firebase/app': 0.9.12
-      '@firebase/component': 0.6.4
-      '@firebase/installations': 0.6.4_@firebase+app@0.9.12
       '@firebase/logger': 0.4.0
       '@firebase/util': 1.9.3
       tslib: 2.6.2
@@ -3925,34 +3565,6 @@ packages:
       - encoding
     dev: true
 
-  /@firebase/rules-unit-testing/2.0.7_firebase@9.22.2:
-    resolution: {integrity: sha512-tioToru3AgRanuHLt650rmP9oeyhyc9yb3i3jtZDFz3MTpztHVFI4q6sYnIneTr9aSllsItCYYCJS5ylPOCsWg==}
-    engines: {node: '>=10.10.0'}
-    peerDependencies:
-      firebase: ^9.0.0
-    dependencies:
-      firebase: 9.22.2
-      node-fetch: 2.6.7
-    transitivePeerDependencies:
-      - encoding
-    dev: true
-
-  /@firebase/storage-compat/0.3.2_6799c90e92a20ab804ed82c8c384a8c5:
-    resolution: {integrity: sha512-wvsXlLa9DVOMQJckbDNhXKKxRNNewyUhhbXev3t8kSgoCotd1v3MmqhKKz93ePhDnhHnDs7bYHy+Qa8dRY6BXw==}
-    peerDependencies:
-      '@firebase/app-compat': 0.x
-    dependencies:
-      '@firebase/app-compat': 0.2.12
-      '@firebase/component': 0.6.4
-      '@firebase/storage': 0.11.2_@firebase+app@0.9.12
-      '@firebase/storage-types': 0.8.0_793e2099263feb91fc499272013e33e3
-      '@firebase/util': 1.9.3
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@firebase/app'
-      - '@firebase/app-types'
-      - encoding
-
   /@firebase/storage-compat/0.3.2_7d1162a6c6c3aadb498d4d57fc97cfb3:
     resolution: {integrity: sha512-wvsXlLa9DVOMQJckbDNhXKKxRNNewyUhhbXev3t8kSgoCotd1v3MmqhKKz93ePhDnhHnDs7bYHy+Qa8dRY6BXw==}
     peerDependencies:
@@ -3968,7 +3580,6 @@ packages:
       - '@firebase/app'
       - '@firebase/app-types'
       - encoding
-    dev: false
 
   /@firebase/storage-types/0.8.0_793e2099263feb91fc499272013e33e3:
     resolution: {integrity: sha512-isRHcGrTs9kITJC0AVehHfpraWFui39MPaU7Eo8QfWlqW7YPymBmRgjDrlOgFdURh6Cdeg07zmkLP5tzTKRSpg==}
@@ -3985,20 +3596,6 @@ packages:
       '@firebase/app': 0.x
     dependencies:
       '@firebase/app': 0.9.11
-      '@firebase/component': 0.6.4
-      '@firebase/util': 1.9.3
-      node-fetch: 2.6.7
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /@firebase/storage/0.11.2_@firebase+app@0.9.12:
-    resolution: {integrity: sha512-CtvoFaBI4hGXlXbaCHf8humajkbXhs39Nbh6MbNxtwJiCqxPy9iH3D3CCfXAvP0QvAAwmJUTK3+z9a++Kc4nkA==}
-    peerDependencies:
-      '@firebase/app': 0.x
-    dependencies:
-      '@firebase/app': 0.9.12
       '@firebase/component': 0.6.4
       '@firebase/util': 1.9.3
       node-fetch: 2.6.7
@@ -4053,20 +3650,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-
-  /@google-cloud/firestore/6.8.0:
-    resolution: {integrity: sha512-JRpk06SmZXLGz0pNx1x7yU3YhkUXheKgH5hbDZ4kMsdhtfV5qPLJLRI4wv69K0cZorIk+zTMOwptue7hizo0eA==}
-    engines: {node: '>=12.0.0'}
-    requiresBuild: true
-    dependencies:
-      fast-deep-equal: 3.1.3
-      functional-red-black-tree: 1.0.1
-      google-gax: 3.6.1
-      protobufjs: 7.2.6
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    optional: true
 
   /@google-cloud/paginator/3.0.7:
     resolution: {integrity: sha512-jJNutk0arIQhmpUUQJPJErsojqo834KcyB6X7a1mxuic8i1tKXxde8E69IZxNZawRIlZdIK2QY4WALvlK5MzYQ==}
@@ -6883,10 +6466,6 @@ packages:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
 
-  /@tootallnate/quickjs-emscripten/0.23.0:
-    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
-    dev: true
-
   /@tsconfig/node10/1.0.9:
     resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
 
@@ -8586,11 +8165,6 @@ packages:
     dependencies:
       safe-buffer: 5.1.2
 
-  /basic-ftp/5.0.4:
-    resolution: {integrity: sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==}
-    engines: {node: '>=10.0.0'}
-    dev: true
-
   /bcrypt-pbkdf/1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
     dependencies:
@@ -9713,12 +9287,6 @@ packages:
   /data-uri-to-buffer/3.0.1:
     resolution: {integrity: sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==}
     engines: {node: '>= 6'}
-    dev: false
-
-  /data-uri-to-buffer/6.0.1:
-    resolution: {integrity: sha512-MZd3VlchQkp8rdend6vrx7MmVDJzSNTBvghvKjirLkD+WTChA3KUf0jkE68Q4UyctNqI11zZO9/x2Yx+ub5Cvg==}
-    engines: {node: '>= 14'}
-    dev: true
 
   /data-urls/2.0.0:
     resolution: {integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==}
@@ -9975,16 +9543,6 @@ packages:
       escodegen: 1.14.3
       esprima: 4.0.1
       vm2: 3.9.19
-    dev: false
-
-  /degenerator/5.0.1:
-    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
-    engines: {node: '>= 14'}
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 2.1.0
-      esprima: 4.0.1
-    dev: true
 
   /del/6.1.1:
     resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==}
@@ -11438,7 +10996,6 @@ packages:
   /file-uri-to-path/2.0.0:
     resolution: {integrity: sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==}
     engines: {node: '>= 6'}
-    dev: false
 
   /filelist/1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
@@ -11524,25 +11081,6 @@ packages:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  /firebase-admin/11.11.1:
-    resolution: {integrity: sha512-UyEbq+3u6jWzCYbUntv/HuJiTixwh36G1R9j0v71mSvGAx/YZEWEW7uSGLYxBYE6ckVRQoKMr40PYUEzrm/4dg==}
-    engines: {node: '>=14'}
-    dependencies:
-      '@fastify/busboy': 1.2.1
-      '@firebase/database-compat': 0.3.4
-      '@firebase/database-types': 0.10.4
-      '@types/node': 18.19.8
-      jsonwebtoken: 9.0.2
-      jwks-rsa: 3.1.0
-      node-forge: 1.3.1
-      uuid: 9.0.1
-    optionalDependencies:
-      '@google-cloud/firestore': 6.8.0
-      '@google-cloud/storage': 6.12.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   /firebase-admin/11.8.0:
     resolution: {integrity: sha512-RxO0wWDnuqVikXExhVjnhVaaXpziKCad4D1rOX5c1WJdk1jAu9hfE4rbrFKZQZgF1okZS04kgCBIFJro7xn8NQ==}
     engines: {node: '>=14'}
@@ -11561,9 +11099,8 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: true
 
-  /firebase-functions-test/0.2.3_1ce1f55c40c1be72e6bb5781b03694cc:
+  /firebase-functions-test/0.2.3_5ef68b09cbc0943fd313b6615767619b:
     resolution: {integrity: sha512-zYX0QTm53wCazuej7O0xqbHl90r/v1PTXt/hwa0jo1YF8nDM+iBKnLDlkIoW66MDd0R6aGg4BvKzTTdJpvigUA==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -11571,28 +11108,10 @@ packages:
       firebase-functions: '>=2.0.0'
     dependencies:
       '@types/lodash': 4.14.202
-      firebase-admin: 11.11.1
-      firebase-functions: 3.24.1_firebase-admin@11.11.1
+      firebase-admin: 11.8.0
+      firebase-functions: 3.24.1_firebase-admin@11.8.0
       lodash: 4.17.21
     dev: true
-
-  /firebase-functions/3.24.1_firebase-admin@11.11.1:
-    resolution: {integrity: sha512-GYhoyOV0864HFMU1h/JNBXYNmDk2MlbvU7VO/5qliHX6u/6vhSjTJjlyCG4leDEI8ew8IvmkIC5QquQ1U8hAuA==}
-    engines: {node: ^8.13.0 || >=10.10.0}
-    hasBin: true
-    peerDependencies:
-      firebase-admin: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
-    dependencies:
-      '@types/cors': 2.8.17
-      '@types/express': 4.17.3
-      cors: 2.8.5
-      express: 4.18.2
-      firebase-admin: 11.11.1
-      lodash: 4.17.21
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-    dev: false
 
   /firebase-functions/3.24.1_firebase-admin@11.8.0:
     resolution: {integrity: sha512-GYhoyOV0864HFMU1h/JNBXYNmDk2MlbvU7VO/5qliHX6u/6vhSjTJjlyCG4leDEI8ew8IvmkIC5QquQ1U8hAuA==}
@@ -11610,7 +11129,6 @@ packages:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
-    dev: true
 
   /firebase-tools/12.2.1:
     resolution: {integrity: sha512-9QjNJRFf+v5kgkRO0yXmVYNUZ8fZI6FrOTrgp7YQ2fhqytaIpEQrKSbKZebGlSjDGvcX87daKEsUEjqj0LuSvw==}
@@ -11682,79 +11200,6 @@ packages:
       - encoding
       - supports-color
       - utf-8-validate
-    dev: false
-
-  /firebase-tools/12.9.1:
-    resolution: {integrity: sha512-t/oTgGnGm3sLT3wR80B7hY6vdAs6rTlZMsmnZGsP+GeKtVzaB5KHEwLbkZuRXtqij9f35IfkQm2a4TKjKY6xUQ==}
-    engines: {node: '>=16.13.0 || >=18.0.0'}
-    hasBin: true
-    dependencies:
-      '@google-cloud/pubsub': 3.7.5
-      abort-controller: 3.0.0
-      ajv: 6.12.6
-      archiver: 5.3.2
-      async-lock: 1.3.2
-      body-parser: 1.20.2
-      chokidar: 3.5.3
-      cjson: 0.3.3
-      cli-table: 0.3.11
-      colorette: 2.0.20
-      commander: 4.1.1
-      configstore: 5.0.1
-      cors: 2.8.5
-      cross-env: 5.2.1
-      cross-spawn: 7.0.3
-      csv-parse: 5.5.3
-      exegesis: 4.1.1
-      exegesis-express: 4.0.0
-      express: 4.18.2
-      filesize: 6.4.0
-      form-data: 4.0.0
-      fs-extra: 10.1.0
-      glob: 7.2.3
-      google-auth-library: 7.14.1
-      inquirer: 8.2.6
-      js-yaml: 3.14.1
-      jsonwebtoken: 9.0.2
-      leven: 3.1.0
-      libsodium-wrappers: 0.7.13
-      lodash: 4.17.21
-      marked: 4.3.0
-      marked-terminal: 5.2.0_marked@4.3.0
-      mime: 2.6.0
-      minimatch: 3.1.2
-      morgan: 1.10.0
-      node-fetch: 2.7.0
-      open: 6.4.0
-      ora: 5.4.1
-      p-limit: 3.1.0
-      portfinder: 1.0.32
-      progress: 2.0.3
-      proxy-agent: 6.3.1
-      request: 2.88.2
-      retry: 0.13.1
-      rimraf: 3.0.2
-      semver: 7.5.4
-      stream-chain: 2.2.5
-      stream-json: 1.8.0
-      strip-ansi: 6.0.1
-      superstatic: 9.0.3
-      tar: 6.2.0
-      tcp-port-used: 1.0.2
-      tmp: 0.2.1
-      triple-beam: 1.4.1
-      universal-analytics: 0.5.3
-      update-notifier-cjs: 5.1.6
-      uuid: 8.3.2
-      winston: 3.11.0
-      winston-transport: 4.6.0
-      ws: 7.5.9
-    transitivePeerDependencies:
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-    dev: true
 
   /firebase/9.22.1:
     resolution: {integrity: sha512-8x55ZZJwPlctKIhlfXL+KTOpdabp6dDpDwTEmuW1QNbfCkE1ZEuXHgjiQMfTkoeyQO9luV6YwVdgbgCt7yfYCg==}
@@ -11787,39 +11232,6 @@ packages:
       '@firebase/util': 1.9.3
     transitivePeerDependencies:
       - encoding
-    dev: false
-
-  /firebase/9.22.2:
-    resolution: {integrity: sha512-eBXsaTzXPx3Y0QhuuluG/qR58tlOx2X/W0GKNoF004FcG9L2gHuvGu5/bIczvrPyfNOCqDF+I5I/kOQi8l9m0A==}
-    dependencies:
-      '@firebase/analytics': 0.10.0_@firebase+app@0.9.12
-      '@firebase/analytics-compat': 0.2.6_87ce4696d37bf2b221712087441a4b69
-      '@firebase/app': 0.9.12
-      '@firebase/app-check': 0.8.0_@firebase+app@0.9.12
-      '@firebase/app-check-compat': 0.3.7_87ce4696d37bf2b221712087441a4b69
-      '@firebase/app-compat': 0.2.12
-      '@firebase/app-types': 0.9.0
-      '@firebase/auth': 0.23.2_@firebase+app@0.9.12
-      '@firebase/auth-compat': 0.4.2_6799c90e92a20ab804ed82c8c384a8c5
-      '@firebase/database': 0.14.4
-      '@firebase/database-compat': 0.3.4
-      '@firebase/firestore': 3.12.2_@firebase+app@0.9.12
-      '@firebase/firestore-compat': 0.3.11_6799c90e92a20ab804ed82c8c384a8c5
-      '@firebase/functions': 0.10.0_@firebase+app@0.9.12
-      '@firebase/functions-compat': 0.3.5_87ce4696d37bf2b221712087441a4b69
-      '@firebase/installations': 0.6.4_@firebase+app@0.9.12
-      '@firebase/installations-compat': 0.2.4_6799c90e92a20ab804ed82c8c384a8c5
-      '@firebase/messaging': 0.12.4_@firebase+app@0.9.12
-      '@firebase/messaging-compat': 0.2.4_87ce4696d37bf2b221712087441a4b69
-      '@firebase/performance': 0.6.4_@firebase+app@0.9.12
-      '@firebase/performance-compat': 0.2.4_87ce4696d37bf2b221712087441a4b69
-      '@firebase/remote-config': 0.4.4_@firebase+app@0.9.12
-      '@firebase/remote-config-compat': 0.2.4_87ce4696d37bf2b221712087441a4b69
-      '@firebase/storage': 0.11.2_@firebase+app@0.9.12
-      '@firebase/storage-compat': 0.3.2_6799c90e92a20ab804ed82c8c384a8c5
-      '@firebase/util': 1.9.3
-    transitivePeerDependencies:
-      - encoding
 
   /firebaseui/6.0.2_firebase@9.22.1:
     resolution: {integrity: sha512-Jwwn2I657loKrvedeCrwED9UibLFl8Cm0uH2ntDBSCpruWzG4HXlIWb35WsDdXMILRPQjJ1PwVwuRsrnsxcaXA==}
@@ -11835,7 +11247,7 @@ packages:
     resolution: {integrity: sha512-F6TkRY//MsuPSHJZYaT76g6ZHTyJZibSSQP1GmoJ/wsjYhtINuI+FUL9Kz6oVTVVYTkdDb/YSlIoATAI1Kl9Cw==}
     engines: {node: '>=16.0.0', pnpm: '>=7'}
     dependencies:
-      firebase-admin: 11.11.1
+      firebase-admin: 11.8.0
       google-gax: 3.6.1
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -12065,7 +11477,6 @@ packages:
     dependencies:
       readable-stream: 1.1.14
       xregexp: 2.0.0
-    dev: false
 
   /function-bind/1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -12230,19 +11641,6 @@ packages:
       ftp: 0.3.10
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /get-uri/6.0.2:
-    resolution: {integrity: sha512-5KLucCJobh8vBY1K07EFV4+cPZH3mrV9YeAruUseCQKHB58SGjjT2l9/eA9LD082IiuMjSlFJEcdJ27TXvbZNw==}
-    engines: {node: '>= 14'}
-    dependencies:
-      basic-ftp: 5.0.4
-      data-uri-to-buffer: 6.0.1
-      debug: 4.3.4
-      fs-extra: 8.1.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /getos/3.2.1:
     resolution: {integrity: sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==}
@@ -12795,6 +12193,7 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   /http-signature/1.2.0:
     resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
@@ -14818,11 +14217,6 @@ packages:
     dependencies:
       yallist: 4.0.0
 
-  /lru-cache/7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
-    dev: true
-
   /lru-memoizer/2.2.0:
     resolution: {integrity: sha512-QfOZ6jNkxCcM/BkIPnFsqDhtrazLRsghi9mBwFAzol5GCvj4EkFT899Za3+QwikCg5sRX8JstioBDwOxEyzaNw==}
     dependencies:
@@ -16618,23 +16012,6 @@ packages:
       socks-proxy-agent: 5.0.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /pac-proxy-agent/7.0.1:
-    resolution: {integrity: sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==}
-    engines: {node: '>= 14'}
-    dependencies:
-      '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.0
-      debug: 4.3.4
-      get-uri: 6.0.2
-      http-proxy-agent: 7.0.0
-      https-proxy-agent: 7.0.2
-      pac-resolver: 7.0.0
-      socks-proxy-agent: 8.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /pac-resolver/5.0.1:
     resolution: {integrity: sha512-cy7u00ko2KVgBAjuhevqpPeHIkCIqPe1v24cydhWjmeuzaBfmUWFCZJ1iAh5TuVzVZoUzXIW7K8sMYOZ84uZ9Q==}
@@ -16643,16 +16020,6 @@ packages:
       degenerator: 3.0.4
       ip: 1.1.8
       netmask: 2.0.2
-    dev: false
-
-  /pac-resolver/7.0.0:
-    resolution: {integrity: sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==}
-    engines: {node: '>= 14'}
-    dependencies:
-      degenerator: 5.0.1
-      ip: 1.1.8
-      netmask: 2.0.2
-    dev: true
 
   /package-hash/4.0.0:
     resolution: {integrity: sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==}
@@ -17245,23 +16612,6 @@ packages:
       socks-proxy-agent: 5.0.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /proxy-agent/6.3.1:
-    resolution: {integrity: sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==}
-    engines: {node: '>= 14'}
-    dependencies:
-      agent-base: 7.1.0
-      debug: 4.3.4
-      http-proxy-agent: 7.0.0
-      https-proxy-agent: 7.0.2
-      lru-cache: 7.18.3
-      pac-proxy-agent: 7.0.1
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /proxy-from-env/1.0.0:
     resolution: {integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==}
@@ -17705,7 +17055,6 @@ packages:
       inherits: 2.0.4
       isarray: 0.0.1
       string_decoder: 0.10.31
-    dev: false
 
   /readable-stream/2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -18421,7 +17770,6 @@ packages:
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /socks-proxy-agent/8.0.2:
     resolution: {integrity: sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==}
@@ -18432,6 +17780,7 @@ packages:
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   /socks/2.7.1:
     resolution: {integrity: sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==}
@@ -18718,7 +18067,6 @@ packages:
 
   /string_decoder/0.10.31:
     resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
-    dev: false
 
   /string_decoder/1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -20300,7 +19648,6 @@ packages:
     dependencies:
       acorn: 8.11.3
       acorn-walk: 8.3.2
-    dev: false
 
   /void-elements/3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
@@ -20734,7 +20081,6 @@ packages:
 
   /xregexp/2.0.0:
     resolution: {integrity: sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==}
-    dev: false
 
   /xtend/4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "0ef04f239fa79bd637fcb1ddf1b015391c3bb4cd",
+  "pnpmShrinkwrapHash": "1ec20d9b165fd5fff4d1fe5a531a38288988dd5c",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/firestore-process-delivery/package.json
+++ b/packages/firestore-process-delivery/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint .",
     "lint:strict": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
-    "test": "bash -c '(trap \"kill 0\" SIGINT; firebase -c ../../firebase-testing.json  emulators:exec --project eisbuk -- \" jest --watch --runInBand --detectOpenHandles src\")'",
+    "test": "bash -c '(trap \"kill 0\" SIGINT; firebase -c ../../firebase-testing.json  emulators:exec --project eisbuk -- \" vitest --ui src\")'",
     "test:verbose": "LOG_LEVEL=verbose rushx test"
   },
   "main": "dist/index.js",
@@ -32,10 +32,10 @@
     "@babel/preset-typescript": "^7.14.5",
     "@firebase/app-types": "~0.9.0",
     "@grpc/grpc-js": "^1.6.2",
-    "@types/jest": "^27.4.1",
     "@types/node": "^18.16.0",
     "@typescript-eslint/eslint-plugin": "~5.59.0",
     "@typescript-eslint/parser": "~5.59.0",
+    "@vitest/ui": "~0.31.4",
     "eslint": "^8.13.0",
     "eslint-config-google": "^0.14.0",
     "eslint-import-resolver-typescript": "~3.5.5",
@@ -43,11 +43,11 @@
     "eslint-plugin-promise": "~6.1.1",
     "eslint-plugin-unused-imports": "~2.0.0",
     "firebase-functions-test": "^0.2.3",
-    "jest": "^27.5.1",
     "mocha": "^8.2.1",
     "typescript": "~5.0.4",
     "vite": "~4.3.1",
-    "vite-plugin-environment": "^1.1.0"
+    "vite-plugin-environment": "^1.1.0",
+    "vitest": "~0.31.3"
   },
   "private": true
 }

--- a/packages/firestore-process-delivery/src/__tests__/process-delivery.test.ts
+++ b/packages/firestore-process-delivery/src/__tests__/process-delivery.test.ts
@@ -1,6 +1,4 @@
-// import functionsTest from "firebase-functions-test";
 import admin from "firebase-admin";
-import { Timestamp } from "@google-cloud/firestore";
 
 import { adminDb } from "../__testSetup__/adminDb";
 
@@ -148,7 +146,7 @@ describe("Test process delivery functionality", () => {
       delivery: {
         status: DeliveryStatus.Processing,
         // Test with expired lease
-        leaseExpireTime: Timestamp.fromMillis(Date.now() - 1000),
+        leaseExpireTime: Date.now() - 1000,
       } as ProcessDocument["delivery"],
     });
     const expiredDoc = await processDocRef.get();

--- a/packages/firestore-process-delivery/src/__tests__/process-delivery.test.ts
+++ b/packages/firestore-process-delivery/src/__tests__/process-delivery.test.ts
@@ -1,4 +1,5 @@
 import admin from "firebase-admin";
+import { beforeEach, afterEach, describe, test, expect, vi } from "vitest";
 
 import { adminDb } from "../__testSetup__/adminDb";
 
@@ -6,23 +7,23 @@ import { DeliveryStatus, ProcessDocument } from "../types";
 
 import processDelivery from "../index";
 
-beforeEach(() =>
-  Promise.all([
+beforeEach(async () => {
+  await Promise.all([
     adminDb.doc("queue/doc1").delete(),
     adminDb.doc("delivery/doc1").delete(),
-  ])
-);
+  ]);
+});
 
 afterEach(() => {
-  jest.clearAllMocks();
+  vi.clearAllMocks();
 });
 
 // We want the transactions be ran against our test db (`adminDB`)
-jest.spyOn(admin, "firestore").mockImplementation(() => adminDb);
+vi.spyOn(admin, "firestore").mockImplementation(() => adminDb);
 
 // We might want to get function logs directly printed to the console
 // as well as avoid the tests breaking because no admin app was initialized
-jest.mock("firebase-functions", () => ({
+vi.mock("firebase-functions", () => ({
   logger: console,
 }));
 
@@ -58,7 +59,7 @@ describe("Test process delivery functionality", () => {
     // Expect the delivery to be processed successfully
     // This execution also features 'PROCESSING' state, but with the resolution of the execution
     // the delivery will already be in 'SUCCESS' state
-    const mockDelivery = jest.fn();
+    const mockDelivery = vi.fn();
     await processDelivery(
       { before: pendingDoc, after: pendingDoc },
       async ({ success }) => {

--- a/packages/firestore-process-delivery/src/types.ts
+++ b/packages/firestore-process-delivery/src/types.ts
@@ -4,7 +4,6 @@ import * as functions from "firebase-functions";
 export type DocumentReference =
   FirebaseFirestore.DocumentReference<FirebaseFirestore.DocumentData>;
 export type Change = functions.Change<FirebaseFirestore.DocumentSnapshot>;
-export type Timestamp = FirebaseFirestore.Timestamp;
 export type FieldValue = FirebaseFirestore.FieldValue;
 // #endregion typeAliases
 
@@ -47,15 +46,15 @@ export interface ProcessDocument<P = Record<string, any>> {
     /**
      * Start time of the delivery process.
      */
-    startTime: Timestamp;
+    startTime: number;
     /**
      * Time of the latest update (`"SUCCESS"`, `"ERROR"`, or additional updates from provider webhooks).
      */
-    endTime?: Timestamp;
+    endTime?: number | null;
     /**
      * Lease expires 60 seconds after the delivery attempted (assigned on `"PENDING"` or `"RETRY"`).
      */
-    leaseExpireTime: Timestamp | null;
+    leaseExpireTime: number | null;
     /**
      * See `DeliveryStatus` enum.
      */
@@ -80,18 +79,7 @@ export interface ProcessDocument<P = Record<string, any>> {
   payload: P;
 }
 
-type TimestampKeys = "startTime" | "endTime" | "leaseExpireTime";
-
-/**
- * An update for `ProcessDocument`'s `delivery` state. Each field is optional due to update being applied
- * using `merge:true`. Additionally, each timestamped field ("startTime", "endTime", "leaseExpiration") can also
- * be `FieldValue` other than `Timestamp | null` as it's an update - resulting in an appropriate
- * `Timestamp | null` value in the state itself
- */
-export type DeliveryUpdate = Partial<
-  Omit<ProcessDocument["delivery"], TimestampKeys> &
-    Record<TimestampKeys, Timestamp | FieldValue | null>
->;
+export type DeliveryUpdate = Partial<ProcessDocument["delivery"]>;
 // #endregion processDocument
 
 // #region deliverCallback

--- a/packages/firestore-process-delivery/tsconfig.json
+++ b/packages/firestore-process-delivery/tsconfig.json
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "noUncheckedIndexedAccess": true,
 
-    "types": ["node", "jest"]
+    "types": ["node"]
   },
   "exclude": ["node_modules", "./.eslintrc.js", "jest.config.js"],
   "include": ["./src/**/*.ts"]


### PR DESCRIPTION
To avoid the hassle of cloud function/firestore version mismatches and `Timestamp` incompatibility, use the good old unix timestamp (number) for timestamp fields in `firestore-process-delivery`

_(also, use Vitest for `firestore-process-delivery` tests)_