### PR TITLE
fix: atomic countSlotsBookings with zero floor (#965)

### DIFF
--- a/packages/client/src/__tests__/dataTriggers.test.ts
+++ b/packages/client/src/__tests__/dataTriggers.test.ts
@@ -127,8 +127,8 @@ describe("Cloud functions -> Data triggers ->", () => {
                   getBookedSlotDocPath(
                     organization,
                     saul.secretKey,
-                    baseSlot.id
-                  )
+                    baseSlot.id,
+                  ),
                 )
                 .set(initialBooking);
 
@@ -144,7 +144,7 @@ describe("Cloud functions -> Data triggers ->", () => {
 
             // update (or delete) the booked slot
             const bookedSlotRef = adminDb.doc(
-              getBookedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getBookedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             );
             if (update) {
               await bookedSlotRef.set(update);
@@ -165,7 +165,7 @@ describe("Cloud functions -> Data triggers ->", () => {
               expect(snap.data()).toEqual(wantAttendanceFinal);
             });
           });
-        }
+        },
       );
     };
 
@@ -341,10 +341,10 @@ describe("Cloud functions -> Data triggers ->", () => {
       // Wait for the data triggers to run
       await Promise.all([
         waitFor(async () =>
-          expect((await saulBookings.get()).exists).toEqual(true)
+          expect((await saulBookings.get()).exists).toEqual(true),
         ),
         waitFor(async () =>
-          expect((await gusBookings.get()).exists).toEqual(true)
+          expect((await gusBookings.get()).exists).toEqual(true),
         ),
       ]);
 
@@ -388,6 +388,19 @@ describe("Cloud functions -> Data triggers ->", () => {
       await waitFor(async () => {
         const snap = await bookingCountsDocRef.get();
         expect(snap.data()![slot.id]).toEqual(1);
+      });
+
+      // Deleting a booking whose counter doesn't exist must not produce a
+      // negative count (regression: #965 - bulk deletions of legacy bookings
+      // used to write counters like -7 into slotBookingsCounts)
+      await bookingCountsDocRef.delete();
+      await gusBookings
+        .collection(BookingSubCollection.BookedSlots)
+        .doc(slot.id)
+        .delete();
+      await waitFor(async () => {
+        const snap = await bookingCountsDocRef.get();
+        expect(snap.data()![slot.id]).toEqual(0);
       });
     });
   });
@@ -468,7 +481,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           .doc(getSlotDocPath(organization, baseSlot.id))
           .set(baseSlot);
         const newSlotRef = adminDb.doc(
-          getSlotDocPath(organization, baseSlot.id)
+          getSlotDocPath(organization, baseSlot.id),
         );
         await newSlotRef.set(newSlot);
         await waitFor(async () => {
@@ -488,7 +501,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           expect(snap.exists).toEqual(true);
           expect(Boolean(snap.data()![testDate][newSlotId])).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -513,7 +526,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         // we're manually deleting attendance to test that it won't get created on slot update
         // the attendance entry for slot shouldn't be edited manually in production
         const attendanceDocRef = adminDb.doc(
-          getAttendanceDocPath(organization, baseSlot.id)
+          getAttendanceDocPath(organization, baseSlot.id),
         );
         await attendanceDocRef.delete();
         // wait for attendance entry to be deleted
@@ -526,7 +539,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         // check the no new entry for slot attendance was created (on update)
         const slotAttendance = await attendanceDocRef.get();
         expect(slotAttendance.exists).toEqual(false);
-      }
+      },
     );
 
     testWithEmulator(
@@ -551,7 +564,7 @@ describe("Cloud functions -> Data triggers ->", () => {
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
 
     testWithEmulator(
@@ -576,7 +589,7 @@ describe("Cloud functions -> Data triggers ->", () => {
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -615,7 +628,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(organizationPath).get();
           expect(snap.data()!.existingSecrets).toEqual(["anotherSecret"]);
         });
-      }
+      },
     );
 
     testWithEmulator(
@@ -639,7 +652,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(organizationPath).get();
           const data = snap.data() as OrganizationData;
           expect(data.existingSecrets).toEqual(
-            expect.arrayContaining(["smtpHost"])
+            expect.arrayContaining(["smtpHost"]),
           );
           expect(data.smtpConfigured).toBeFalsy();
         });
@@ -658,8 +671,8 @@ describe("Cloud functions -> Data triggers ->", () => {
           const data = snap.data() as OrganizationData;
           expect(
             Object.keys(secrets).every((key) =>
-              data.existingSecrets!.includes(key)
-            )
+              data.existingSecrets!.includes(key),
+            ),
           ).toEqual(true);
           expect(data.smtpConfigured).toEqual(true);
         });
