### PR TITLE
fix: self-registration hygiene — org-doc log leak, error strings, error conflation (#963, #964)

### DIFF
--- a/packages/client/src/store/actions/__tests__/bookingOperations.test.ts
+++ b/packages/client/src/store/actions/__tests__/bookingOperations.test.ts
@@ -139,14 +139,14 @@ describe("Booking operations", () => {
         });
         // get all `bookedSlots` for customer
         const bookedSlotsForCustomer = await getDocs(
-          collection(db, getBookedSlotsPath(organization, secretKey))
+          collection(db, getBookedSlotsPath(organization, secretKey)),
         );
         // the updated `bookedSlots` should contain 2 default entries and one new (testBooking)
         expect(bookedSlotsForCustomer.docs.length).toEqual(3);
         // check the updated booking
         const updatedBooking = (
           await getDoc(
-            doc(db, getBookedSlotDocPath(organization, secretKey, bookingId))
+            doc(db, getBookedSlotDocPath(organization, secretKey, bookingId)),
           )
         ).data();
         expect(updatedBooking).toEqual({
@@ -161,9 +161,9 @@ describe("Booking operations", () => {
               interval: intervals[0],
             }),
             variant: NotifVariant.Success,
-          })
+          }),
         );
-      }
+      },
     );
 
     // testWithEmulator(
@@ -183,7 +183,7 @@ describe("Booking operations", () => {
           date: baseSlot.date,
         });
         const mockDispatch = vi.fn();
-        await runThunk(testThunk, mockDispatch, () => ({} as any), {
+        await runThunk(testThunk, mockDispatch, () => ({}) as any, {
           getFirestore,
         });
         expect(mockDispatch).toHaveBeenCalledWith(
@@ -194,9 +194,9 @@ describe("Booking operations", () => {
             }),
             variant: NotifVariant.Error,
             error: testError,
-          })
+          }),
         );
-      }
+      },
     );
   });
 
@@ -240,7 +240,7 @@ describe("Booking operations", () => {
         });
         // get all `bookedSlots` for customer
         const bookedSlotsForCustomer = await getDocs(
-          collection(db, getBookedSlotsPath(organization, secretKey))
+          collection(db, getBookedSlotsPath(organization, secretKey)),
         );
         // the updated `bookedSlots` should contain 2 default entries (with testBooking removed)
         expect(bookedSlotsForCustomer.docs.length).toEqual(2);
@@ -252,9 +252,9 @@ describe("Booking operations", () => {
               interval: intervals[0],
             }),
             variant: NotifVariant.Success,
-          })
+          }),
         );
-      }
+      },
     );
 
     testWithEmulator(
@@ -273,7 +273,7 @@ describe("Booking operations", () => {
           date: baseSlot.date,
         });
         const mockDispatch = vi.fn();
-        await runThunk(testThunk, mockDispatch, () => ({} as any), {
+        await runThunk(testThunk, mockDispatch, () => ({}) as any, {
           getFirestore,
         });
         expect(mockDispatch).toHaveBeenCalledWith(
@@ -284,9 +284,9 @@ describe("Booking operations", () => {
             }),
             variant: NotifVariant.Error,
             error: testError,
-          })
+          }),
         );
-      }
+      },
     );
   });
 
@@ -341,8 +341,8 @@ describe("Booking operations", () => {
         const updatedBooking = await getDoc(
           doc(
             db,
-            getBookedSlotDocPath(organization, saul.secretKey, testSlot.id)
-          )
+            getBookedSlotDocPath(organization, saul.secretKey, testSlot.id),
+          ),
         );
         // the updated booking should contain the same data with 'bookingNotes' added
         expect(updatedBooking.data()).toEqual({
@@ -354,9 +354,9 @@ describe("Booking operations", () => {
           enqueueNotification({
             message: i18n.t(NotificationMessage.BookingNotesUpdated),
             variant: NotifVariant.Success,
-          })
+          }),
         );
-      }
+      },
     );
 
     testWithEmulator(
@@ -376,7 +376,7 @@ describe("Booking operations", () => {
           bookingNotes: "",
         });
         const mockDispatch = vi.fn();
-        await runThunk(testThunk, mockDispatch, () => ({} as any), {
+        await runThunk(testThunk, mockDispatch, () => ({}) as any, {
           getFirestore,
         });
         expect(mockDispatch).toHaveBeenCalledWith(
@@ -384,9 +384,9 @@ describe("Booking operations", () => {
             message: i18n.t(NotificationMessage.BookingNotesError),
             variant: NotifVariant.Error,
             error: testError,
-          })
+          }),
         );
-      }
+      },
     );
   });
 
