### PR TITLE
fix: make GatewayAPI SMS status callbacks actually work (#968)

### DIFF
--- a/packages/client/src/__tests__/updateSMSStatus.test.ts
+++ b/packages/client/src/__tests__/updateSMSStatus.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment node
+ */
+
+import { v4 as uuid } from "uuid";
+import { describe, expect } from "vitest";
+
+import { Collection, DeliveryQueue } from "@eisbuk/shared";
+
+import { adminDb } from "@/__testSetup__/firestoreSetup";
+import { testWithEmulator } from "@/__testUtils__/envUtils";
+
+/**
+ * URL of the `updateSMSStatus` https endpoint in the functions emulator,
+ * the same way GatewayAPI would call it (id/organization as query params).
+ */
+const getUpdateSMSStatusUrl = (params?: { id: string; organization: string }) =>
+  `http://127.0.0.1:5002/eisbuk/europe-west6/updateSMSStatus${
+    params
+      ? `?id=${encodeURIComponent(params.id)}&organization=${encodeURIComponent(
+          params.organization,
+        )}`
+      : ""
+  }`;
+
+const getSMSProcessDocPath = (organization: string, id: string) =>
+  [Collection.DeliveryQueues, organization, DeliveryQueue.SMSQueue, id].join(
+    "/",
+  );
+
+describe("updateSMSStatus", () => {
+  testWithEmulator(
+    "should store the delivery status (sent as query params + body, like GatewayAPI does) to the SMS process document",
+    async () => {
+      const organization = uuid();
+      const id = uuid();
+
+      // Set up an SMS process document (as if an SMS had been sent out)
+      const processDocRef = adminDb.doc(getSMSProcessDocPath(organization, id));
+      await processDocRef.set({ payload: { to: "+385991111111" } });
+
+      const res = await fetch(getUpdateSMSStatusUrl({ id, organization }), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "DELIVERED" }),
+      });
+      expect(res.status).toEqual(200);
+
+      const processDoc = await processDocRef.get();
+      expect(processDoc.data()?.delivery?.meta?.status).toEqual("DELIVERED");
+    },
+  );
+
+  testWithEmulator(
+    "should respond 400 (and not write anything) when id/organization query params are missing",
+    async () => {
+      const res = await fetch(getUpdateSMSStatusUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "DELIVERED" }),
+      });
+      expect(res.status).toEqual(400);
+
+      // Regression: the handler used to fall through after the 400 and write
+      // a junk document to 'deliveryQueues/undefined/SMSQueue/undefined'
+      const junkDoc = await adminDb
+        .doc(getSMSProcessDocPath("undefined", "undefined"))
+        .get();
+      expect(junkDoc.exists).toEqual(false);
+    },
+  );
+
+  testWithEmulator(
+    "should respond 400 when no status is received in the request body",
+    async () => {
+      const organization = uuid();
+      const id = uuid();
+
+      const res = await fetch(getUpdateSMSStatusUrl({ id, organization }), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toEqual(400);
+
+      const processDoc = await adminDb
+        .doc(getSMSProcessDocPath(organization, id))
+        .get();
+      expect(processDoc.exists).toEqual(false);
+    },
+  );
+});

--- a/packages/functions/src/sendSMS/deliver.ts
+++ b/packages/functions/src/sendSMS/deliver.ts
@@ -41,12 +41,15 @@ export const deliverSMS = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.DeliveryQueues}/{organization}/${DeliveryQueue.SMSQueue}/{sms}`
+    `${Collection.DeliveryQueues}/{organization}/${DeliveryQueue.SMSQueue}/{sms}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler("deliverSMS", (change, { params }) =>
       processDelivery(change, async ({ success, error }) => {
-        const { organization } = params as { organization: string };
+        const { organization, sms: smsId } = params as {
+          organization: string;
+          sms: string;
+        };
 
         // Get current SMS payload
         const {
@@ -74,7 +77,7 @@ export const deliverSMS = functions
         const { proto, ...options } = createSMSReqOptions(
           "POST",
           __smsUrl__,
-          authToken
+          authToken,
         );
 
         // Construct and validate SMS data
@@ -82,7 +85,7 @@ export const deliverSMS = functions
           message,
           sender: smsFrom,
           recipients: [{ msisdn: to }],
-          callback_url: getSMSCallbackUrl(),
+          callback_url: getSMSCallbackUrl(organization, smsId),
         });
         if (errs) {
           return error(errs);
@@ -106,6 +109,6 @@ export const deliverSMS = functions
             "Error occurred while trying to send SMS, check the function logs for more info.",
           ]);
         }
-      })
-    )
+      }),
+    ),
   );

--- a/packages/functions/src/sendSMS/https.ts
+++ b/packages/functions/src/sendSMS/https.ts
@@ -33,7 +33,7 @@ export const sendSMS = functions
         ClientMessageMethod.SMS,
         Exclude<ClientMessageType, ClientMessageType.SendCalendarFile>
       >,
-      { auth }
+      { auth },
     ) => {
       const { organization } = payload;
 
@@ -68,7 +68,7 @@ export const sendSMS = functions
       const deliveryDoc = admin
         .firestore()
         .collection(
-          `${Collection.DeliveryQueues}/${organization}/${DeliveryQueue.SMSQueue}`
+          `${Collection.DeliveryQueues}/${organization}/${DeliveryQueue.SMSQueue}`,
         )
         .doc();
       await deliveryDoc.set({ payload: smsPayload });
@@ -79,7 +79,7 @@ export const sendSMS = functions
         success: true,
         deliveryDocumentPath: deliveryDoc.path,
       };
