### PR TITLE
fix: prevent ghost slots from out-of-order slot trigger events (#966)

### DIFF
--- a/packages/client/src/__tests__/dataTriggers.test.ts
+++ b/packages/client/src/__tests__/dataTriggers.test.ts
@@ -127,8 +127,8 @@ describe("Cloud functions -> Data triggers ->", () => {
                   getBookedSlotDocPath(
                     organization,
                     saul.secretKey,
-                    baseSlot.id
-                  )
+                    baseSlot.id,
+                  ),
                 )
                 .set(initialBooking);
 
@@ -144,7 +144,7 @@ describe("Cloud functions -> Data triggers ->", () => {
 
             // update (or delete) the booked slot
             const bookedSlotRef = adminDb.doc(
-              getBookedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getBookedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             );
             if (update) {
               await bookedSlotRef.set(update);
@@ -165,7 +165,7 @@ describe("Cloud functions -> Data triggers ->", () => {
               expect(snap.data()).toEqual(wantAttendanceFinal);
             });
           });
-        }
+        },
       );
     };
 
@@ -341,10 +341,10 @@ describe("Cloud functions -> Data triggers ->", () => {
       // Wait for the data triggers to run
       await Promise.all([
         waitFor(async () =>
-          expect((await saulBookings.get()).exists).toEqual(true)
+          expect((await saulBookings.get()).exists).toEqual(true),
         ),
         waitFor(async () =>
-          expect((await gusBookings.get()).exists).toEqual(true)
+          expect((await gusBookings.get()).exists).toEqual(true),
         ),
       ]);
 
@@ -467,9 +467,10 @@ describe("Cloud functions -> Data triggers ->", () => {
         await adminDb
           .doc(getSlotDocPath(organization, baseSlot.id))
           .set(baseSlot);
-        const newSlotRef = adminDb.doc(
-          getSlotDocPath(organization, baseSlot.id)
-        );
+        // (this used to - mistakenly - point to baseSlot's doc, which only
+        // passed because the old aggregation left stale entries behind on
+        // date change)
+        const newSlotRef = adminDb.doc(getSlotDocPath(organization, newSlotId));
         await newSlotRef.set(newSlot);
         await waitFor(async () => {
           const snap = await adminDb
@@ -477,7 +478,11 @@ describe("Cloud functions -> Data triggers ->", () => {
             .get();
           // wait until both slots are aggregated
           const data = snap.data()!;
-          expect(Boolean(data[testDate] && data[dayAfter])).toEqual(true);
+          expect(
+            Boolean(
+              data[testDate]?.[baseSlot.id] && data[dayAfter]?.[newSlotId],
+            ),
+          ).toEqual(true);
         });
         // test removing of the additional slot
         await newSlotRef.delete();
@@ -486,9 +491,81 @@ describe("Cloud functions -> Data triggers ->", () => {
             .doc(getSlotsByDayDocPath(organization, testMonth))
             .get();
           expect(snap.exists).toEqual(true);
-          expect(Boolean(snap.data()![testDate][newSlotId])).toEqual(false);
+          const data = snap.data()!;
+          // the deleted slot is removed from the aggregate...
+          expect(data[dayAfter]?.[newSlotId]).toBeUndefined();
+          // ...while the other slot is untouched
+          expect(Boolean(data[testDate]?.[baseSlot.id])).toEqual(true);
         });
-      }
+      },
+    );
+
+    testWithEmulator(
+      "should not leave a ghost slot (in slotsByDay or attendance) when a slot is created and deleted in quick succession (regression: #966)",
+      async () => {
+        const { organization } = await setUpOrganization();
+        const slotRef = adminDb.doc(getSlotDocPath(organization, baseSlot.id));
+
+        // Create and delete the slot back-to-back, without waiting for the
+        // create-event triggers to process. With unordered/at-least-once
+        // trigger delivery this used to resurrect the slot in 'slotsByDay'
+        // (and its 'attendance' doc) with no way for the admin to remove it.
+        await slotRef.set(baseSlot);
+        await slotRef.delete();
+
+        // Give both events' triggers time to fully process
+        await new Promise((resolve) => setTimeout(resolve, 4000));
+
+        const aggSnap = await adminDb
+          .doc(getSlotsByDayDocPath(organization, testMonth))
+          .get();
+        expect(aggSnap.data()?.[testDate]?.[baseSlot.id]).toBeUndefined();
+
+        const attendanceSnap = await adminDb
+          .doc(getAttendanceDocPath(organization, baseSlot.id))
+          .get();
+        expect(attendanceSnap.exists).toEqual(false);
+      },
+      { timeout: 15000 },
+    );
+
+    testWithEmulator(
+      "should move (not duplicate) the slotsByDay entry when a slot's date is edited",
+      async () => {
+        const { organization } = await setUpOrganization();
+        const slotRef = adminDb.doc(getSlotDocPath(organization, baseSlot.id));
+        await slotRef.set(baseSlot);
+
+        // wait for the initial aggregate entry
+        await waitFor(async () => {
+          const snap = await adminDb
+            .doc(getSlotsByDayDocPath(organization, testMonth))
+            .get();
+          expect(Boolean(snap.data()?.[testDate]?.[baseSlot.id])).toEqual(true);
+        });
+
+        // move the slot to a date in the next month
+        const movedDateLuxon = testDateLuxon.plus({ months: 1 });
+        const movedDate = luxon2ISODate(movedDateLuxon);
+        const movedMonth = movedDate.substring(0, 7);
+        const movedSlot = { ...baseSlot, date: movedDate };
+        await slotRef.set(movedSlot);
+
+        // the entry should appear under the new month...
+        await waitFor(async () => {
+          const snap = await adminDb
+            .doc(getSlotsByDayDocPath(organization, movedMonth))
+            .get();
+          expect(snap.data()?.[movedDate]?.[baseSlot.id]).toEqual(movedSlot);
+        });
+        // ...and disappear from the old one (previously it was left behind)
+        await waitFor(async () => {
+          const snap = await adminDb
+            .doc(getSlotsByDayDocPath(organization, testMonth))
+            .get();
+          expect(snap.data()?.[testDate]?.[baseSlot.id]).toBeUndefined();
+        });
+      },
     );
   });
 
@@ -513,7 +590,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         // we're manually deleting attendance to test that it won't get created on slot update
         // the attendance entry for slot shouldn't be edited manually in production
         const attendanceDocRef = adminDb.doc(
-          getAttendanceDocPath(organization, baseSlot.id)
+          getAttendanceDocPath(organization, baseSlot.id),
         );
         await attendanceDocRef.delete();
         // wait for attendance entry to be deleted
@@ -526,7 +603,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         // check the no new entry for slot attendance was created (on update)
         const slotAttendance = await attendanceDocRef.get();
         expect(slotAttendance.exists).toEqual(false);
-      }
+      },
     );
 
     testWithEmulator(
@@ -551,7 +628,7 @@ describe("Cloud functions -> Data triggers ->", () => {
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
 
     testWithEmulator(
@@ -576,7 +653,7 @@ describe("Cloud functions -> Data triggers ->", () => {
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -615,7 +692,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(organizationPath).get();
           expect(snap.data()!.existingSecrets).toEqual(["anotherSecret"]);
         });
-      }
+      },
     );
 
     testWithEmulator(
@@ -639,7 +716,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(organizationPath).get();
           const data = snap.data() as OrganizationData;
           expect(data.existingSecrets).toEqual(
-            expect.arrayContaining(["smtpHost"])
+            expect.arrayContaining(["smtpHost"]),
           );
           expect(data.smtpConfigured).toBeFalsy();
         });