@@ -416,17 +416,17 @@ describe("Booking operations", () => {
       // Check updates
       await waitFor(async () => {
         const bookingsSnap = await getDoc(
-          doc(db, getBookingsDocPath(organization, saul.secretKey))
+          doc(db, getBookingsDocPath(organization, saul.secretKey)),
         );
         expect(bookingsSnap.data()).toEqual(
-          sanitizeCustomer({ ...saul, name: "Jimmy" })
+          sanitizeCustomer({ ...saul, name: "Jimmy" }),
         );
       });
       expect(mockDispatch).toHaveBeenCalledWith(
         enqueueNotification({
           message: i18n.t(NotificationMessage.CustomerProfileUpdated),
           variant: NotifVariant.Success,
-        })
+        }),
       );
     });
 
@@ -441,7 +441,7 @@ describe("Booking operations", () => {
         // run the thunk
         const testThunk = customerSelfUpdate(saul);
         const mockDispatch = vi.fn();
-        await runThunk(testThunk, mockDispatch, () => ({} as any), {
+        await runThunk(testThunk, mockDispatch, () => ({}) as any, {
           getFunctions,
         });
         expect(mockDispatch).toHaveBeenCalledWith(
@@ -449,9 +449,9 @@ describe("Booking operations", () => {
             message: i18n.t(NotificationMessage.CustomerProfileError),
             variant: NotifVariant.Error,
             error: testError,
-          })
+          }),
         );
-      }
+      },
     );
   });
 
@@ -466,7 +466,7 @@ describe("Booking operations", () => {
           // Set up organization 'registrationCode'
           const docRef = doc(
             db,
-            [Collection.Organizations, organization].join("/")
+            [Collection.Organizations, organization].join("/"),
           );
           await setDoc(docRef, { registrationCode }, { merge: true });
         },
@@ -483,14 +483,14 @@ describe("Booking operations", () => {
       const { id, secretKey } = await runThunk(
         testThunk,
         mockDispatch,
-        store.getState
+        store.getState,
       );
       expect(id).toBeTruthy();
       expect(secretKey).toBeTruthy();
       // Check updates
       await waitFor(async () => {
         const bookingsSnap = await getDoc(
-          doc(db, getBookingsDocPath(organization, secretKey))
+          doc(db, getBookingsDocPath(organization, secretKey)),
         );
         expect(bookingsSnap.data()).toEqual({ ...saul, id, secretKey });
       });
@@ -498,7 +498,7 @@ describe("Booking operations", () => {
         enqueueNotification({
           message: i18n.t(NotificationMessage.SelfRegSuccess),
           variant: NotifVariant.Success,
-        })
+        }),
       );
     });
 
@@ -516,7 +516,7 @@ describe("Booking operations", () => {
           registrationCode: "",
         });
         const mockDispatch = vi.fn();
-        await runThunk(testThunk, mockDispatch, () => ({} as any), {
+        await runThunk(testThunk, mockDispatch, () => ({}) as any, {
           getFunctions,
         });
         expect(mockDispatch).toHaveBeenCalledWith(
@@ -524,9 +524,62 @@ describe("Booking operations", () => {
             message: i18n.t(NotificationMessage.SelfRegError),
             variant: NotifVariant.Error,
             error: testError,
-          })
+          }),
         );
-      }
+      },
+    );
+
+    testWithEmulator(
+      "should return codeOk: false when the backend explicitly rejects the registration code",
+      async () => {
+        const invalidCodeError = Object.assign(new Error("invalid code"), {
+          code: "functions/unauthenticated",
+        });
+        const getFunctions = () => {
+          throw invalidCodeError;
+        };
+        const testThunk = customerSelfRegister({
+          ...saul,
+          registrationCode: "wrong-code",
+        });
+        const mockDispatch = vi.fn();
+        const res = await runThunk(testThunk, mockDispatch, () => ({}) as any, {
+          getFunctions,
+        });
+        expect(res.codeOk).toEqual(false);
+      },
+    );
+
+    testWithEmulator(
+      "should not blame the registration code for unrelated failures (regression: #964)",
+      async () => {
+        // e.g. a flaky network / cold start - nothing to do with the code
+        const networkError = Object.assign(new Error("deadline exceeded"), {
+          code: "functions/deadline-exceeded",
+        });
+        const getFunctions = () => {
+          throw networkError;
+        };
+        const testThunk = customerSelfRegister({
+          ...saul,
+          registrationCode: "correct-code",
+        });
+        const mockDispatch = vi.fn();
+        const res = await runThunk(testThunk, mockDispatch, () => ({}) as any, {
+          getFunctions,
+        });
+        // No misleading "invalid registration code" field error...
+        expect(res.codeOk).toEqual(true);
+        // ...but the registration did fail (no secretKey to proceed with)
+        expect(res.secretKey).toEqual("");
+        expect(mockDispatch).toHaveBeenCalledWith(
+          enqueueNotification({
+            message: i18n.t(NotificationMessage.SelfRegError),
+            variant: NotifVariant.Error,
+            error: networkError,
+          }),
+        );
+      },
     );
   });
 
