### PR TITLE
ci: unbreak the pipeline (browserslist staleness, retired runner)

### DIFF
--- a/.github/workflow.templates/build.yml
+++ b/.github/workflow.templates/build.yml
@@ -13,6 +13,13 @@ name: OnPush
 "on":
   - push
 
+#! caniuse-lite pinned in the lockfile is >6 months old, which makes Browserslist
+#! print a warning to stderr; rush treats any stderr output as a warning and exits
+#! non-zero even when every project builds. Silence the staleness warning in CI
+#! until the lockfile is refreshed. Deliberately NOT set in deploy-production.yml.
+env:
+  BROWSERSLIST_IGNORE_OLD_DATA: "1"
+
 jobs:
   build_v18:
     name: Build and deploy to preview channel
@@ -164,7 +171,7 @@ jobs:
         run: rush typecheck
   cypress-run:
     name: Cypress browser tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       -  #@ checkout()
       - uses: actions/setup-node@v4

--- a/.github/workflow.templates/cypress-matrix.yml
+++ b/.github/workflow.templates/cypress-matrix.yml
@@ -20,10 +20,14 @@ name: CypressMatrix
   schedule:
     - cron: "30 5 * * 1,3"
 
+#! See build.yml: silence the Browserslist staleness warning so rush build exits 0.
+env:
+  BROWSERSLIST_IGNORE_OLD_DATA: "1"
+
 jobs:
   cypress-run:
     name: Cypress browser tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflow.templates/vitest-matrix.yml
+++ b/.github/workflow.templates/vitest-matrix.yml
@@ -15,10 +15,14 @@ name: VitestMatrix
   schedule:
     - cron: "30 5 * * 1,3"
 
+#! See build.yml: silence the Browserslist staleness warning so rush build exits 0.
+env:
+  BROWSERSLIST_IGNORE_OLD_DATA: "1"
+
 jobs:
   test-v18:
     name: Run tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: OnPush
 "on":
 - push
+env:
+  BROWSERSLIST_IGNORE_OLD_DATA: "1"
 jobs:
   build_v18:
     name: Build and deploy to preview channel
@@ -216,7 +218,7 @@ jobs:
       run: rush typecheck
   cypress-run:
     name: Cypress browser tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/cypress-matrix.yml
+++ b/.github/workflows/cypress-matrix.yml
@@ -5,10 +5,12 @@ name: CypressMatrix
     - cypress-matrix/**
   schedule:
   - cron: 30 5 * * 1,3
+env:
+  BROWSERSLIST_IGNORE_OLD_DATA: "1"
 jobs:
   cypress-run:
     name: Cypress browser tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/vitest-matrix.yml
+++ b/.github/workflows/vitest-matrix.yml
@@ -5,10 +5,12 @@ name: VitestMatrix
     - vitest-matrix/**
   schedule:
   - cron: 30 5 * * 1,3
+env:
+  BROWSERSLIST_IGNORE_OLD_DATA: "1"
 jobs:
   test-v18:
     name: Run tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Makes CI runnable again after 18 months of dormancy. Every job on every branch currently fails or hangs for two reasons that have nothing to do with any code change: a Browserslist staleness warning that rush turns into exit 1, and a Cypress job requesting a runner GitHub retired in April 2025.

**Deliberately scoped so master still cannot deploy.** `deploy-production.yml` runs the same `rush build` and keeps failing at it; this PR leaves that workflow untouched, so merging this (or anything) to master stays unable to reach the deploy step until that workflow is fixed on purpose.

## What changed

- `BROWSERSLIST_IGNORE_OLD_DATA=1` set at workflow level in `build.yml`, `cypress-matrix.yml`, `vitest-matrix.yml` (templates edited, workflows regenerated with `.github/build-workflows.sh`).
- Cypress/matrix jobs moved from `ubuntu-20.04` (retired, jobs sat queued forever and held runs open) to `ubuntu-latest`.

## Why it's correct

- The caniuse-lite snapshot in the lockfile is >6 months old, so Browserslist warns on stderr while building `@eisbuk/ui` and `@eisbuk/svg`; rush treats any stderr as a warning and exits 1 even though all 13 projects build (`SUCCESS WITH WARNINGS` then `exit code 1` in every red run, e.g. [this lint job](https://github.com/eisbuk/EisBuk/actions/runs/27308032199/job/80670893972)). Reproduced locally: `rush rebuild --to @eisbuk/svg` exits 1; with the env var it exits 0 and the warning is gone.
- The env var only suppresses the staleness warning; build output is otherwise unchanged.

## Cost / what this does not do

- The env var is a stopgap. The real fix is refreshing caniuse-lite in the lockfile; left out here because it changes a build input and deserves its own reviewed PR.
- `actions/checkout@v4`, `setup-node@v4`, `cache@v4` get force-migrated to Node 24 on June 16th; expected to keep working, bumping them is a separate follow-up.
- Cypress runs for the first time since 2024 on this PR; any failure it surfaces is pre-existing e2e rot, not introduced here.

## Tests

This PR's own checks are the test: all seven jobs should go green, including the Cypress job that could never start before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)