@@ -658,8 +735,8 @@ describe("Cloud functions -> Data triggers ->", () => {
           const data = snap.data() as OrganizationData;
           expect(
             Object.keys(secrets).every((key) =>
-              data.existingSecrets!.includes(key)
-            )
+              data.existingSecrets!.includes(key),
+            ),
           ).toEqual(true);
           expect(data.smtpConfigured).toEqual(true);
         });
@@ -675,7 +752,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(organizationPath).get();
           expect(snap.data()!.smtpConfigured).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -736,7 +813,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(publicOrgPath).get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -782,7 +859,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         await waitFor(async () => {
           const snap = await adminDb
             .doc(
-              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             )
             .get();
           expect(snap.data()).toEqual({
@@ -805,7 +882,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         await waitFor(async () => {
           const attendedSlotDoc = await adminDb
             .doc(
-              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             )
             .get();
           expect(attendedSlotDoc.data()).toEqual({
@@ -823,12 +900,12 @@ describe("Cloud functions -> Data triggers ->", () => {
         await waitFor(async () => {
           const snap = await adminDb
             .doc(
-              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             )
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
 
     testWithEmulator(
@@ -876,7 +953,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           waitFor(async () => {
             const snap = await adminDb
               .doc(
-                getBookingsDocPath(organization, controlledCustomer.secretKey)
+                getBookingsDocPath(organization, controlledCustomer.secretKey),
               )
               .get();
             expect(snap.exists).toEqual(true);
@@ -889,8 +966,8 @@ describe("Cloud functions -> Data triggers ->", () => {
             getBookedSlotDocPath(
               organization,
               testCustomer.secretKey,
-              baseSlot.id
-            )
+              baseSlot.id,
+            ),
           )
           .set({
             date: baseSlot.date,
@@ -935,8 +1012,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getAttendedSlotDocPath(
                 organization,
                 controlledCustomer.secretKey,
-                baseSlot.id
-              )
+                baseSlot.id,
+              ),
             )
             .get();
           expect(snap.exists).toEqual(true);
@@ -949,13 +1026,13 @@ describe("Cloud functions -> Data triggers ->", () => {
               getAttendedSlotDocPath(
                 organization,
                 testCustomer.secretKey,
-                baseSlot.id
-              )
+                baseSlot.id,
+              ),
             )
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
   });
   describe("createCustomerStats", () => {
@@ -1028,8 +1105,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotThisMonthIce.date}-9`
-              )
+                `${bookedSlotThisMonthIce.date}-9`,
+              ),
             )
             .set(bookedSlotThisMonthIce),
           await adminDb
@@ -1037,8 +1114,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotNextMonthIce.date}-9`
-              )
+                `${bookedSlotNextMonthIce.date}-9`,
+              ),
             )
             .set(bookedSlotNextMonthIce),
           await adminDb
@@ -1046,8 +1123,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotThisMonthOffIce.date}-10`
-              )
+                `${bookedSlotThisMonthOffIce.date}-10`,
+              ),
             )
             .set(bookedSlotThisMonthOffIce),
           await adminDb
@@ -1055,8 +1132,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotNextMonthOffIce.date}-10`
-              )
+                `${bookedSlotNextMonthOffIce.date}-10`,
+              ),
             )
             .set(bookedSlotNextMonthOffIce),
         ]);
@@ -1090,8 +1167,8 @@ describe("Cloud functions -> Data triggers ->", () => {
             getBookedSlotDocPath(
               organization,
               saul.secretKey,
-              `${bookedSlotThisMonthIce.date}-9`
-            )
+              `${bookedSlotThisMonthIce.date}-9`,
+            ),
           )
           .delete();
 
@@ -1115,7 +1192,7 @@ describe("Cloud functions -> Data triggers ->", () => {
             },
           });
         });
-      }
+      },
     );
   });
 });