@@ -557,7 +610,7 @@ describe("Booking operations", () => {
         // Check updates
         await waitFor(async () => {
           const bookingsSnap = await getDoc(
-            doc(db, getBookingsDocPath(organization, saul.secretKey))
+            doc(db, getBookingsDocPath(organization, saul.secretKey)),
           );
           expect(bookingsSnap.data()?.privacyPolicyAccepted).toEqual({
             timestamp: expect.stringContaining(timestampDate),
@@ -567,9 +620,9 @@ describe("Booking operations", () => {
           enqueueNotification({
             message: i18n.t(NotificationMessage.SelectionSaved),
             variant: NotifVariant.Success,
-          })
+          }),
         );
-      }
+      },
     );
 
     testWithEmulator(
@@ -583,7 +636,7 @@ describe("Booking operations", () => {
         // run the thunk
         const testThunk = acceptPrivacyPolicy(saul);
         const mockDispatch = vi.fn();
-        await runThunk(testThunk, mockDispatch, () => ({} as any), {
+        await runThunk(testThunk, mockDispatch, () => ({}) as any, {
           getFunctions,
         });
         expect(mockDispatch).toHaveBeenCalledWith(
@@ -591,9 +644,9 @@ describe("Booking operations", () => {
             message: i18n.t(NotificationMessage.Error),
             variant: NotifVariant.Error,
             error: testError,
-          })
+          }),
         );
-      }
+      },
     );
   });
 });

--- a/packages/client/src/store/actions/bookingOperations.ts
+++ b/packages/client/src/store/actions/bookingOperations.ts
@@ -26,7 +26,7 @@ import {
 import { getOrganization } from "@/lib/getters";
 
 interface UpdateBooking<
-  P extends Record<string, any> = Record<string, unknown>
+  P extends Record<string, any> = Record<string, unknown>,
 > {
   (
     payload: {
@@ -34,7 +34,7 @@ interface UpdateBooking<
       secretKey: Customer["secretKey"];
       date: string;
       interval: string;
-    } & P
+    } & P,
   ): FirestoreThunk;
 }
 
@@ -51,7 +51,7 @@ export const bookInterval: UpdateBooking =
       // update booked interval to firestore
       await setDoc(
         doc(db, getBookedSlotDocPath(getOrganization(), secretKey, slotId)),
-        { interval, date }
+        { interval, date },
       );
 
       // show success message
@@ -62,7 +62,7 @@ export const bookInterval: UpdateBooking =
             interval,
           }),
           variant: NotifVariant.Success,
-        })
+        }),
       );
     } catch (err) {
       dispatch(
@@ -73,7 +73,7 @@ export const bookInterval: UpdateBooking =
           }),
           variant: NotifVariant.Error,
           error: err as Error,
-        })
+        }),
       );
     }
   };
@@ -89,7 +89,7 @@ export const cancelBooking: UpdateBooking =
 
       // remove the booking from firestore
       await deleteDoc(
-        doc(db, getBookedSlotDocPath(getOrganization(), secretKey, slotId))
+        doc(db, getBookedSlotDocPath(getOrganization(), secretKey, slotId)),
       );
 
       // show success message
@@ -100,7 +100,7 @@ export const cancelBooking: UpdateBooking =
             interval,
           }),
           variant: NotifVariant.Success,
-        })
+        }),
       );
     } catch (err) {
       dispatch(
@@ -111,7 +111,7 @@ export const cancelBooking: UpdateBooking =
           }),
           variant: NotifVariant.Error,
           error: err as Error,
-        })
+        }),
       );
     }
   };
@@ -128,7 +128,7 @@ export const updateBookingNotes: UpdateBooking<{ bookingNotes: string }> =
 
       const bookingDocRef = doc(
         db,
-        getBookedSlotDocPath(organization, secretKey, slotId)
+        getBookedSlotDocPath(organization, secretKey, slotId),
       );
 
       await setDoc(bookingDocRef, { ...booking, bookingNotes });
