### PR TITLE
fix: make notes red 

### DIFF
--- a/packages/ui/src/AttendanceCard/UserAttendance.tsx
+++ b/packages/ui/src/AttendanceCard/UserAttendance.tsx
@@ -183,7 +183,7 @@ const UserAttendance: React.FC<Props> = ({
           <p className="w-fit text-gray-600 text-xs mt-2 ml-4 border-b-[1px] border-gray-400">
             {t(AttendanceAria.TrainerNotes)}
           </p>
-          <p className="text-gray-600 text-xs px-2 pt-1 pb-2">{bookingNotes}</p>
+          <p className="text-red-700 text-xs px-2 pt-1 pb-2">{bookingNotes}</p>
         </div>
       )}
     </div>

--- a/packages/ui/src/IntervalCard/NotesSection.tsx
+++ b/packages/ui/src/IntervalCard/NotesSection.tsx
@@ -55,10 +55,10 @@ const NotesSection: React.FC<NotesSectionProps> = ({
       <Form className={className}>
         <FastField
           name="bookingNotes"
-          className="w-full h-full min-h-[105px] border-t border-gray-300"
+          className="w-full h-full min-h-[105px] border-t border-gray-300 "
+          innerClassName="text-red-700"
           component={TextareaEditable}
           isEditing={isEditing}
-          placeholder={t(BookingNotesForm.Placeholder)}
           // Fast field runs some sort of memoization
           // by switching the key (when 'isEditing' is toggled)
           // we're ensuring the component gets rerendered (from 'p' to 'textarea' in this case)
@@ -73,7 +73,7 @@ const NotesSection: React.FC<NotesSectionProps> = ({
           </HoverText>
           <div className="absolute right-2 top-1/2 -translate-y-1/2 flex gap-1">
             <IconButton
-              className="text-red-500"
+              className="text-red-700"
               {...actionButtonProps}
               type="reset"
             >

--- a/packages/ui/src/TextareaEditable/TextareaEditable.tsx
+++ b/packages/ui/src/TextareaEditable/TextareaEditable.tsx
@@ -8,6 +8,7 @@ type TextareaEditableProps = React.HTMLAttributes<HTMLElement> &
      */
     isEditing?: boolean;
     value?: string;
+    innerClassName?: string;
   };
 
 /**
@@ -17,6 +18,7 @@ type TextareaEditableProps = React.HTMLAttributes<HTMLElement> &
 const TextareaEditable: React.FC<TextareaEditableProps> = ({
   isEditing,
   className: inputClasses = "",
+  innerClassName: inputInnerClasses = "",
   field = {},
   ...initialProps
 }) => {
@@ -42,6 +44,7 @@ const TextareaEditable: React.FC<TextareaEditableProps> = ({
     // If there's no value, we might show a placeholder (even outside edit mode)
     // so it should be colored as such
     value ? "text-gray-900" : "text-gray-400",
+    inputInnerClasses,
   ];
 
   return (


### PR DESCRIPTION
- make notes red for teacher
- extend TextareaEditable with `innerClassName` prop
- remove placeholder from TextareaEditable on NotesSection
- make notes red on notes input for user