--- a/packages/functions/src/dataTriggers.ts
+++ b/packages/functions/src/dataTriggers.ts
@@ -38,13 +38,13 @@ export const addIdToSlot = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`,
   )
   .onCreate(
     wrapFirestoreOnCreateHandler("addIdToSlot", async ({ ref }, context) => {
       const { slotId } = context.params as Record<string, string>;
       ref.update({ id: slotId });
-    })
+    }),
   );
 
 /**
@@ -61,7 +61,7 @@ export const addCustomerIdAndSecretKey = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Customers}/{customerId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Customers}/{customerId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -98,7 +98,7 @@ export const addCustomerIdAndSecretKey = functions
               id: customerId,
               secretKey,
             } as Pick<Customer, "id" | "secretKey">,
-            { merge: true }
+            { merge: true },
           );
         }
 
@@ -111,12 +111,12 @@ export const addCustomerIdAndSecretKey = functions
         // create/update booking entry
         batch.set(
           orgRef.collection(OrgSubCollection.Bookings).doc(secretKey),
-          customer
+          customer,
         );
 
         await batch.commit();
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -132,7 +132,7 @@ export const triggerAttendanceEntryForSlot = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -148,24 +148,37 @@ export const triggerAttendanceEntryForSlot = functions
         const isCreate = !change.before.exists;
         const isDelete = !change.after.exists;
 
-        const attendanceEntryRef = db
+        const orgRef = db
           .collection(Collection.Organizations)
-          .doc(organization)
+          .doc(organization);
+        const attendanceEntryRef = orgRef
           .collection(OrgSubCollection.Attendance)
           .doc(slotId);
+        const slotRef = orgRef.collection(OrgSubCollection.Slots).doc(slotId);
 
         switch (true) {
           case isCreate:
-            // check if attendance entry already exists (in case we're dumping/restoring the data)
-            const { exists } = await attendanceEntryRef.get();
-            if (exists) {
-              return;
-            }
-            // add empty entry for slot's attendance
-            await attendanceEntryRef.set({
-              date: change.after.data()!.date,
-              attendances: {},
-            } as SlotAttendnace);
+            // Firestore triggers are at-least-once and unordered: when a slot is
+            // created and deleted in quick succession, this create event can be
+            // processed *after* the delete event, which would resurrect the
+            // attendance entry as an orphan. Re-read the slot inside a
+            // transaction and only create the entry if the slot still exists.
+            await db.runTransaction(async (tx) => {
+              const slotSnap = await tx.get(slotRef);
+              if (!slotSnap.exists) {
+                return;
+              }
+              // check if attendance entry already exists (in case we're dumping/restoring the data)
+              const attendanceSnap = await tx.get(attendanceEntryRef);
+              if (attendanceSnap.exists) {
+                return;
+              }
+              // add empty entry for slot's attendance
+              tx.set(attendanceEntryRef, {
+                date: slotSnap.data()!.date,
+                attendances: {},
+              } as SlotAttendnace);
+            });
             break;
           case isDelete:
             // delete attendance entry for slot
@@ -175,8 +188,8 @@ export const triggerAttendanceEntryForSlot = functions
             // exit if slot was just updated
             return;
         }
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -191,7 +204,7 @@ export const aggregateSlots = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler("aggregateSlots", async (change, context) => {
@@ -202,78 +215,103 @@ export const aggregateSlots = functions
 
       const db = admin.firestore();
 
-      let date: string;
-      let newSlot: SlotInterface | FirebaseFirestore.FieldValue;
-
-      const isCreate = !change.before.exists;
-      const isDelete = !change.after.exists;
-
       const deleteSentinel = admin.firestore.FieldValue.delete();
 
-      switch (true) {
-        case isDelete:
-          // if deleting, we're just setting slot value as delete sentinel and getting the date from before
-          const beforeData = change.before.data() as SlotInterface;
-          date = beforeData.date;
-          newSlot = deleteSentinel;
-          break;
-        case isCreate:
-          // if creating, we're only using the new (after data) and adding generated id
-          const afterData = change.after.data()! as Omit<SlotInterface, "id">;
-          newSlot = { ...afterData, id };
-          date = newSlot.date;
-          break;
-        default:
-          // if not change or create: is update
-          const { intervals: newIntervals, ...updatedData } =
-            change.after.data() as Omit<SlotInterface, "id">;
-          const { intervals: oldIntervals } = change.before.data() as Omit<
-            SlotInterface,
-            "id"
-          >;
+      const orgRef = db.collection(Collection.Organizations).doc(organization);
+      const slotRef = orgRef.collection(OrgSubCollection.Slots).doc(id);
+      const getMonthRef = (date: string) =>
+        orgRef
+          .collection(OrgSubCollection.SlotsByDay)
+          .doc(date.substring(0, 7));
 
-          // we're using {merge: true} flag for setting the document so
-          // we need to process intervals in order to make sure the old intervals get deleted
-          // and only the updated values remain (prevent merging of the old values with the new)
-          const deletedIntervals = Object.keys(oldIntervals).reduce(
-            (acc, intervalString) => ({
-              ...acc,
-              [intervalString]: deleteSentinel,
-            }),
-            {} as Record<string, typeof deleteSentinel>
+      const beforeData = change.before.data() as SlotInterface | undefined;
+      const eventDate = (change.after.data() || change.before.data())!
+        .date as string;
+
+      // Firestore triggers are at-least-once and unordered: when a slot is
+      // created (or updated) and deleted within a short period, this handler can
+      // process the create event *after* the delete event, overwriting the
+      // delete sentinel and resurrecting the slot in the (publicly readable)
+      // aggregate - a "ghost" slot athletes see but can never book, and which
+      // the admin can't remove (deleting the already-absent slot doc fires no
+      // trigger). Instead of trusting the event snapshot, re-read the slot
+      // inside a transaction and write the aggregate from current truth.
+      await db.runTransaction(async (tx) => {
+        const currentSlot = await tx.get(slotRef);
+
+        if (!currentSlot.exists) {
+          // Slot is gone (delete event, or a stale create/update event arriving
+          // after deletion): remove the aggregate entry wherever the event saw it
+          tx.set(
+            getMonthRef(eventDate),
+            { [eventDate]: { [id]: deleteSentinel } },
+            { merge: true },
           );
-          const updatedIntervals = Object.keys(newIntervals).reduce(
-            (acc, intervalString) => ({
-              ...acc,
-              [intervalString]: newIntervals[intervalString],
-            }),
-            {} as Record<string, SlotInterval>
+          // If the event also saw an older date (date-edit), clear that location too
+          if (beforeData && beforeData.date !== eventDate) {
+            tx.set(
+              getMonthRef(beforeData.date),
+              { [beforeData.date]: { [id]: deleteSentinel } },
+              { merge: true },
+            );
+          }
+          return;
+        }
+
+        const { intervals: newIntervals, ...updatedData } =
+          currentSlot.data() as Omit<SlotInterface, "id">;
+        const date = updatedData.date;
+
+        // we're using {merge: true} flag for setting the document so
+        // we need to process intervals in order to make sure the old intervals get deleted
+        // and only the updated values remain (prevent merging of the old values with the new)
+        const deletedIntervals = Object.keys(
+          beforeData?.intervals || {},
+        ).reduce(
+          (acc, intervalString) => ({
+            ...acc,
+            [intervalString]: deleteSentinel,
+          }),
+          {} as Record<string, typeof deleteSentinel>,
+        );
+        const updatedIntervals = Object.keys(newIntervals).reduce(
+          (acc, intervalString) => ({
+            ...acc,
+            [intervalString]: newIntervals[intervalString],
+          }),
+          {} as Record<string, SlotInterval>,
+        );
+
+        // we're merging old intervals as delete sentinels and new intervals as they are
+        // this way old intervals get deleted and in case some interval should stay (wasn't changed/deleted),
+        // the delete sentinel gets overwritten with the new value
+        const intervals = {
+          ...deletedIntervals,
+          ...updatedIntervals,
+        } as Record<string, SlotInterval>;
+
+        const newSlot = { ...updatedData, intervals, id } as SlotInterface;
+
+        // If the slot's date was edited, remove the aggregate entry from the old
+        // date/month (previously the old entry was left behind, duplicating the
+        // slot across months)
+        if (beforeData && beforeData.date !== date) {
+          tx.set(
+            getMonthRef(beforeData.date),
+            { [beforeData.date]: { [id]: deleteSentinel } },
+            { merge: true },
           );
+        }
 
-          // we're merging old intervals as delete sentinels and new intervals as they are
-          // this way old intervals get deleted and in case some interval should stay (wasn't changed/deleted),
-          // the delete sentinel gets overwritten with the new value
-          const intervals = {
-            ...deletedIntervals,
-            ...updatedIntervals,
-          } as Record<string, SlotInterval>;
-
-          newSlot = { ...updatedData, intervals, id };
-          date = newSlot.date;
-      }
-
-      const monthStr = date.substring(0, 7);
-
-      const monthSlotsRef = db
-        .collection(Collection.Organizations)
-        .doc(organization)
-        .collection(OrgSubCollection.SlotsByDay)
-        .doc(monthStr);
-
-      await monthSlotsRef.set({ [date]: { [id]: newSlot } }, { merge: true });
+        tx.set(
+          getMonthRef(date),
+          { [date]: { [id]: newSlot } },
+          { merge: true },
+        );
+      });
 
       return change.after;
-    })
+    }),
   );
 
 export const countSlotsBookings = functions
@@ -282,7 +320,7 @@ export const countSlotsBookings = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -316,8 +354,8 @@ export const countSlotsBookings = functions
         data[bookingId] = slotsBookings + delta;
 
         await bookingCountsDocRef.set(data, { merge: true });
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -332,7 +370,7 @@ export const createAttendanceForBooking = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -385,8 +423,8 @@ export const createAttendanceForBooking = functions
         await attendanceRef.set(updatedEntry, {
           mergeFields: [`attendances.${customerId}`],
         });
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -435,14 +473,14 @@ export const registerCreatedOrgSecret = functions
         const smtpConfig = ["smtpHost", "smtpPort", "smtpUser", "smtpPass"];
 
         const smtpConfigured = smtpConfig.every((element) =>
-          updatedSecrets.includes(element)
+          updatedSecrets.includes(element),
         );
         await organizationRef.set(
           { existingSecrets: updatedSecrets, smtpConfigured },
-          { merge: true }
+          { merge: true },
         );
-      }
-    )
+      },
+    ),
   );
 
 export const createPublicOrgInfo = functions
@@ -479,11 +517,11 @@ export const createPublicOrgInfo = functions
         ].reduce(
           (acc, curr) =>
             orgData[curr] ? { ...acc, [curr]: orgData[curr] } : acc,
-          {}
+          {},
         );
         await publicOrgInfoDocRef.set(updates, { merge: true });
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -499,7 +537,7 @@ export const createAttendedSlotOnAttendance = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Attendance}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Attendance}/{slotId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -589,12 +627,12 @@ export const createAttendedSlotOnAttendance = functions
             // Finally, if interval doesn't exist, we're deleting the attended slot
             batch.delete(attendedSlotRef);
             return;
-          })
+          }),
         );
 
         await batch.commit();
-      }
-    )
+      },
+    ),
   );
 
 export const createCustomerStats = functions
@@ -603,7 +641,7 @@ export const createCustomerStats = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -659,6 +697,6 @@ export const createCustomerStats = functions
           .collection(OrgSubCollection.Customers)
           .doc(customerId)
           .set({ bookingStats: stats }, { merge: true });
-      }
-    )
+      },
+    ),
   );


### PR DESCRIPTION
## What

Fixes the **ghost slot** trigger race (#966): when a slot is created and deleted within a short window, the unordered/at-least-once delivery of Firestore Gen-1 trigger events meant the create-event handler could run *after* the delete-event handler, resurrecting the slot in the publicly-readable `slotsByDay` aggregate (and re-creating its `attendance` doc). Athletes then see a slot they can never book (rules deny booking because `slots/{slotId}` is gone), and the admin can't remove it (deleting the already-absent slot doc fires no trigger). This happened in production during a bulk slot-copy: the ghost sat in the calendar for weeks collecting failed booking attempts.

## How

Both triggers stop trusting the event snapshot and instead **re-read `slots/{slotId}` inside a transaction**, writing from current truth:

- **`aggregateSlots`**: the month-aggregate write now happens in a transaction that first reads the slot doc. If it no longer exists, the handler writes the delete sentinel (regardless of what kind of event it's processing). If it exists, the aggregate entry is built from the *current* doc; the existing interval-sentinel merge logic is preserved (old intervals from the event's `before`).
- **`triggerAttendanceEntryForSlot`**: the create-event branch transactionally checks the slot still exists before (re-)creating the attendance entry, so a stale create event can no longer leave an orphaned attendance doc.

Bonus fix in the same code path: **date edits no longer duplicate the slot across months/days** — when the slot's date changes, the old `slotsByDay` location now gets a delete sentinel (previously the old entry was left behind forever).

## Tests

Added to the emulator suite (`dataTriggers.test.ts`):
- rapid create→delete leaves **no ghost** in `slotsByDay` and no orphan `attendance` doc
- a date edit **moves** (not duplicates) the aggregate entry to the new month, removing the old one

Plus the existing `aggreagateSlots` / `createAttendanceForSlot` tests still pass. Note: the emulator delivers events in order, so the reversed-order race itself can't be reproduced deterministically there — the guarantee comes from the read-truth-in-transaction design, which is correct under any delivery order or retry.

## Production note

This prevents *new* ghosts. The ghost currently live in production is repairable with the already-deployed `dbSlotSlotsByDayAutofix` + `dbSlotAttendanceAutofix` callables (admin-invoked).

Fixes #966. Related: #823 (scheduled hygiene checks would catch any residue automatically), #816 (data-side reconciliation).
