### PR TITLE
fix: don't hang the app when queryAuthStatus fails on load (#960)

### DIFF
--- a/packages/client/src/store/actions/__tests__/authOperations.test.ts
+++ b/packages/client/src/store/actions/__tests__/authOperations.test.ts
@@ -75,6 +75,31 @@ describe("Auth operations", () => {
       });
     });
 
+    test("should not hang the app if the auth-status callable rejects (regression: #960 / unhandled rejection)", async () => {
+      const { dispatch, getState } = getNewStore();
+      const testThunk = updateAuthUser(testUser);
+
+      // Simulate the callable failing (network blip / cold-start timeout / 5xx)
+      mockQueryAuthStatus.mockRejectedValueOnce(
+        new Error("internal: callable failed"),
+      );
+
+      // The thunk must resolve (not reject) ...
+      await expect(
+        runThunk(testThunk, dispatch, getState),
+      ).resolves.not.toThrow();
+
+      // ... and the auth state must be marked loaded so the UI stops hanging,
+      // with the user authenticated but not (wrongly) granted admin/secret access.
+      expect(getState().auth).toEqual({
+        isAdmin: false,
+        secretKeys: [],
+        isEmpty: false,
+        isLoaded: true,
+        userData: testUser,
+      });
+    });
+
     test("should reset the state (perform local logout) if no user is received", async () => {
       // set up tests with authenticated admin
       const { dispatch, getState } = getNewStore();

--- a/packages/client/src/store/actions/authOperations.ts
+++ b/packages/client/src/store/actions/authOperations.ts
@@ -31,14 +31,14 @@ export const signOut = (): FirestoreThunk => async (dispatch) => {
       enqueueNotification({
         message: i18n.t(NotificationMessage.LogoutSuccess),
         variant: NotifVariant.Success,
-      })
+      }),
     );
   } catch (err) {
     dispatch(
       enqueueNotification({
         message: i18n.t(NotificationMessage.LogoutError),
         variant: NotifVariant.Error,
-      })
+      }),
     );
   }
 };
@@ -50,7 +50,7 @@ export const signOut = (): FirestoreThunk => async (dispatch) => {
  */
 export const checkAuthStatus = async (
   functions: Functions,
-  authString: string
+  authString: string,
 ): Promise<AuthStatus> => {
   const organization = getOrganization();
 
@@ -64,7 +64,7 @@ export const checkAuthStatus = async (
     CloudFunction.QueryAuthStatus,
     {
       organization,
-    }
+    },
   )();
 
   return res.data;
@@ -88,18 +88,46 @@ export const updateAuthUser =
 
     const { email, phoneNumber } = user;
 
-    const authStatus = await checkAuthStatus(
-      getFunctions(),
-      email || phoneNumber || ""
-    );
+    try {
+      const authStatus = await checkAuthStatus(
+        getFunctions(),
+        email || phoneNumber || "",
+      );
 
-    dispatch({
-      type: Action.UpdateAuthInfo,
-      payload: {
-        ...authStatus,
-        userData: user,
-        isEmpty: false,
-        isLoaded: true,
-      },
-    } as AuthReducerAction<Action.UpdateAuthInfo>);
+      dispatch({
+        type: Action.UpdateAuthInfo,
+        payload: {
+          ...authStatus,
+          userData: user,
+          isEmpty: false,
+          isLoaded: true,
+        },
+      } as AuthReducerAction<Action.UpdateAuthInfo>);
+    } catch (err) {
+      // The `queryAuthStatus` callable can fail (flaky mobile network, Gen-1
+      // cold-start `deadline-exceeded`, or a backend error). Previously this
+      // rejected unhandled and, crucially, never dispatched `UpdateAuthInfo`, so
+      // the store stayed `isLoaded: false` and the app hung on the loading/login
+      // screen until a manual refresh. Instead, surface the error and mark auth as
+      // loaded (authenticated, but admin/secretKeys unknown) so the UI renders and
+      // the user can retry; the next auth-state change re-runs this check.
+      dispatch(
+        enqueueNotification({
+          message: i18n.t(NotificationMessage.Error),
+          variant: NotifVariant.Error,
+          error: err as Error,
+        }),
+      );
+
+      dispatch({
+        type: Action.UpdateAuthInfo,
+        payload: {
+          isAdmin: false,
+          secretKeys: [],
+          userData: user,
+          isEmpty: false,
+          isLoaded: true,
+        },
+      } as AuthReducerAction<Action.UpdateAuthInfo>);
+    }
   };


### PR DESCRIPTION
## What

Makes the auth bootstrap resilient so a failed `queryAuthStatus` call no longer leaves the app **hung on the loading/login screen**.

## Problem

`onAuthStateChanged` → `updateAuthUser` → `checkAuthStatus` → `queryAuthStatus` (callable) had **no error handling**:

- `packages/client/src/store/actions/authOperations.ts` — `await checkAuthStatus(...)` uncaught
- `packages/client/src/react-redux-firebase-auth/hooks/useConnectAuthToStore.ts:42` — dispatched with no `.catch`

When the callable fails (flaky mobile network, Gen-1 cold-start `deadline-exceeded`, or a real backend error — e.g. #944, where Sentry being down made `queryAuthStatus` itself 5xx), the promise rejected unhandled and `Action.UpdateAuthInfo` was **never dispatched**, so the store stayed `isLoaded: false` and the UI sat on the loading screen until a manual refresh.

This is the single most frequent client error in production Sentry (hundreds of events, still active, heavily iOS) and is a likely cause of #960.

## Fix

Wrap the call in `try/catch`. On failure:
1. surface an error notification, and
2. dispatch a **loaded** auth state (`isLoaded: true`, user authenticated, but `isAdmin: false` / `secretKeys: []` since status is unknown) so the UI renders and the next auth-state change retries.

No behaviour change on the success path.

## Tests

Added a regression test asserting the thunk **resolves** (no unhandled rejection) and the auth state is marked loaded when the callable rejects. Full `authOperations` suite passes (3/3).

Refs #960, #944.