@@ -137,7 +137,7 @@ export const updateBookingNotes: UpdateBooking<{ bookingNotes: string }> =
         enqueueNotification({
           variant: NotifVariant.Success,
           message: i18n.t(NotificationMessage.BookingNotesUpdated),
-        })
+        }),
       );
     } catch (err) {
       dispatch(
@@ -145,7 +145,7 @@ export const updateBookingNotes: UpdateBooking<{ bookingNotes: string }> =
           variant: NotifVariant.Error,
           message: i18n.t(NotificationMessage.BookingNotesError),
           error: err as Error,
-        })
+        }),
       );
     }
   };
@@ -175,7 +175,7 @@ export const customerSelfUpdate: {
         enqueueNotification({
           variant: NotifVariant.Success,
           message: i18n.t(NotificationMessage.CustomerProfileUpdated),
-        })
+        }),
       );
     } catch (err) {
       dispatch(
@@ -183,13 +183,15 @@ export const customerSelfUpdate: {
           variant: NotifVariant.Error,
           message: i18n.t(NotificationMessage.CustomerProfileError),
           error: err as Error,
-        })
+        }),
       );
     }
   };
 
 export const customerSelfRegister: {
-  (paylod: CustomerBase & { registrationCode: string }): (
+  (
+    paylod: CustomerBase & { registrationCode: string },
+  ): (
     ...params: Parameters<FirestoreThunk>
   ) => Promise<{ id: string; secretKey: string; codeOk: boolean }>;
 } =
@@ -212,7 +214,7 @@ export const customerSelfRegister: {
       const res = await createFunctionCaller(
         getFunctions(),
         handler,
-        payload
+        payload,
       )();
       const { id, secretKey } = res.data;
 
@@ -220,7 +222,7 @@ export const customerSelfRegister: {
         enqueueNotification({
           variant: NotifVariant.Success,
           message: i18n.t(NotificationMessage.SelfRegSuccess),
-        })
+        }),
       );
       return {
         id,
@@ -233,9 +235,16 @@ export const customerSelfRegister: {
           variant: NotifVariant.Error,
           message: i18n.t(NotificationMessage.SelfRegError),
           error: err as Error,
-        })
+        }),
       );
-      return { id: "", secretKey: "", codeOk: false };
+      // Only report the registration code as wrong when the backend explicitly
+      // rejected it ('unauthenticated'). For any other failure (network,
+      // backend error, ...) returning codeOk: false would show a misleading
+      // "invalid registration code" field error and send the athlete chasing
+      // a code that is in fact correct.
+      const isInvalidCode =
+        (err as { code?: string })?.code === "functions/unauthenticated";
+      return { id: "", secretKey: "", codeOk: !isInvalidCode };
     }
   };
 
@@ -268,7 +277,7 @@ export const acceptPrivacyPolicy: {
         enqueueNotification({
           variant: NotifVariant.Success,
           message: i18n.t(NotificationMessage.SelectionSaved),
-        })
+        }),
       );
     } catch (err) {
       dispatch(
@@ -276,7 +285,7 @@ export const acceptPrivacyPolicy: {
           variant: NotifVariant.Error,
           message: i18n.t(NotificationMessage.Error),
           error: err as Error,
-        })
+        }),
       );
     }
   };

--- a/packages/functions/src/https.ts
+++ b/packages/functions/src/https.ts
@@ -51,7 +51,7 @@ export const finalizeBookings = functions
       if (!customerInStore.exists) {
         throw new functions.https.HttpsError(
           "not-found",
-          BookingsErrors.CustomerNotFound
+          BookingsErrors.CustomerNotFound,
         );
       }
 
@@ -61,13 +61,13 @@ export const finalizeBookings = functions
       if (secretKey !== existingSecretKey) {
         throw new functions.https.HttpsError(
           "invalid-argument",
-          BookingsErrors.SecretKeyMismatch
+          BookingsErrors.SecretKeyMismatch,
         );
       }
 
       // remove `extendedDate`
       await customerRef.set({ extendedDate: null }, { merge: true });
