### PR TITLE
Update github actions to use node20 compatible versions

### DIFF
--- a/.github/workflow.templates/build.yml
+++ b/.github/workflow.templates/build.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
     steps:
       -  #@ checkout()
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       -  #@ cache_node()
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 10
     steps:
       -  #@ checkout()
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       -  #@ cache_node()
@@ -113,7 +113,7 @@ jobs:
           path: packages/client/junit.xml
           reporter: java-junit
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         if: steps.has_secret.outputs.HAS_SECRETS
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
     timeout-minutes: 10
     steps:
       -  #@ checkout()
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       -  #@ cache_node()
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       -  #@ checkout()
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       -  #@ cache_cypress()
@@ -165,7 +165,7 @@ jobs:
       - name: Build app
         run: cd packages/client && NODE_OPTIONS="--max-old-space-size=8192" rushx build:test
       - name: Cypress run
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           start: emulators-start
           browser: chrome
@@ -191,7 +191,7 @@ jobs:
 
       -  #@ check_secrets()
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         if: steps.has_secret.outputs.HAS_SECRETS
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -224,7 +224,7 @@ jobs:
     steps:
       -  #@ check_secrets()
       - name: Finalize Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         if: steps.has_secret.outputs.HAS_SECRETS
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -236,7 +236,7 @@ jobs:
     timeout-minutes: 10
     steps:
       -  #@ checkout()
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       -  #@ cache_node()

--- a/.github/workflow.templates/cache.lib.yml
+++ b/.github/workflow.templates/cache.lib.yml
@@ -1,6 +1,6 @@
 #@ def cache_node():
 name: Cache node modules and firebase emulators
-uses: actions/cache@v3
+uses: actions/cache@v4
 with:
   path: |
     ~/.rush
@@ -13,7 +13,7 @@ with:
 
 #@ def cache_cypress():
 name: Cache node modules, firebase emulators and cypress
-uses: actions/cache@v3
+uses: actions/cache@v4
 with:
   path: |
     ~/.rush

--- a/.github/workflow.templates/cypress-matrix.yml
+++ b/.github/workflow.templates/cypress-matrix.yml
@@ -31,7 +31,7 @@ jobs:
         dummy2: [1, 2, 3, 4, 5, 6]
     steps:
       -  #@ checkout()
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       -  #@ cache_cypress()
@@ -41,7 +41,7 @@ jobs:
       - name: Build app
         run: cd packages/client && NODE_OPTIONS="--max-old-space-size=8192" rushx build:test
       - name: Cypress run
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v6
         with:
           start: emulators-start
           #! We're using our own instalation as it is, so just skipping this part
@@ -52,7 +52,7 @@ jobs:
           config-file: cypress-ci.config.ts
       -  #@ check_secrets()
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         if: steps.has_secret.outputs.HAS_SECRETS
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflow.templates/deploy-production.yml
+++ b/.github/workflow.templates/deploy-production.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install expect
         run: sudo apt-get -y install expect
       -  #@ checkout()
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       -  #@ cache_node()

--- a/.github/workflow.templates/pr.yml
+++ b/.github/workflow.templates/pr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check if PRs are dirty
-      uses: eps1lon/actions-label-merge-conflict@releases/2.x
+      uses: eps1lon/actions-label-merge-conflict@v3
       if: env.LABELING_TOKEN != '' && env.LABELING_TOKEN != null
       id: check
       with:

--- a/.github/workflow.templates/setup.lib.yml
+++ b/.github/workflow.templates/setup.lib.yml
@@ -1,5 +1,5 @@
 #@ def checkout(fetchdepth=1):
-uses: actions/checkout@v3
+uses: actions/checkout@v4
 with:
   submodules: "recursive"
   fetch-depth: #@ fetchdepth

--- a/.github/workflow.templates/storybook.lib.yml
+++ b/.github/workflow.templates/storybook.lib.yml
@@ -12,7 +12,7 @@ runs-on: ubuntu-latest
 timeout-minutes: 10
 steps:
   -  #@ checkout(0)
-  - uses: actions/setup-node@v3
+  - uses: actions/setup-node@v4
     with:
       node-version: "18"
   -  #@ cache_node()

