### PR TITLE
fix: guard client selectors & helpers against missing/dangling data (crashes #832, #816)

### DIFF
--- a/packages/client/src/store/selectors/attendance/__tests__/attendance.test.ts
+++ b/packages/client/src/store/selectors/attendance/__tests__/attendance.test.ts
@@ -12,7 +12,10 @@ import {
   getBookedIntervalsCustomers,
 } from "../slotAttendance";
 
-import { processAttendances } from "../attendanceVariance";
+import {
+  processAttendances,
+  getMonthAttendanceVariance,
+} from "../attendanceVariance";
 
 import { getNewStore } from "@/store/createStore";
 
@@ -44,6 +47,36 @@ describe("Selectors ->", () => {
     test("should get slots for current day (read from store) with customers attendance (sorted by booked interval) data for each slot", () => {
       const res = getSlotsWithAttendance(testStore.getState());
       expect(res).toEqual(expectedStruct);
+    });
+
+    test("should not crash when a slot has no attendance doc (regression: #832, missing/lagging attendance trigger)", () => {
+      const dateISO = testDateLuxon.toISODate();
+      const monthStr = dateISO.substring(0, 7);
+      const slot = {
+        ...baseSlot,
+        id: "slot-without-attendance",
+        date: dateISO,
+      };
+
+      const store = getNewStore({
+        firestore: {
+          data: {
+            // Slot exists for the current day...
+            slotsByDay: { [monthStr]: { [dateISO]: { [slot.id]: slot } } },
+            // ...but there's no attendance/{slotId} doc for it.
+            attendance: {},
+            customers: {},
+          },
+        },
+        app: {
+          calendarDay: testDateLuxon,
+        },
+      });
+
+      expect(() => getSlotsWithAttendance(store.getState())).not.toThrow();
+      const res = getSlotsWithAttendance(store.getState());
+      expect(res).toHaveLength(1);
+      expect(res[0].customers).toEqual([]);
     });
   });
 
@@ -232,6 +265,25 @@ describe("Selectors ->", () => {
         },
       ],
     ]);