-    })
+    }),
   );
 
 /**
@@ -104,7 +104,7 @@ export const customerSelfUpdate = functions
         if (!customerInStore.exists) {
           throw new functions.https.HttpsError(
             "not-found",
-            BookingsErrors.CustomerNotFound
+            BookingsErrors.CustomerNotFound,
           );
         }
 
@@ -114,13 +114,13 @@ export const customerSelfUpdate = functions
         if (customer.secretKey !== existingSecretKey) {
           throw new functions.https.HttpsError(
             "invalid-argument",
-            BookingsErrors.SecretKeyMismatch
+            BookingsErrors.SecretKeyMismatch,
           );
         }
 
         await customerRef.set({ ...customer }, { merge: true });
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -166,14 +166,19 @@ export const customerSelfRegister = functions
         const orgDoc = await orgRef.get();
         const orgData = orgDoc.data() as OrganizationData;
 
-        functions.logger.log({ orgData });
+        // Log only non-sensitive flags: this is an unauthenticated endpoint and
+        // the full org doc contains the registration code, admin emails, etc.
+        functions.logger.log({
+          smtpConfigured: Boolean(orgData.smtpConfigured),
+          hasRegistrationCode: Boolean(orgData.registrationCode),
+        });
         if (!checkExpected(registrationCode, orgData.registrationCode || "")) {
           throw new EisbukHttpsError(
             "unauthenticated",
             HTTPSErrors.SelfRegInvalidCode,
             {
               registrationCode,
-            }
+            },
           );
         }
 
@@ -210,8 +215,8 @@ To verify the athlete, add them to a category/categories on their respective pro
         }
 
         return fullCustomer;
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -255,7 +260,7 @@ export const acceptPrivacyPolicy = functions
       if (!customerInStore.exists) {
         throw new functions.https.HttpsError(
           "not-found",
-          BookingsErrors.CustomerNotFound
+          BookingsErrors.CustomerNotFound,
         );
       }
 
@@ -265,14 +270,14 @@ export const acceptPrivacyPolicy = functions
       if (secretKey !== existingSecretKey) {
         throw new functions.https.HttpsError(
           "invalid-argument",
-          BookingsErrors.SecretKeyMismatch
+          BookingsErrors.SecretKeyMismatch,
         );
       }
 
       // Store the accepted privacy policy timestamp to the customer structure
       await customerRef.set(
         { privacyPolicyAccepted: { timestamp } },
-        { merge: true }
+        { merge: true },
       );
-    })
+    }),
   );

--- a/packages/shared/src/enums/errorMessages.ts
+++ b/packages/shared/src/enums/errorMessages.ts
@@ -1,7 +1,7 @@
 // #region cloudFunctions
 export enum HTTPSErrors {
   NoPayload = "No request payload provided",
-  Unauth = "Unathorized",
+  Unauth = "Unauthorized",
   TimedOut = "Function timed out",
   MissingParameter = "One or more required parameters are missing from the payload",
   EmailInvalidType = "Email type missing or invalid",
@@ -10,7 +10,7 @@ export enum HTTPSErrors {
   NoSecrets = "No secrets document found, make sure to create a secrets document for an organziation at: '/secrets/{ organization }'",
   NoSMTPConfigured = "No smtp configuration found, make sure to create a secrets document for an organziation at: '/secrets/{ organization }' with your smtp configuration",
   NoEmailConfigured = "No emailFrom found, make sure to add an emailFrom to your organziation settings",
-  SelfRegInvalidCode = "Unathorized: Invalid registration code code",
+  SelfRegInvalidCode = "Unauthorized: Invalid registration code",
 }
 
 export enum SendSMSErrors {


### PR DESCRIPTION
## What

Three small self-registration hygiene fixes:

1. **Stop logging the full org doc on a public endpoint** (#963): `customerSelfRegister` logged the entire organization document — including the secret `registrationCode`, admin emails and templates — to Cloud Logging on *every* call (before the code check, so also for strangers probing the endpoint). Now logs only non-sensitive booleans.

2. **Fix the doubly-broken error string** (#964): `"Unathorized"` → `"Unauthorized"` and `"Invalid registration code code"` → `"Invalid registration code"` in `shared/enums/errorMessages.ts`. All consumers reference the enum, so no other call sites change.

3. **Stop blaming the registration code for every failure** (#964): the client thunk `customerSelfRegister` returned `codeOk: false` on *any* error, so the self-register page showed "invalid registration code" even when the real failure was a network error or a backend bug — a diagnostic dead-end that makes athletes give up. Now the field error is shown only when the backend explicitly rejects the code (`functions/unauthenticated`); other failures surface the generic error notification only.

## Tests

- New unit tests for the thunk: an `unauthenticated` callable error → `codeOk: false` (field error); any other error → `codeOk: true` (generic notification only, no misleading field error).
- Existing `customerSelfRegister` emulator + thunk tests pass.

Fixes #963, fixes #964.