--- a/.github/workflow.templates/vitest-matrix.yml
+++ b/.github/workflow.templates/vitest-matrix.yml
@@ -26,7 +26,7 @@ jobs:
         dummy2: [1, 2, 3, 4, 5, 6]
     steps:
       -  #@ checkout()
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
       -  #@ cache_node()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 1
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: "18"
     - name: Cache node modules and firebase emulators
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.rush
@@ -96,15 +96,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 1
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: "18"
     - name: Cache node modules and firebase emulators
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.rush
@@ -133,7 +133,7 @@ jobs:
         path: packages/client/junit.xml
         reporter: java-junit
     - name: Coveralls
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       if: steps.has_secret.outputs.HAS_SECRETS
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -175,15 +175,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 1
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: "18"
     - name: Cache node modules and firebase emulators
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.rush
@@ -206,15 +206,15 @@ jobs:
     name: Cypress browser tests
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 1
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: "18"
     - name: Cache node modules, firebase emulators and cypress
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.rush
@@ -233,7 +233,7 @@ jobs:
     - name: Build app
       run: cd packages/client && NODE_OPTIONS="--max-old-space-size=8192" rushx build:test
     - name: Cypress run
-      uses: cypress-io/github-action@v5
+      uses: cypress-io/github-action@v6
       with:
         start: emulators-start
         browser: chrome
@@ -250,7 +250,7 @@ jobs:
       if: success() || failure()
       run: '[ "${{ secrets.CYPRESS_KEY }}" != "" ] && echo HAS_SECRETS=true >> $GITHUB_OUTPUT || echo HAS_SECRETS= >> $GITHUB_OUTPUT'
     - name: Coveralls
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       if: steps.has_secret.outputs.HAS_SECRETS
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -304,7 +304,7 @@ jobs:
       if: success() || failure()
       run: '[ "${{ secrets.CYPRESS_KEY }}" != "" ] && echo HAS_SECRETS=true >> $GITHUB_OUTPUT || echo HAS_SECRETS= >> $GITHUB_OUTPUT'
     - name: Finalize Coveralls
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       if: steps.has_secret.outputs.HAS_SECRETS
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -314,15 +314,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 1
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: "18"
     - name: Cache node modules and firebase emulators
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.rush
@@ -342,15 +342,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 0
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: "18"
     - name: Cache node modules and firebase emulators
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.rush
@@ -405,15 +405,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 0
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: "18"
     - name: Cache node modules and firebase emulators
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.rush

--- a/.github/workflows/cypress-matrix.yml
+++ b/.github/workflows/cypress-matrix.yml
@@ -27,15 +27,15 @@ jobs:
         - 5
         - 6
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 1
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: "18"
     - name: Cache node modules, firebase emulators and cypress
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.rush
@@ -54,7 +54,7 @@ jobs:
     - name: Build app
       run: cd packages/client && NODE_OPTIONS="--max-old-space-size=8192" rushx build:test
     - name: Cypress run
-      uses: cypress-io/github-action@v4
+      uses: cypress-io/github-action@v6
       with:
         start: emulators-start
         install: false
@@ -67,7 +67,7 @@ jobs:
       if: success() || failure()
       run: '[ "${{ secrets.CYPRESS_KEY }}" != "" ] && echo HAS_SECRETS=true >> $GITHUB_OUTPUT || echo HAS_SECRETS= >> $GITHUB_OUTPUT'
     - name: Coveralls
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       if: steps.has_secret.outputs.HAS_SECRETS
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -11,15 +11,15 @@ jobs:
     steps:
     - name: Install expect
       run: sudo apt-get -y install expect
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 1
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: "18"
     - name: Cache node modules and firebase emulators
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.rush

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check if PRs are dirty
-      uses: eps1lon/actions-label-merge-conflict@releases/2.x
+      uses: eps1lon/actions-label-merge-conflict@v3
       if: env.LABELING_TOKEN != '' && env.LABELING_TOKEN != null
       id: check
       with:

--- a/.github/workflows/vitest-matrix.yml
+++ b/.github/workflows/vitest-matrix.yml
@@ -27,15 +27,15 @@ jobs:
         - 5
         - 6
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
         fetch-depth: 1
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v4
       with:
         node-version: "18"
     - name: Cache node modules and firebase emulators
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.rush


### PR DESCRIPTION
There are warnings about the need to upgrade actions to nodejs 20 in the github actions summaries pointing to this document: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

This PR gets rid of the warnings.