+  });
+
+  test("'getMonthAttendanceVariance' should not crash when the month has no slotsByDay entry (regression: #832 / Object.values(undefined))", () => {
+    const store = getNewStore({
+      firestore: {
+        data: {
+          attendance: {},
+          customers: {},
+          // No entry for the viewed month (not loaded yet, or no slots).
+          slotsByDay: {},
+        },
+      },
+      app: {
+        calendarDay: testDateLuxon,
+      },
+    });
+
+    expect(() => getMonthAttendanceVariance(store.getState())).not.toThrow();
+    expect(getMonthAttendanceVariance(store.getState())).toEqual([]);
   });
 
   describe("Test 'getBookedIntervalsCustomers'", () => {

--- a/packages/client/src/store/selectors/attendance/attendanceVariance.ts
+++ b/packages/client/src/store/selectors/attendance/attendanceVariance.ts
@@ -37,7 +37,7 @@ export const processAttendances = (
   attendance: Attendance,
   slots: Slots,
   customers: Customers,
-  month: string,
+  month: string
 ) =>
   wrapIter(Object.entries(attendance))
     // Get only current month's attendance
@@ -46,8 +46,8 @@ export const processAttendances = (
     .flatMap(([slotId, { date, attendances }]) =>
       // { customerId => attendanceIntervals } pairs
       Object.entries(attendances).map(
-        valueMapper(mergeMapper({ date, slotType: slots[slotId].type })),
-      ),
+        valueMapper(mergeMapper({ date, slotType: slots[slotId].type }))
+      )
     )
     // { customerId => attendanceDurations } pairs
     .map(valueMapper(convertIntervalsToDurations))
@@ -66,7 +66,7 @@ export const processAttendances = (
     .map(keyMapper(joinCustomerName));
 
 export const getMonthAttendanceVariance = (
-  state: LocalStore,
+  state: LocalStore
 ): AthleteAttendanceMonth[] => {
   const { app, firestore } = state;
   const { calendarDay } = app;
@@ -75,12 +75,13 @@ export const getMonthAttendanceVariance = (
   const currentMonth = getMonthStr(calendarDay, 0);
   const slots = Object.fromEntries(
     flatMap(
-      // `slotsByDay` is defaulted to `{}` above, so it is always truthy; the month
-      // entry itself can be missing (month not loaded yet, or no slots that month),
-      // in which case `Object.values(undefined)` would throw.
-      Object.values(slotsByDay[currentMonth] || {}),
-      (slots) => Object.entries(slots),
-    ),
+      // The `= {}` destructuring default above only covers `undefined`, not `null`
+      // (which the store type allows); the month entry itself can also be missing
+      // (month not loaded yet, or no slots that month), in which case
+      // `Object.values(undefined)` would throw.
+      Object.values(slotsByDay?.[currentMonth] || {}),
+      (slots) => Object.entries(slots)
+    )
   );
 
   return processAttendances(attendance, slots, customers, currentMonth);
@@ -97,14 +98,12 @@ export const filterAttendanceByMonth =
 
 export const replaceCustomerIdWithName =
   (customerLookup: Customers) =>
-  (id: string): CustomerNameTuple => [
-    customerLookup[id].surname,
-    customerLookup[id].name,
-  ];
+  (id: string): CustomerNameTuple =>
+    [customerLookup[id].surname, customerLookup[id].name];
 
 const compareCustomerNames = (
   [[a]]: [CustomerNameTuple, any],
-  [[b]]: [CustomerNameTuple, any],
+  [[b]]: [CustomerNameTuple, any]
 ) => (a > b ? 1 : -1);
 
 const joinCustomerName = (customer: CustomerNameTuple) => customer.join(" ");
@@ -131,7 +130,7 @@ const datePairFromAttendance = <A extends { date: string }>({
 
 const aggregateAttendance = (
   acc: AttendanceBySlotType,
-  { slotType, booked, attended }: AttendanceDurationsWithType,
+  { slotType, booked, attended }: AttendanceDurationsWithType
 ) => ({
   ...acc,
   [slotType]: {
@@ -141,7 +140,7 @@ const aggregateAttendance = (
 });
 
 const aggregateAttendanceEntries = (
-  attendances: Iterable<AttendanceDurationsWithType>,
+  attendances: Iterable<AttendanceDurationsWithType>
 ): AttendanceBySlotType =>
   _reduce(attendances, aggregateAttendance, {
     [SlotType.Ice]: { booked: 0, attended: 0 },
@@ -149,7 +148,7 @@ const aggregateAttendanceEntries = (
   });
 
 const aggregateAttendanceByDate = (
-  attendances: Iterable<DateAttendancePair<AttendanceDurationsWithType>>,
+  attendances: Iterable<DateAttendancePair<AttendanceDurationsWithType>>
 ): AttendanceByDate =>
   wrapIter(attendances)
     // Group each pair by date:

--- a/packages/client/src/store/selectors/attendance/attendanceVariance.ts
+++ b/packages/client/src/store/selectors/attendance/attendanceVariance.ts
@@ -37,7 +37,7 @@ export const processAttendances = (
   attendance: Attendance,
   slots: Slots,
   customers: Customers,
-  month: string
+  month: string,
 ) =>
   wrapIter(Object.entries(attendance))
     // Get only current month's attendance
@@ -46,8 +46,8 @@ export const processAttendances = (
     .flatMap(([slotId, { date, attendances }]) =>
       // { customerId => attendanceIntervals } pairs
       Object.entries(attendances).map(
-        valueMapper(mergeMapper({ date, slotType: slots[slotId].type }))
-      )
+        valueMapper(mergeMapper({ date, slotType: slots[slotId].type })),
+      ),
     )
     // { customerId => attendanceDurations } pairs
     .map(valueMapper(convertIntervalsToDurations))
@@ -66,7 +66,7 @@ export const processAttendances = (
     .map(keyMapper(joinCustomerName));
 
 export const getMonthAttendanceVariance = (
-  state: LocalStore
+  state: LocalStore,
 ): AthleteAttendanceMonth[] => {
   const { app, firestore } = state;
   const { calendarDay } = app;
@@ -75,9 +75,12 @@ export const getMonthAttendanceVariance = (
   const currentMonth = getMonthStr(calendarDay, 0);
   const slots = Object.fromEntries(
     flatMap(
-      Object.values(slotsByDay ? slotsByDay[currentMonth] : {}),
-      (slots) => Object.entries(slots)
-    )
+      // `slotsByDay` is defaulted to `{}` above, so it is always truthy; the month
+      // entry itself can be missing (month not loaded yet, or no slots that month),
+      // in which case `Object.values(undefined)` would throw.
+      Object.values(slotsByDay[currentMonth] || {}),
+      (slots) => Object.entries(slots),
+    ),
   );
 
   return processAttendances(attendance, slots, customers, currentMonth);
@@ -94,12 +97,14 @@ export const filterAttendanceByMonth =
 
 export const replaceCustomerIdWithName =
   (customerLookup: Customers) =>
-  (id: string): CustomerNameTuple =>
-    [customerLookup[id].surname, customerLookup[id].name];
+  (id: string): CustomerNameTuple => [
+    customerLookup[id].surname,
+    customerLookup[id].name,
+  ];
 
 const compareCustomerNames = (
   [[a]]: [CustomerNameTuple, any],
-  [[b]]: [CustomerNameTuple, any]
+  [[b]]: [CustomerNameTuple, any],
 ) => (a > b ? 1 : -1);
 
 const joinCustomerName = (customer: CustomerNameTuple) => customer.join(" ");
@@ -126,7 +131,7 @@ const datePairFromAttendance = <A extends { date: string }>({
 
 const aggregateAttendance = (
   acc: AttendanceBySlotType,
-  { slotType, booked, attended }: AttendanceDurationsWithType
+  { slotType, booked, attended }: AttendanceDurationsWithType,
 ) => ({
   ...acc,
   [slotType]: {
@@ -136,7 +141,7 @@ const aggregateAttendance = (
 });
 
 const aggregateAttendanceEntries = (
-  attendances: Iterable<AttendanceDurationsWithType>
+  attendances: Iterable<AttendanceDurationsWithType>,
 ): AttendanceBySlotType =>
   _reduce(attendances, aggregateAttendance, {
     [SlotType.Ice]: { booked: 0, attended: 0 },
@@ -144,7 +149,7 @@ const aggregateAttendanceEntries = (
   });
 
 const aggregateAttendanceByDate = (
-  attendances: Iterable<DateAttendancePair<AttendanceDurationsWithType>>
+  attendances: Iterable<DateAttendancePair<AttendanceDurationsWithType>>,
 ): AttendanceByDate =>
   wrapIter(attendances)
     // Group each pair by date:

--- a/packages/client/src/store/selectors/attendance/slotAttendance.ts
+++ b/packages/client/src/store/selectors/attendance/slotAttendance.ts
@@ -20,7 +20,7 @@ import { getCustomerById } from "../customers";
  * @returns
  */
 export const getSlotsWithAttendance = (
-  state: LocalStore
+  state: LocalStore,
 ): Omit<AttendanceCardProps, "allCustomers">[] => {
   const slotsByDay = getSlotsByMonth(state);
   const {
@@ -56,9 +56,12 @@ export const getSlotsWithAttendance = (
     .map(({ id }) => id);
 
   return slotIds.map((slotId) => {
-    const slotsAttendance = attendance[slotId]?.attendances;
+    // A slot can be missing its `attendance/{slotId}` doc (trigger lag/miss, or
+    // initial load), in which case `attendances` is undefined and `Object.keys`
+    // would throw. Fall back to an empty record.
+    const slotsAttendance = attendance[slotId]?.attendances ?? {};
     const customers: AttendanceCardProps["customers"] = Object.keys(
-      slotsAttendance
+      slotsAttendance,
     )
       .map((customerId) => ({
         ...allCustomers[customerId],
@@ -113,7 +116,7 @@ export const getBookedIntervalsCustomers =
           ],
         };
       },
-      {}
+      {},
     );
     return customersWhoBooked;
   };

--- a/packages/client/src/store/selectors/bookings/__tests__/bookings.test.ts
+++ b/packages/client/src/store/selectors/bookings/__tests__/bookings.test.ts
@@ -192,9 +192,9 @@ describe("Selectors ->", () => {
             slotsByDay: { [currentMonthString]: slotsByDay },
           });
           expect(
-            getMonthEmptyForBooking(saul.secretKey)(store.getState())
+            getMonthEmptyForBooking(saul.secretKey)(store.getState()),
           ).toEqual(wantRes);
-        })
+        }),
       );
 
     runTableTests([
@@ -279,7 +279,7 @@ describe("Selectors ->", () => {
             interval: bookedIntervalKey,
             bookingNotes,
           },
-        })
+        }),
       );
       expect(getBookingsForCalendar(store.getState())).toEqual([
         {
@@ -289,6 +289,86 @@ describe("Selectors ->", () => {
           bookingNotes,
         },
       ]);
+    });
+
+    test("should skip bookings whose slot no longer exists on that day, without crashing (regression: #816 / ghost slots #966)", () => {
+      const monthStr = "2022-01";
+      const day = "2022-01-01";
+
+      // A real slot that still exists for the day
+      const liveSlot = {
+        ...baseSlot,
+        id: "live-slot",
+        categories: [Category.Competitive],
+        date: day,
+      };
+
+      const store = setupBookingsTest({
+        category: Category.Competitive,
+        date: DateTime.fromISO(day),
+        slotsByDay: {
+          [monthStr]: {
+            [day]: { [liveSlot.id]: liveSlot },
+          },
+        },
+      });
+
+      const intervalKey = Object.keys(baseSlot.intervals)[0];
+
+      // Two bookings: one for the live slot and one for a slot that has been
+      // deleted (its id is absent from slotsByDay even though the day exists).
+      // The dangling one used to crash on `bookedSlot.intervals[...]`.
+      store.dispatch(
+        updateLocalDocuments(BookingSubCollection.BookedSlots, {
+          [liveSlot.id]: { date: day, interval: intervalKey },
+          "deleted-slot": { date: day, interval: intervalKey },
+        }),
+      );
+
+      const res = getBookingsForCalendar(store.getState());
+      expect(res).toHaveLength(1);
+      expect(res[0].id).toEqual(liveSlot.id);
+    });
+
+    test("getBookedAndAttendedSlotsForCalendar should skip booked/attended slots whose slot no longer exists, without crashing", () => {
+      const monthStr = "2022-01";
+      const day = "2022-01-01";
+
+      const liveSlot = {
+        ...baseSlot,
+        id: "live-slot",
+        categories: [Category.Competitive],
+        date: day,
+      };
+
+      const store = setupBookingsTest({
+        category: Category.Competitive,
+        date: DateTime.fromISO(day),
+        slotsByDay: {
+          [monthStr]: {
+            [day]: { [liveSlot.id]: liveSlot },
+          },
+        },
+      });
+
+      const intervalKey = Object.keys(baseSlot.intervals)[0];
+
+      store.dispatch(
+        updateLocalDocuments(BookingSubCollection.BookedSlots, {
+          [liveSlot.id]: { date: day, interval: intervalKey },
+          "deleted-booked": { date: day, interval: intervalKey },
+        }),
+      );
+      store.dispatch(
+        updateLocalDocuments(BookingSubCollection.AttendedSlots, {
+          "deleted-attended": { date: day, interval: intervalKey },
+        }),
+      );
+
+      const ids = getBookedAndAttendedSlotsForCalendar(store.getState()).map(
+        ({ id }) => id,
+      );
+      expect(ids).toEqual([liveSlot.id]);
     });
 
     test("should sort the slots (by date, and by time intraday)", () => {
@@ -374,7 +454,7 @@ describe("Selectors ->", () => {
             // Regerdless of this not being the last interval, this slot should appear last as the date sorting takes precenence
             interval: "09:00-10:00",
           },
-        })
+        }),
       );
       // Second slot should be attended, not booked to verify that the final result sorts all results, regerdless of the booked state
       store.dispatch(
@@ -384,12 +464,12 @@ describe("Selectors ->", () => {
             // Second interval (we want this slot to appear 2nd - be merged with the booked slots, and then sorted)
             interval: "10:00-11:00",
           },
-        })
+        }),
       );
 
       // It's enough to just check that the ids appear in the desired order
       const ids = getBookedAndAttendedSlotsForCalendar(store.getState()).map(
-        ({ id }) => id
+        ({ id }) => id,
       );
       expect(ids).toEqual(["slot-1", "slot-2", "slot-3", "slot-4"]);
     });

--- a/packages/client/src/store/selectors/bookings/slots.ts
+++ b/packages/client/src/store/selectors/bookings/slots.ts
@@ -22,7 +22,7 @@ import { isEmpty } from "@/utils/helpers";
  * @returns record of subscribed slots
  */
 export const getBookedSlots = (
-  state: LocalStore
+  state: LocalStore,
 ): Record<string, CustomerBookingEntry> =>
   state.firestore.data?.bookedSlots || {};
 /**
@@ -31,7 +31,7 @@ export const getBookedSlots = (
  * @returns record of subscribed slots
  */
 export const getAttendedSlots = (
-  state: LocalStore
+  state: LocalStore,
 ): Record<string, Omit<CustomerBookingEntry, "bookingNotes">> =>
   state.firestore.data?.attendedSlots || {};
 
@@ -49,7 +49,7 @@ export const getSlotsForBooking =
 
     // Sort dates so that the final output is sorted
     const daysToRender = Object.keys(slotsMonth).sort((a, b) =>
-      a < b ? -1 : 1
+      a < b ? -1 : 1,
     );
     if (!daysToRender.length || !customerData) {
       return [];
@@ -68,7 +68,7 @@ export const getSlotsForBooking =
           // If slot booked add interval to the return structure
           bookedSlots[slot.id]
             ? { ...slot, interval: bookedSlots[slot.id].interval }
-            : slot
+            : slot,
         ),
     }));
   };
@@ -108,11 +108,11 @@ export const getSlotsForCustomer =
       .map(valueMapper((slots) => Object.entries(slots)))
       // FlatMap: [date, [slotId, SlotInterface][]] -> [date, slotId, SlotInterface]
       .flatMap(([date, slots]) =>
-        slots.map(([id, slot]) => [date, id, slot] as const)
+        slots.map(([id, slot]) => [date, id, slot] as const),
       )
       // Filter out slots not matching customer's category
       .filter(([, , slot]) =>
-        categories.some((c) => slot.categories.includes(c))
+        categories.some((c) => slot.categories.includes(c)),
       )
       // Filter out slots booked at full capacity (or without any capacity set)
       .filter(
@@ -124,12 +124,12 @@ export const getSlotsForCustomer =
           !bookingCountsForAMonth[slotId] ||
           !slot.capacity ||
           slot.capacity > bookingCountsForAMonth[slotId] ||
-          Boolean(bookedSlots[slotId])
+          Boolean(bookedSlots[slotId]),
       )
       // GroupEntries by date: [date, [slotId, SlotInterface][]]
       ._group(
         ([date, id, slot]) =>
-          [date, [id, slot]] as [string, [string, SlotInterface]]
+          [date, [id, slot]] as [string, [string, SlotInterface]],
       )
       // Map the value: [date, [slotId, SlotInterface][]] -> [date, SlotsById]
       .map(valueMapper((slots) => Object.fromEntries(slots)));
@@ -162,8 +162,11 @@ export const getBookingsForCalendar = (state: LocalStore): BookingsList => {
     .filter(([, { date }]) => Boolean(slotsForAMonth[date]))
     .reduce(
       (acc, [slotId, { date, interval: bookedInterval, bookingNotes }]) => {
-        // If this returns undefined, our slot isn't in date range
+        // The slot may no longer exist on that day (slot deleted, or its date/
+        // intervals changed after the athlete booked it). Skip dangling bookings
+        // instead of crashing on `bookedSlot.intervals`.
         const bookedSlot = slotsForAMonth[date][slotId];
+        if (!bookedSlot) return acc;
         const interval = bookedSlot.intervals[bookedInterval];
         return [
           ...acc,
@@ -175,7 +178,7 @@ export const getBookingsForCalendar = (state: LocalStore): BookingsList => {
           } as BookingsEntry,
         ];
       },
-      [] as BookingsList
+      [] as BookingsList,
     )
     .sort((a, b) => (a.date < b.date ? -1 : 1));
 };
@@ -190,7 +193,7 @@ type CalendarSlotEntry = SlotInterface & {
 type CalendarSlotList = CalendarSlotEntry[];
 
 export const getBookedAndAttendedSlotsForCalendar = (
-  state: LocalStore
+  state: LocalStore,
 ): CalendarSlotList => {
   // Current month in view is determined by `currentDate` in Redux store
   const monthString = getCalendarDay(state).toISO().substring(0, 7);
@@ -211,6 +214,8 @@ export const getBookedAndAttendedSlotsForCalendar = (
       }
 
       const attendedSlot = dayOfAttendedSlot[slotId];
+      // Skip if the slot no longer exists on that day (deleted/changed slot)
+      if (!attendedSlot) return acc;
       const interval = attendedSlot.intervals[attendedInterval];
       const completeAttendanceEntry = {
         ...attendedSlot,
@@ -219,7 +224,7 @@ export const getBookedAndAttendedSlotsForCalendar = (
       };
       return [...acc, completeAttendanceEntry];
     },
-    [] as CalendarSlotList
+    [] as CalendarSlotList,
   );
   const bookedSlotsObj = Object.entries(bookedSlots).reduce(
     (acc, [slotId, { date, interval: bookedInterval, bookingNotes }]) => {
@@ -230,6 +235,8 @@ export const getBookedAndAttendedSlotsForCalendar = (
       }
 
       const bookedSlot = dayOfBookedSlot[slotId];
+      // Skip if the slot no longer exists on that day (deleted/changed slot)
+      if (!bookedSlot) return acc;
       const interval = bookedSlot.intervals[bookedInterval];
       const completeBookingEntry = {
         ...bookedSlot,
@@ -239,7 +246,7 @@ export const getBookedAndAttendedSlotsForCalendar = (
       };
       return [...acc, completeBookingEntry];
     },
-    [] as CalendarSlotList
+    [] as CalendarSlotList,
   );
   return [...attendedSlotsObj, ...bookedSlotsObj].sort(compareCalendarSlots);
 };
@@ -248,7 +255,7 @@ const compareCalendarSlots = (a: CalendarSlotEntry, b: CalendarSlotEntry) =>
   a.date < b.date
     ? -1
     : a.date > b.date
-    ? 1
-    : a.interval.startTime < b.interval.startTime
-    ? -1
-    : 1;
+      ? 1
+      : a.interval.startTime < b.interval.startTime
+        ? -1
+        : 1;

--- a/packages/shared/src/utils/__tests__/sort.test.ts
+++ b/packages/shared/src/utils/__tests__/sort.test.ts
@@ -17,7 +17,7 @@ interface ComparePeriodsTest {
 
 const comparePeriodsTableTests = (
   compareFn: (x: string, y: string) => number,
-  tests: ComparePeriodsTest[]
+  tests: ComparePeriodsTest[],
 ) => {
   tests.forEach(({ name, input, want }) => {
     test(name, () => {
@@ -47,7 +47,7 @@ interface CompareCustomerBookingsTest {
 }
 
 const compareCustomerBookingsTableTests = (
-  tests: CompareCustomerBookingsTest[]
+  tests: CompareCustomerBookingsTest[],
 ) => {
   tests.forEach(({ name, input, want }) => {
     test(name, () => {
@@ -152,6 +152,20 @@ describe("Sort utils tests", () => {
         ],
       },
     ]);
+
+    test("should not crash on entries with a missing name/surname (regression: deleted/not-yet-loaded customer)", () => {
+      // An attendance doc referencing a deleted customer yields an entry with no
+      // name/surname; this used to throw on `surname.toLowerCase()`.
+      const input = [
+        { name: "Bfoo", surname: "Bbar" },
+        {} as Pick<Customer, "name" | "surname">,
+        { name: "Afoo", surname: "Abar" },
+      ];
+      expect(() => [...input].sort(compareCustomerNames)).not.toThrow();
+      const sorted = [...input].sort(compareCustomerNames);
+      // The undefined-surname entry sorts first (treated as empty string)
+      expect(sorted.map((x) => x.surname)).toEqual([undefined, "Abar", "Bbar"]);
+    });
   });
 
   compareCustomerBookingsTableTests([

--- a/packages/shared/src/utils/sort.ts
+++ b/packages/shared/src/utils/sort.ts
@@ -23,7 +23,7 @@ export function composeCompare<T>(
 
 export function asc<C extends string | number>(): (a: C, b: C) => number;
 export function asc<C extends string | number, T>(
-  transform: (x: T) => C
+  transform: (x: T) => C,
 ): (a: T, b: T) => number;
 /** */
 export function asc<C extends string | number, T>(transform?: (x: T) => C) {
@@ -38,7 +38,7 @@ export function asc<C extends string | number, T>(transform?: (x: T) => C) {
 
 export function desc<C extends string | number>(): (a: C, b: C) => number;
 export function desc<C extends string | number, T>(
-  transform: (x: T) => C
+  transform: (x: T) => C,
 ): (a: T, b: T) => number;
 /** */
 export function desc<C extends string | number, T>(transform?: (x: T) => C) {
@@ -92,7 +92,7 @@ export const comparePeriodsEarliestFirst = composeCompare<
   // Compare (asc) by start time first
   asc(getStartTime),
   // If start times are equal, compare (desc) by end time - longer periods take precedence
-  desc(getIntervalDuration)
+  desc(getIntervalDuration),
 );
 
 /**
@@ -106,7 +106,7 @@ export const comparePeriodsLongestFirst = composeCompare<string | SlotInterval>(
   // If start times are equal, compare (desc) by end time - longer periods take precedence
   desc(getIntervalDuration),
   // Compare (asc) by start time first
-  asc(getStartTime)
+  asc(getStartTime),
 );
 
 /**
@@ -119,8 +119,11 @@ export const comparePeriodsLongestFirst = composeCompare<string | SlotInterval>(
 export const compareCustomerNames = composeCompare<
   Pick<Customer, "name" | "surname">
 >(
-  asc((x) => x.surname.toLowerCase()),
-  asc((x) => x.name.toLowerCase())
+  // Guard against entries with a missing name/surname (e.g. an attendance doc
+  // referencing a customer that was deleted/not yet loaded), which would
+  // otherwise throw on `.toLowerCase()`.
+  asc((x) => (x.surname || "").toLowerCase()),
+  asc((x) => (x.name || "").toLowerCase()),
 );
 
 /**
@@ -137,5 +140,5 @@ export const compareCustomerBookings = composeCompare<
 >(
   (a, b) =>
     comparePeriodsEarliestFirst(a.bookedInterval || "", b.bookedInterval || ""),
-  compareCustomerNames
+  compareCustomerNames,
 );

--- a/packages/ui/src/utils/__tests__/helpers.test.ts
+++ b/packages/ui/src/utils/__tests__/helpers.test.ts
@@ -47,5 +47,22 @@ describe("Test helpers", () => {
         "de P. J. N. M. de los R. C. de la S. T. R. y Picasso",
       ]);
     });
+
+    test("should not crash on missing name/surname (regression: dirty customer data crashing the avatar menu)", () => {
+      expect(() =>
+        shortName(
+          undefined as unknown as string,
+          undefined as unknown as string,
+        ),
+      ).not.toThrow();
+      expect(shortName(undefined as unknown as string, "Doe")).toEqual([
+        "",
+        "Doe",
+      ]);
+      expect(shortName("John", undefined as unknown as string)).toEqual([
+        "John",
+        "",
+      ]);
+    });
   });
 });

--- a/packages/ui/src/utils/helpers.ts
+++ b/packages/ui/src/utils/helpers.ts
@@ -1,6 +1,8 @@
-export const shortName = (name: string, surname: string) => {
-  const nameWords = name.trim().split(" ");
-  const surnameWords = surname.trim().split(" ");
+export const shortName = (name = "", surname = "") => {
+  // Guard against customers with a missing name/surname (e.g. dirty/legacy data)
+  // so the avatar menu doesn't crash on `.trim()` of undefined.
+  const nameWords = (name || "").trim().split(" ");
+  const surnameWords = (surname || "").trim().split(" ");
 
   const n = nameWords
     .map((word, i) => (i === 0 ? word : `${word[0]}.`))
@@ -11,8 +13,8 @@ export const shortName = (name: string, surname: string) => {
       i === o.length - 1
         ? word
         : surnameParticles.includes(word.toLowerCase())
-        ? word
-        : `${word[0]}.`
+          ? word
+          : `${word[0]}.`,
     )
     .join(" ");
 


### PR DESCRIPTION
## What

Defensive guards for a cluster of **render-phase crashes** in client selectors and a UI helper, all caused by partial or dirty Firestore data reaching the UI. These are among the most frequent client errors in production (Sentry `eisbuk-client`).

## Fixes

| Crash | Site | Fix |
|---|---|---|
| `bookedSlot.intervals[...]` on a deleted/changed slot crashes the athlete **Calendar** | `client/.../bookings/slots.ts` — `getBookingsForCalendar`, `getBookedAndAttendedSlotsForCalendar` | skip dangling booked/attended entries |
| `Object.keys(undefined)` when a slot has no attendance doc crashes the admin **Attendance · by day** | `client/.../attendance/slotAttendance.ts` | `attendance[slotId]?.attendances ?? {}` |
| `Object.values(undefined)` when the month has no `slotsByDay` entry crashes the admin **Attendance · by month** | `client/.../attendance/attendanceVariance.ts` | `slotsByDay[currentMonth] \|\| {}` |
| `surname.toLowerCase()` on a deleted/not-loaded customer crashes attendance sorting | `shared/.../utils/sort.ts` — `compareCustomerNames` | `(x.surname \|\| "")` / `(x.name \|\| "")` |
| `name.trim()` of an undefined name/surname crashes the avatar menu | `ui/.../utils/helpers.ts` — `shortName` | default params to `""` |

## Issues

Addresses #832 and bug1 of #816; also fixes the avatar/sort crashes. Related to the ghost-slot data condition in #966 (this PR makes the client resilient to it; the trigger fix is separate).

## Tests

Added regression tests for every case (client bookings + attendance selectors, shared `sort`, ui `shortName`). All green:

```
shared sort:        15 passed
ui helpers:          6 passed
client selectors:   17 passed (bookings + attendance)
```

These are pure selector/unit tests (no emulator needed). No behaviour change for valid data — only previously-crashing inputs are now skipped/handled.