@@ -675,7 +688,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(organizationPath).get();
           expect(snap.data()!.smtpConfigured).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -736,7 +749,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(publicOrgPath).get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -782,7 +795,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         await waitFor(async () => {
           const snap = await adminDb
             .doc(
-              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             )
             .get();
           expect(snap.data()).toEqual({
@@ -805,7 +818,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         await waitFor(async () => {
           const attendedSlotDoc = await adminDb
             .doc(
-              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             )
             .get();
           expect(attendedSlotDoc.data()).toEqual({
@@ -823,12 +836,12 @@ describe("Cloud functions -> Data triggers ->", () => {
         await waitFor(async () => {
           const snap = await adminDb
             .doc(
-              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             )
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
 
     testWithEmulator(
@@ -876,7 +889,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           waitFor(async () => {
             const snap = await adminDb
               .doc(
-                getBookingsDocPath(organization, controlledCustomer.secretKey)
+                getBookingsDocPath(organization, controlledCustomer.secretKey),
               )
               .get();
             expect(snap.exists).toEqual(true);
@@ -889,8 +902,8 @@ describe("Cloud functions -> Data triggers ->", () => {
             getBookedSlotDocPath(
               organization,
               testCustomer.secretKey,
-              baseSlot.id
-            )
+              baseSlot.id,
+            ),
           )
           .set({
             date: baseSlot.date,
@@ -935,8 +948,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getAttendedSlotDocPath(
                 organization,
                 controlledCustomer.secretKey,
-                baseSlot.id
-              )
+                baseSlot.id,
+              ),
             )
             .get();
           expect(snap.exists).toEqual(true);
@@ -949,13 +962,13 @@ describe("Cloud functions -> Data triggers ->", () => {
               getAttendedSlotDocPath(
                 organization,
                 testCustomer.secretKey,
-                baseSlot.id
-              )
+                baseSlot.id,
+              ),
             )
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
   });
   describe("createCustomerStats", () => {
@@ -1028,8 +1041,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotThisMonthIce.date}-9`
-              )
+                `${bookedSlotThisMonthIce.date}-9`,
+              ),
             )
             .set(bookedSlotThisMonthIce),
           await adminDb
@@ -1037,8 +1050,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotNextMonthIce.date}-9`
-              )
+                `${bookedSlotNextMonthIce.date}-9`,
+              ),
             )
             .set(bookedSlotNextMonthIce),
           await adminDb
@@ -1046,8 +1059,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotThisMonthOffIce.date}-10`
-              )
+                `${bookedSlotThisMonthOffIce.date}-10`,
+              ),
             )
             .set(bookedSlotThisMonthOffIce),
           await adminDb
@@ -1055,8 +1068,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotNextMonthOffIce.date}-10`
-              )
+                `${bookedSlotNextMonthOffIce.date}-10`,
+              ),
             )
             .set(bookedSlotNextMonthOffIce),
         ]);
@@ -1090,8 +1103,8 @@ describe("Cloud functions -> Data triggers ->", () => {
             getBookedSlotDocPath(
               organization,
               saul.secretKey,
-              `${bookedSlotThisMonthIce.date}-9`
-            )
+              `${bookedSlotThisMonthIce.date}-9`,
+            ),
           )
           .delete();
 
@@ -1115,7 +1128,7 @@ describe("Cloud functions -> Data triggers ->", () => {
             },
           });
         });
-      }
+      },
     );
   });
 });