-    }
+    },
   );
 
 /**
@@ -92,21 +92,28 @@ export const updateSMSStatus = functions
   .region(__functionsZone__)
   .https.onRequest(async (req, res) => {
     functions.logger.log(
-      "Received a SMS delivery status update from GatewayAPI, processing..."
+      "Received a SMS delivery status update from GatewayAPI, processing...",
     );
 
     // This id is the id of the firestore document for a process delivery
-    // rather than the GatewayAPI assigned SMS id
-    const params = (req.params as { id: string; organization: string }) || {};
-    const { id, organization } = params;
+    // rather than the GatewayAPI assigned SMS id.
+    // The values are sent as query string params (see `getSMSCallbackUrl`),
+    // so they're found on `req.query` (`req.params` only carries route params,
+    // which this endpoint doesn't have).
+    const { id, organization } =
+      (req.query as {
+        id?: string;
+        organization?: string;
+      }) || {};
     if (!id || !organization) {
       functions.logger.log("GatewayAPI request missing query params", {
-        params,
+        query: req.query,
       });
       // This is an error on GatewayAPI side
       // Return 'Bad Request' so that the request is retried
       res.writeHead(400);
       res.end();
+      return;
     }
 
     const { status } = (req.body as SMSStatusPayload) || {};
@@ -115,19 +122,20 @@ export const updateSMSStatus = functions
       functions.logger.log("No status received with GatewayAPI update");
       res.writeHead(400);
       res.end();
+      return;
     }
 
     // Store the status in the appropriate process document
     await admin
       .firestore()
       .doc(
-        `${Collection.DeliveryQueues}/${organization}/${DeliveryQueue.SMSQueue}/${id}`
+        `${Collection.DeliveryQueues}/${organization}/${DeliveryQueue.SMSQueue}/${id}`,
       )
       .set(
         { delivery: { meta: { status } } },
         {
           merge: true,
-        }
+        },
       );
 
     res.writeHead(200);

--- a/packages/functions/src/sendSMS/utils.ts
+++ b/packages/functions/src/sendSMS/utils.ts
@@ -23,7 +23,7 @@ import {
  * Validate client email payload accepts an email payload and applies the correct validation for an email type.
  */
 export const validateSMSPayload = <T extends SMSMessageType>(
-  payload: ClientMessagePayload<ClientMessageMethod.SMS, T>
+  payload: ClientMessagePayload<ClientMessageMethod.SMS, T>,
 ) => {
   // Check that the type has been provided and is a supported email type
   if (
@@ -50,7 +50,7 @@ export const validateSMSPayload = <T extends SMSMessageType>(
   const [res, errors] = validateJSON(
     validationSchemaLookup[payload.type] as ValidationSchemaLookup[T],
     payload,
-    "Constructing the email gave following errors (check the email payload and organization preferences):"
+    "Constructing the email gave following errors (check the email payload and organization preferences):",
   );
 
   if (errors !== null) {
@@ -70,7 +70,7 @@ export const validateSMSPayload = <T extends SMSMessageType>(
 export const createSMSReqOptions = (
   method: "GET" | "POST",
   url: string,
-  token: string
+  token: string,
 ): http.RequestOptions & { proto: "http" | "https" } => {
   let proto: "http" | "https" = "https";
   let hostname = "";
@@ -110,7 +110,14 @@ export const createSMSReqOptions = (
 };
 
 /**
- * Creates an URL of and endpoint for `updateSMSSStatus` for GatewayAPI status update.
+ * Creates an URL of and endpoint for `updateSMSStatus` for GatewayAPI status update.
+ * The `id` (SMS process document id) and `organization` are sent as query params,
+ * read back by `updateSMSStatus` to locate the process document to update.
  */
-export const getSMSCallbackUrl = (): string =>
-  `https://${__functionsZone__}-${__projectId__}.cloudfunctions.net/sendSMS`;
+export const getSMSCallbackUrl = (
+  organization: string,
+  smsId: string,
+): string =>
+  `https://${__functionsZone__}-${__projectId__}.cloudfunctions.net/updateSMSStatus?id=${encodeURIComponent(
+    smsId,
+  )}&organization=${encodeURIComponent(organization)}`;


### PR DESCRIPTION
## What

Makes GatewayAPI SMS delivery-status callbacks actually work. Three bugs (the first discovered while fixing the other two) meant statuses were **never** recorded:

1. **Wrong callback target**: `getSMSCallbackUrl()` (`packages/functions/src/sendSMS/utils.ts`) pointed GatewayAPI's callback at the **`sendSMS` callable** instead of the `updateSMSStatus` endpoint — and passed no `id`/`organization` at all.
2. **`req.params` instead of `req.query`**: `updateSMSStatus` read `req.params`, which is always `{}` for this endpoint, so `id`/`organization` were always `undefined`.
3. **Missing `return` after the 400s**: the handler fell through after `res.end()` and attempted a Firestore write to `deliveryQueues/undefined/SMSQueue/undefined`.

## Fix

- `getSMSCallbackUrl(organization, smsId)` now targets `updateSMSStatus` with both values as URL-encoded query params; `deliverSMS` passes the process-doc id from the trigger params.
- `updateSMSStatus` reads `req.query` and returns early from both validation branches.

## Tests

New emulator test (`packages/client/src/__tests__/updateSMSStatus.test.ts`) exercising the deployed function over HTTP exactly like GatewayAPI does:

- status callback with query params + JSON body → 200, status stored at `delivery.meta.status` on the right process doc ✅
- missing query params → 400 and **no junk write** to `deliveryQueues/undefined/...` ✅
- missing body status → 400, no write ✅

```
Tests  3 passed (3)
```

Fixes #968. Related context: #967 (delivery-pipeline visibility), #912.
