### PR TITLE
ci: deploy to production on pushes to the production branch, not master

### DIFF
--- a/.github/workflow.templates/deploy-production.yml
+++ b/.github/workflow.templates/deploy-production.yml
@@ -8,8 +8,17 @@ name: Deploy to production
 "on":
   push:
     branches:
-      - master
+      #! Deploys are decoupled from merges: master no longer deploys. To release,
+      #! fast-forward the `production` branch to the commit you want live:
+      #!   git push origin <commit-or-master>:production
+      - production
       - test/production-deployment
+
+#! Same stopgap as the CI workflows: the stale caniuse-lite snapshot in the
+#! lockfile makes Browserslist warn on stderr and rush turn that into exit 1.
+#! Remove once the lockfile is refreshed.
+env:
+  BROWSERSLIST_IGNORE_OLD_DATA: "1"
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -2,8 +2,10 @@ name: Deploy to production
 "on":
   push:
     branches:
-    - master
+    - production
     - test/production-deployment
+env:
+  BROWSERSLIST_IGNORE_OLD_DATA: "1"
 jobs:
   deploy:
     environment: Production


### PR DESCRIPTION
Moves the production deploy trigger from `master` to a dedicated `production` branch. Merging to master becomes release-inert; releasing becomes an explicit act: `git push origin <commit-or-master>:production`.

**This also re-arms the deploy pipeline.** The browserslist stopgap from #978 is now set in `deploy-production.yml` too, so the workflow can build again. That guard existed only because master pushes used to trigger deploys; with master out of the trigger list, the first push to `production` containing this commit will really deploy.

## What changed

- `deploy-production.yml` trigger: `master` replaced by `production` (`test/production-deployment` kept for pipeline testing; note it deploys to real prod).
- `BROWSERSLIST_IGNORE_OLD_DATA=1` at workflow level, same stopgap as #978; remove both when the lockfile's caniuse-lite gets refreshed.
- Templates edited, workflows regenerated with `.github/build-workflows.sh`.

## Why it's safe

- Merging this PR to master fires no deploy: push-event triggers are evaluated against the workflow file at the pushed commit, which no longer lists master.
- The `production` branch will be created at the commit currently running in prod (the Dec 2024 release), so creating it cannot change what is deployed; at that old commit the workflow file only triggered on master, so the creation push fires no deploy either.
- The "Production" environment branch policy needs `production` added to its allowed deployment branches (done via API alongside this PR, it is repo settings, not code).

## What this does not do

- No required-reviewer gate on the Production environment; a push to `production` deploys without further approval. Can be added in repo settings if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)