--- a/packages/functions/src/dataTriggers.ts
+++ b/packages/functions/src/dataTriggers.ts
@@ -38,13 +38,13 @@ export const addIdToSlot = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`,
   )
   .onCreate(
     wrapFirestoreOnCreateHandler("addIdToSlot", async ({ ref }, context) => {
       const { slotId } = context.params as Record<string, string>;
       ref.update({ id: slotId });
-    })
+    }),
   );
 
 /**
@@ -61,7 +61,7 @@ export const addCustomerIdAndSecretKey = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Customers}/{customerId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Customers}/{customerId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -98,7 +98,7 @@ export const addCustomerIdAndSecretKey = functions
               id: customerId,
               secretKey,
             } as Pick<Customer, "id" | "secretKey">,
-            { merge: true }
+            { merge: true },
           );
         }
 
@@ -111,12 +111,12 @@ export const addCustomerIdAndSecretKey = functions
         // create/update booking entry
         batch.set(
           orgRef.collection(OrgSubCollection.Bookings).doc(secretKey),
-          customer
+          customer,
         );
 
         await batch.commit();
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -132,7 +132,7 @@ export const triggerAttendanceEntryForSlot = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -175,8 +175,8 @@ export const triggerAttendanceEntryForSlot = functions
             // exit if slot was just updated
             return;
         }
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -191,7 +191,7 @@ export const aggregateSlots = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler("aggregateSlots", async (change, context) => {
@@ -240,14 +240,14 @@ export const aggregateSlots = functions
               ...acc,
               [intervalString]: deleteSentinel,
             }),
-            {} as Record<string, typeof deleteSentinel>
+            {} as Record<string, typeof deleteSentinel>,
           );
           const updatedIntervals = Object.keys(newIntervals).reduce(
             (acc, intervalString) => ({
               ...acc,
               [intervalString]: newIntervals[intervalString],
             }),
-            {} as Record<string, SlotInterval>
+            {} as Record<string, SlotInterval>,
           );
 
           // we're merging old intervals as delete sentinels and new intervals as they are
@@ -273,7 +273,7 @@ export const aggregateSlots = functions
       await monthSlotsRef.set({ [date]: { [id]: newSlot } }, { merge: true });
 
       return change.after;
-    })
+    }),
   );
 
 export const countSlotsBookings = functions
@@ -282,7 +282,7 @@ export const countSlotsBookings = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -309,15 +309,28 @@ export const countSlotsBookings = functions
           .collection(OrgSubCollection.SlotBookingsCounts)
           .doc(date.substring(0, 7));
 
-        const doc = await bookingCountsDocRef.get();
-        const data = doc.data() || ({} as SlotBookingsCounts);
+        // Use a transaction: the previous non-transactional read-modify-write
+        // lost updates when two bookings for the same month changed
+        // concurrently, permanently corrupting the counters that drive the
+        // "slot is full" filtering in the athlete booking view.
+        await db.runTransaction(async (tx) => {
+          const doc = await tx.get(bookingCountsDocRef);
+          const data = doc.data() || ({} as SlotBookingsCounts);
 
-        const slotsBookings = data[bookingId] || 0;
-        data[bookingId] = slotsBookings + delta;
+          const slotsBookings = data[bookingId] || 0;
+          // Floor at 0: decrements for bookings whose counter was never
+          // created (e.g. bulk deletions of legacy bookings) used to write
+          // negative counts.
+          const updatedCount = Math.max(0, slotsBookings + delta);
 
-        await bookingCountsDocRef.set(data, { merge: true });
-      }
-    )
+          tx.set(
+            bookingCountsDocRef,
+            { [bookingId]: updatedCount },
+            { merge: true },
+          );
+        });
+      },
+    ),
   );
 
 /**
@@ -332,7 +345,7 @@ export const createAttendanceForBooking = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -385,8 +398,8 @@ export const createAttendanceForBooking = functions
         await attendanceRef.set(updatedEntry, {
           mergeFields: [`attendances.${customerId}`],
         });
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -435,14 +448,14 @@ export const registerCreatedOrgSecret = functions
         const smtpConfig = ["smtpHost", "smtpPort", "smtpUser", "smtpPass"];
 
         const smtpConfigured = smtpConfig.every((element) =>
-          updatedSecrets.includes(element)
+          updatedSecrets.includes(element),
         );
         await organizationRef.set(
           { existingSecrets: updatedSecrets, smtpConfigured },
-          { merge: true }
+          { merge: true },
         );
-      }
-    )
+      },
+    ),
   );
 
 export const createPublicOrgInfo = functions
@@ -479,11 +492,11 @@ export const createPublicOrgInfo = functions
         ].reduce(
           (acc, curr) =>
             orgData[curr] ? { ...acc, [curr]: orgData[curr] } : acc,
-          {}
+          {},
         );
         await publicOrgInfoDocRef.set(updates, { merge: true });
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -499,7 +512,7 @@ export const createAttendedSlotOnAttendance = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Attendance}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Attendance}/{slotId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -589,12 +602,12 @@ export const createAttendedSlotOnAttendance = functions
             // Finally, if interval doesn't exist, we're deleting the attended slot
             batch.delete(attendedSlotRef);
             return;
-          })
+          }),
         );
 
         await batch.commit();
-      }
-    )
+      },
+    ),
   );
 
 export const createCustomerStats = functions
@@ -603,7 +616,7 @@ export const createCustomerStats = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -659,6 +672,6 @@ export const createCustomerStats = functions
           .collection(OrgSubCollection.Customers)
           .doc(customerId)
           .set({ bookingStats: stats }, { merge: true });
-      }
-    )
+      },
+    ),
   );


### PR DESCRIPTION
## What

Makes the `countSlotsBookings` trigger atomic and floors counters at zero (#965).

## Problem

The trigger maintained `slotBookingsCounts/{month}` with a **non-transactional read-modify-write** of the whole month doc:

- two concurrent booking changes in the same month could lose updates, and drift is permanent (nothing ever recomputes the counters);
- decrementing a counter that was never created wrote **negative** counts (several historical month docs in production contain values like `-7` and `-11` from a bulk cleanup).

These counters drive the "slot is full" filtering in the athlete booking view (`getSlotsForCustomer`), so an inflated counter silently hides a bookable slot from athletes.

## Fix

The update now runs in a transaction, writes only the affected slot's counter (no whole-doc rewrite), and clamps the result at 0.

## Tests

Extended the existing `countSlotsBookings` emulator test with the regression case: deleting a booking whose counter doc was removed results in `0`, not `-1`. Suite passes.

Fixes #965.
