### PR TITLE
Use 'emailNameFrom' when sending email (and use 'emailFrom' as fallback)

### DIFF
--- a/packages/client/src/__tests__/sendEmail.test.ts
+++ b/packages/client/src/__tests__/sendEmail.test.ts
@@ -202,8 +202,7 @@ describe("SendEmail", () => {
     expect(deliveryDocData).toEqual(
       expect.objectContaining({
         payload: expect.objectContaining({
-          // Using email name from instead of email from
-          from: "Eisbuk Team",
+          from: `Eisbuk Team <${emailSetup.emailFrom}>`,
           to: saul.email,
           bcc: emailSetup.emailBcc,
         }),

--- a/packages/functions/src/sendEmail/https.ts
+++ b/packages/functions/src/sendEmail/https.ts
@@ -65,6 +65,7 @@ export const sendEmail = functions
         displayName = organization,
         smtpConfigured,
         emailFrom,
+        emailNameFrom,
         emailBcc,
       } = orgDoc.data() as OrganizationData;
 
@@ -90,7 +91,7 @@ export const sendEmail = functions
 
       // Construct an email for process delivery
       const email = {
-        from: emailFrom,
+        from: emailNameFrom || emailFrom,
         to: validatedPayload.email,
         bcc: emailBcc || emailFrom,
         subject,

--- a/packages/functions/src/sendEmail/https.ts
+++ b/packages/functions/src/sendEmail/https.ts
@@ -89,9 +89,14 @@ export const sendEmail = functions
         calendarFile: validatedPayload.attachments?.filename,
       });
 
+      // If the 'emailNameFrom' is set, we're wrapping the emailFrom to the mailbox format
+      const from = emailNameFrom
+        ? `${emailNameFrom} <${emailFrom}>`
+        : emailFrom;
+
       // Construct an email for process delivery
       const email = {
-        from: emailNameFrom || emailFrom,
+        from,
         to: validatedPayload.email,
         bcc: emailBcc || emailFrom,
         subject,


### PR DESCRIPTION
Fixes #931 

This needs to be deployed first (the updated `sendEmail`) and checked that way...I wrote a test verifying that the expected payload is handed off for delivery, but can't verify for sure that it will work e2e as expected (until and actual mail has beed sent, that is...).