### PR TITLE
fix: scrub athletes' PII from Sentry error events (#969)

### DIFF
--- a/packages/functions/src/constants.ts
+++ b/packages/functions/src/constants.ts
@@ -1,5 +1,7 @@
 import * as Sentry from "@sentry/serverless";
 
+import { scrubPII } from "@eisbuk/shared";
+
 export const __functionsZone__ = "europe-west6";
 export const __projectId__ = process.env.PROJECT_ID;
 export const __smsUrl__ = "https://gatewayapi.com/rest/mtsms";
@@ -15,5 +17,16 @@ if (__enableSentry__) {
     dsn: __sentryDSN__,
     release: __sentryRelease__,
     tracesSampleRate: 1.0,
+    // Strip athletes' personal data (callable request bodies, trigger context,
+    // caller IP) before events leave the process. Default server-side scrubbing
+    // only catches key names like 'password', so customer fields (name,
+    // surname, birthday, email, phone - many belonging to minors) would
+    // otherwise be persisted in the error tracker verbatim.
+    beforeSend: (event) => {
+      if (event.request) event.request = scrubPII(event.request);
+      if (event.user) event.user = scrubPII(event.user);
+      if (event.extra) event.extra = scrubPII(event.extra);
+      return event;
+    },
   });
 }

--- a/packages/shared/src/utils/__tests__/scrub.test.ts
+++ b/packages/shared/src/utils/__tests__/scrub.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from "vitest";
+
+import { scrubPII } from "../scrub";
+
+describe("scrubPII", () => {
+  test("should replace values of PII keys at any depth with '[Filtered]'", () => {
+    const event = {
+      request: {
+        url: "https://europe-west6-project.cloudfunctions.net/customerSelfRegister",
+        data: {
+          data: {
+            organization: "test-org",
+            registrationCode: "super-secret",
+            customer: {
+              name: "Ayla",
+              surname: "Marucelli",
+              birthday: "2013-02-02",
+              email: "parent@example.com",
+              phone: "+393331111111",
+            },
+          },
+        },
+      },
+      user: { ip_address: "203.0.113.7", country: "IT" },
+    };
+
+    const scrubbed = scrubPII(event);
+
+    expect(scrubbed.request.data.data.registrationCode).toEqual("[Filtered]");
+    expect(scrubbed.request.data.data.customer).toEqual({
+      name: "[Filtered]",
+      surname: "[Filtered]",
+      birthday: "[Filtered]",
+      email: "[Filtered]",
+      phone: "[Filtered]",
+    });
+    expect(scrubbed.user.ip_address).toEqual("[Filtered]");
+    // Non-sensitive data is left intact
+    expect(scrubbed.request.url).toEqual(event.request.url);
+    expect(scrubbed.request.data.data.organization).toEqual("test-org");
+    expect(scrubbed.user.country).toEqual("IT");
+    // The input is not mutated
+    expect(event.request.data.data.customer.name).toEqual("Ayla");
+  });
+
+  test("should handle arrays, null values and custom key lists", () => {
+    const input = {
+      list: [{ email: "a@b.c", keep: 1 }, null, "plain"],
+      nothing: null,
+    };
+    expect(scrubPII(input)).toEqual({
+      list: [{ email: "[Filtered]", keep: 1 }, null, "plain"],
+      nothing: null,
+    });
+
+    expect(scrubPII({ foo: "x", bar: "y" }, ["foo"])).toEqual({
+      foo: "[Filtered]",
+      bar: "y",
+    });
+  });
+
+  test("should not choke on circular references or class instances", () => {
+    const circular: Record<string, any> = { email: "a@b.c" };
+    circular.self = circular;
+    expect(() => scrubPII(circular)).not.toThrow();
+    expect(scrubPII(circular).email).toEqual("[Filtered]");
+
+    const date = new Date(0);
+    expect(scrubPII({ created: date }).created).toBe(date);
+  });
+});

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from "./slots";
 
 export * from "./generators";
 export * from "./sort";
+export * from "./scrub";

--- a/packages/shared/src/utils/scrub.ts
+++ b/packages/shared/src/utils/scrub.ts
@@ -1,0 +1,73 @@
+/**
+ * Default list of keys considered personal/sensitive data wherever they appear
+ * in a structure: customer identity fields, contact data, secrets and message
+ * payloads (which embed customer data in free text).
+ */
+export const defaultPIIKeys = [
+  "name",
+  "surname",
+  "email",
+  "phone",
+  "birthday",
+  "certificateExpiration",
+  "photoURL",
+  "secretKey",
+  "registrationCode",
+  "password",
+  "smtpPass",
+  "smtpUser",
+  "smsAuthToken",
+  "authToken",
+  "ip_address",
+  // Email/SMS payload fields (interpolated with customer data)
+  "html",
+  "subject",
+  "to",
+  "bcc",
+  "cc",
+  "message",
+  "attachments",
+];
+
+/**
+ * Returns a deep copy of `value` with the values of all properties whose key
+ * is in `keys` (at any depth) replaced by "[Filtered]". Used to scrub personal
+ * data out of structures before handing them to third parties (e.g. Sentry
+ * error reports - athletes' data shouldn't end up in the error tracker).
+ *
+ * Non-plain values (class instances, functions) are passed through untouched,
+ * and circular references are left in place rather than followed.
+ */
+export const scrubPII = <T>(value: T, keys: string[] = defaultPIIKeys): T => {
+  const keySet = new Set(keys);
+  const seen = new WeakSet<object>();
+
+  const scrub = (node: any): any => {
+    if (node === null || typeof node !== "object") {
+      return node;
+    }
+    if (seen.has(node)) {
+      return node;
+    }
+    seen.add(node);
+
+    if (Array.isArray(node)) {
+      return node.map(scrub);
+    }
+
+    // Leave non-plain objects (Dates, class instances, ...) untouched
+    if (Object.getPrototypeOf(node) !== Object.prototype) {
+      return node;
+    }
+
+    return Object.entries(node).reduce(
+      (acc, [key, val]) => {
+        acc[key] = keySet.has(key) ? "[Filtered]" : scrub(val);
+        return acc;
+      },
+      {} as Record<string, any>,
+    );
+  };
+
+  return scrub(value);
+};


### PR DESCRIPTION
## What

Stops athletes' personal data from being persisted in the Sentry error tracker (#969). Cloud-function error events included the full callable request body — for `customerSelfRegister` (unauthenticated) that means name, surname, **birthday** (many athletes are minors), email and phone — plus the caller IP. The `Authorization` header was filtered but the JSON body wasn't, and Sentry's default scrubbing only matches keys like `password`.

## How

- New tested utility `scrubPII` in `@eisbuk/shared` (`packages/shared/src/utils/scrub.ts`): deep-copies a structure replacing the values of a denylist of keys (`name`, `surname`, `email`, `phone`, `birthday`, `secretKey`, `registrationCode`, smtp/sms secrets, email/SMS payload fields, `ip_address`, …) with `"[Filtered]"` at any depth. Handles arrays, circular references and non-plain objects.
- `Sentry.init` in `packages/functions/src/constants.ts` gains a `beforeSend` that scrubs `event.request`, `event.user` and `event.extra` before anything leaves the process. `beforeSend` runs after all event processors, so it also covers the request data attached by the serverless wrapper.

Non-sensitive debugging context (request URL, org id, country tag, stack traces) is preserved.

## Tests

`scrubPII` unit tests (3) cover: nested callable-body scrubbing with intact non-sensitive fields and no input mutation; arrays/null/custom key lists; circular references and class instances. Functions package typechecks and builds.

Fixes #969.
