### PR TITLE
Deploy integration: 8 production fixes (#970–#977)

### DIFF
--- a/packages/client/src/__tests__/cloudFunctions.test.ts
+++ b/packages/client/src/__tests__/cloudFunctions.test.ts
@@ -8,6 +8,7 @@ import { describe, expect } from "vitest";
 import {
   HTTPSErrors,
   BookingsErrors,
+  Category,
   ClientMessagePayload,
   ClientMessageType,
   sanitizeCustomer,
@@ -39,7 +40,7 @@ describe("Cloud functions", () => {
     testWithEmulator("should respond if pinged", async () => {
       const result = await httpsCallable(
         functions,
-        CloudFunction.Ping
+        CloudFunction.Ping,
       )({
         foo: "bar",
       });
@@ -66,9 +67,9 @@ describe("Cloud functions", () => {
           },
         };
         await expect(
-          httpsCallable(functions, CloudFunction.SendEmail)(payload)
+          httpsCallable(functions, CloudFunction.SendEmail)(payload),
         ).rejects.toThrow(HTTPSErrors.Unauth);
-      }
+      },
     );
 
     testWithEmulator(
@@ -91,9 +92,9 @@ describe("Cloud functions", () => {
           email: saul.email,
         };
         await expect(
-          httpsCallable(functions, CloudFunction.SendEmail)(payload)
+          httpsCallable(functions, CloudFunction.SendEmail)(payload),
         ).rejects.toThrow(HTTPSErrors.NoSMTPConfigured);
-      }
+      },
     );
 
     testWithEmulator(
@@ -108,9 +109,9 @@ describe("Cloud functions", () => {
           customer: saul,
         };
         await expect(
-          httpsCallable(functions, CloudFunction.SendEmail)(payload)
+          httpsCallable(functions, CloudFunction.SendEmail)(payload),
         ).rejects.toThrow(HTTPSErrors.EmailInvalidType);
-      }
+      },
     );
 
     testWithEmulator(
@@ -151,13 +152,13 @@ describe("Cloud functions", () => {
           secretKey: saul.secretKey,
         };
         await expect(
-          httpsCallable(functions, CloudFunction.SendEmail)(payload)
+          httpsCallable(functions, CloudFunction.SendEmail)(payload),
         ).resolves.toEqual(
           expect.objectContaining({
             data: expect.objectContaining({ success: true }),
-          })
+          }),
         );
-      }
+      },
     );
 
     testWithEmulator(
@@ -174,9 +175,9 @@ describe("Cloud functions", () => {
           },
         };
         await expect(
-          httpsCallable(functions, CloudFunction.SendEmail)(payload)
+          httpsCallable(functions, CloudFunction.SendEmail)(payload),
         ).rejects.toThrow(HTTPSErrors.Unauth);
-      }
+      },
     );
 
     testWithEmulator("should reject if no recipient provided", async () => {
@@ -195,7 +196,7 @@ describe("Cloud functions", () => {
         await httpsCallable(functions, CloudFunction.SendEmail)(payload);
       } catch (error) {
         expect((error as FunctionsError).message).toEqual(
-          expect.stringContaining("must have required property 'email'")
+          expect.stringContaining("must have required property 'email'"),
         );
       }
     });
@@ -219,7 +220,7 @@ describe("Cloud functions", () => {
         // run the function
         await httpsCallable(
           functions,
-          CloudFunction.FinalizeBookings
+          CloudFunction.FinalizeBookings,
         )({
           id: saul.id,
           organization,
@@ -232,16 +233,16 @@ describe("Cloud functions", () => {
             .get();
           expect(Boolean(bookingsSnap.data()?.extendedDate)).toEqual(false);
         });
-      }
+      },
     );
 
     testWithEmulator(
       "should return an error if no payload provided",
       async () => {
         await expect(
-          httpsCallable(functions, CloudFunction.FinalizeBookings)()
+          httpsCallable(functions, CloudFunction.FinalizeBookings)(),
         ).rejects.toThrow(HTTPSErrors.NoPayload);
-      }
+      },
     );
 
     testWithEmulator(
@@ -251,10 +252,10 @@ describe("Cloud functions", () => {
           await httpsCallable(functions, CloudFunction.FinalizeBookings)({});
         } catch (error) {
           expect((error as FunctionsError).message).toEqual(
-            `${HTTPSErrors.MissingParameter}: id, organization, secretKey`
+            `${HTTPSErrors.MissingParameter}: id, organization, secretKey`,
           );
         }
-      }
+      },
     );
 
     testWithEmulator(
@@ -266,14 +267,14 @@ describe("Cloud functions", () => {
         await expect(
           httpsCallable(
             functions,
-            CloudFunction.FinalizeBookings
+            CloudFunction.FinalizeBookings,
           )({
             organization,
             id: saul.id,
             secretKey: "wrong-key",
-          })
+          }),
         ).rejects.toThrow(BookingsErrors.SecretKeyMismatch);
-      }
+      },
     );
 
     testWithEmulator(
@@ -283,14 +284,14 @@ describe("Cloud functions", () => {
         await expect(
           httpsCallable(
             functions,
-            CloudFunction.FinalizeBookings
+            CloudFunction.FinalizeBookings,
           )({
             organization,
             id: saul.id,
             secretKey: saul.secretKey,
-          })
+          }),
         ).rejects.toThrow(BookingsErrors.CustomerNotFound);
-      }
+      },
     );
   });
 
@@ -304,7 +305,7 @@ describe("Cloud functions", () => {
         await saulRef.set(saul);
         // wait for bookings to get created (through data trigger)
         await waitFor(() =>
-          adminDb.doc(getBookingsDocPath(organization, saul.secretKey)).get()
+          adminDb.doc(getBookingsDocPath(organization, saul.secretKey)).get(),
         );
         // Timestamp used for the test, the actual time doesn't matter,
         // only that it's stord in the db after the function is ran.
@@ -312,7 +313,7 @@ describe("Cloud functions", () => {
         // run the function
         await httpsCallable(
           functions,
-          CloudFunction.AcceptPrivacyPolicy
+          CloudFunction.AcceptPrivacyPolicy,
         )({
           id: saul.id,
           organization,
@@ -333,16 +334,16 @@ describe("Cloud functions", () => {
             timestamp,
           });
         });
-      }
+      },
     );
 
     testWithEmulator(
       "should return an error if no payload provided",
       async () => {
         await expect(
-          httpsCallable(functions, CloudFunction.AcceptPrivacyPolicy)()
+          httpsCallable(functions, CloudFunction.AcceptPrivacyPolicy)(),
         ).rejects.toThrow(HTTPSErrors.NoPayload);
-      }
+      },
     );
 
     testWithEmulator(
@@ -352,10 +353,10 @@ describe("Cloud functions", () => {
           await httpsCallable(functions, CloudFunction.AcceptPrivacyPolicy)({});
         } catch (error) {
           expect((error as FunctionsError).message).toEqual(
-            `${HTTPSErrors.MissingParameter}: id, organization, secretKey, timestamp`
+            `${HTTPSErrors.MissingParameter}: id, organization, secretKey, timestamp`,
           );
         }
-      }
+      },
     );
 
     testWithEmulator(
@@ -367,15 +368,15 @@ describe("Cloud functions", () => {
         await expect(
           httpsCallable(
             functions,
-            CloudFunction.AcceptPrivacyPolicy
+            CloudFunction.AcceptPrivacyPolicy,
           )({
             organization,
             id: saul.id,
             secretKey: "wrong-key",
             timestamp: DateTime.now().toISO(),
-          })
+          }),
         ).rejects.toThrow(BookingsErrors.SecretKeyMismatch);
-      }
+      },
     );
 
     testWithEmulator(
@@ -385,15 +386,15 @@ describe("Cloud functions", () => {
         await expect(
           httpsCallable(
             functions,
-            CloudFunction.AcceptPrivacyPolicy
+            CloudFunction.AcceptPrivacyPolicy,
           )({
             organization,
             id: saul.id,
             secretKey: saul.secretKey,
             timestamp: DateTime.now().toISO(),
-          })
+          }),
         ).rejects.toThrow(BookingsErrors.CustomerNotFound);
-      }
+      },
     );
   });
 
@@ -417,7 +418,7 @@ describe("Cloud functions", () => {
         // run the function to update customer
         await httpsCallable(
           functions,
-          CloudFunction.CustomerSelfUpdate
+          CloudFunction.CustomerSelfUpdate,
         )({
           organization,
           customer: saul,
@@ -430,16 +431,54 @@ describe("Cloud functions", () => {
             .get();
           expect(bookingsSnap.data()).toEqual(sanitizeCustomer(saul));
         });
-      }
+      },
+    );
+
+    testWithEmulator(
+      "should ignore admin-managed fields (categories, extendedDate, deleted, secretKey rotation) sent by the customer (regression: #962)",
+      async () => {
+        const { organization } = await setUpOrganization();
+        const saulRef = adminDb.doc(getCustomerDocPath(organization, saul.id));
+        await saulRef.set(saul);
+
+        // Attempt a self-update smuggling in admin-managed fields
+        await httpsCallable(
+          functions,
+          CloudFunction.CustomerSelfUpdate,
+        )({
+          organization,
+          customer: {
+            ...saul,
+            // Legitimate self-edit
+            name: "Jimmy",
+            // Privilege-escalation attempts: none of these may be persisted
+            // (note: different from the fixture's categories)
+            categories: [Category.PrivateLessons],
+            extendedDate: "2099-12-31",
+            deleted: true,
+            subscriptionNumber: "tampered",
+          },
+        });
+
+        const updatedSaul = (await saulRef.get()).data()!;
+        // The legitimate field is updated
+        expect(updatedSaul.name).toEqual("Jimmy");
+        // Admin-managed fields are unchanged
+        expect(updatedSaul.categories).toEqual(saul.categories);
+        expect(updatedSaul.extendedDate).toEqual(saul.extendedDate);
+        expect(Boolean(updatedSaul.deleted)).toEqual(Boolean(saul.deleted));
+        expect(updatedSaul.subscriptionNumber).toEqual(saul.subscriptionNumber);
+        expect(updatedSaul.secretKey).toEqual(saul.secretKey);
+      },
     );
 
     testWithEmulator(
       "should return an error if no payload provided",
       async () => {
         await expect(
-          httpsCallable(functions, CloudFunction.CustomerSelfUpdate)()
+          httpsCallable(functions, CloudFunction.CustomerSelfUpdate)(),
         ).rejects.toThrow(HTTPSErrors.NoPayload);
-      }
+      },
     );
 
     testWithEmulator(
@@ -449,10 +488,10 @@ describe("Cloud functions", () => {
           await httpsCallable(functions, CloudFunction.CustomerSelfUpdate)({});
         } catch (error) {
           expect((error as FunctionsError).message).toEqual(
-            `${HTTPSErrors.MissingParameter}: organization, customer`
+            `${HTTPSErrors.MissingParameter}: organization, customer`,
           );
         }
-      }
+      },
     );
 
     testWithEmulator(
@@ -463,17 +502,17 @@ describe("Cloud functions", () => {
         try {
           await httpsCallable(
             functions,
-            CloudFunction.CustomerSelfUpdate
+            CloudFunction.CustomerSelfUpdate,
           )({
             organization: {},
             customer: saulNoId,
           });
         } catch (error) {
           expect((error as FunctionsError).message).toEqual(
-            `${HTTPSErrors.MissingParameter}: id, secretKey`
+            `${HTTPSErrors.MissingParameter}: id, secretKey`,
           );
         }
-      }
+      },
     );
 
     testWithEmulator(
@@ -487,13 +526,13 @@ describe("Cloud functions", () => {
         await expect(
           httpsCallable(
             functions,
-            CloudFunction.CustomerSelfUpdate
+            CloudFunction.CustomerSelfUpdate,
           )({
             organization,
             customer: { ...saulNoSecretKey, secretKey: "wrong-key" },
-          })
+          }),
         ).rejects.toThrow(BookingsErrors.SecretKeyMismatch);
-      }
+      },
     );
 
     testWithEmulator(
@@ -503,13 +542,13 @@ describe("Cloud functions", () => {
         await expect(
           httpsCallable(
             functions,
-            CloudFunction.CustomerSelfUpdate
+            CloudFunction.CustomerSelfUpdate,
           )({
             organization,
             customer: saul,
-          })
+          }),
         ).rejects.toThrow(BookingsErrors.CustomerNotFound);
-      }
+      },
     );
   });
 
@@ -539,7 +578,7 @@ describe("Cloud functions", () => {
         // run the function to update customer
         await httpsCallable(
           functions,
-          CloudFunction.CustomerSelfRegister
+          CloudFunction.CustomerSelfRegister,
         )({
           organization,
           registrationCode,
@@ -583,7 +622,7 @@ describe("Cloud functions", () => {
 
               secretKey,
               id,
-            } as Customer)
+            } as Customer),
           );
         });
 
@@ -602,18 +641,18 @@ describe("Cloud functions", () => {
               to: emailFrom,
               from: emailFrom,
             },
-          })
+          }),
         );
-      }
+      },
     );
 
     testWithEmulator(
       "should return an error if no payload provided",
       async () => {
         await expect(
-          httpsCallable(functions, CloudFunction.CustomerSelfRegister)()
+          httpsCallable(functions, CloudFunction.CustomerSelfRegister)(),
         ).rejects.toThrow(HTTPSErrors.NoPayload);
-      }
+      },
     );
 
     testWithEmulator(
@@ -622,14 +661,14 @@ describe("Cloud functions", () => {
         try {
           await httpsCallable(
             functions,
-            CloudFunction.CustomerSelfRegister
+            CloudFunction.CustomerSelfRegister,
           )({});
         } catch (error) {
           expect((error as FunctionsError).message).toEqual(
-            `${HTTPSErrors.MissingParameter}: organization, customer`
+            `${HTTPSErrors.MissingParameter}: organization, customer`,
           );
         }
-      }
+      },
     );
 
     testWithEmulator(
@@ -640,7 +679,7 @@ describe("Cloud functions", () => {
         try {
           await httpsCallable(
             functions,
-            CloudFunction.CustomerSelfRegister
+            CloudFunction.CustomerSelfRegister,
           )({
             organization: "dummy-organization",
             registrationCode: "not-real-code",
@@ -648,10 +687,10 @@ describe("Cloud functions", () => {
           });
         } catch (error) {
           expect((error as FunctionsError).message).toEqual(
-            `${HTTPSErrors.MissingParameter}: No 'email' nor 'phone' provided, at least one is required to register.`
+            `${HTTPSErrors.MissingParameter}: No 'email' nor 'phone' provided, at least one is required to register.`,
           );
         }
-      }
+      },
     );
 
     testWithEmulator("should validate registration code", async () => {
@@ -665,7 +704,7 @@ describe("Cloud functions", () => {
       try {
         await httpsCallable(
           functions,
-          CloudFunction.CustomerSelfRegister
+          CloudFunction.CustomerSelfRegister,
         )({
           organization,
           registrationCode: "not-real-code",
@@ -673,7 +712,7 @@ describe("Cloud functions", () => {
         });
       } catch (error) {
         expect((error as FunctionsError).message).toEqual(
-          HTTPSErrors.SelfRegInvalidCode
+          HTTPSErrors.SelfRegInvalidCode,
         );
       }
     });

--- a/packages/client/src/__tests__/dataTriggers.test.ts
+++ b/packages/client/src/__tests__/dataTriggers.test.ts
@@ -127,8 +127,8 @@ describe("Cloud functions -> Data triggers ->", () => {
                   getBookedSlotDocPath(
                     organization,
                     saul.secretKey,
-                    baseSlot.id
-                  )
+                    baseSlot.id,
+                  ),
                 )
                 .set(initialBooking);
 
@@ -144,7 +144,7 @@ describe("Cloud functions -> Data triggers ->", () => {
 
             // update (or delete) the booked slot
             const bookedSlotRef = adminDb.doc(
-              getBookedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getBookedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             );
             if (update) {
               await bookedSlotRef.set(update);
@@ -165,7 +165,7 @@ describe("Cloud functions -> Data triggers ->", () => {
               expect(snap.data()).toEqual(wantAttendanceFinal);
             });
           });
-        }
+        },
       );
     };
 
@@ -341,10 +341,10 @@ describe("Cloud functions -> Data triggers ->", () => {
       // Wait for the data triggers to run
       await Promise.all([
         waitFor(async () =>
-          expect((await saulBookings.get()).exists).toEqual(true)
+          expect((await saulBookings.get()).exists).toEqual(true),
         ),
         waitFor(async () =>
-          expect((await gusBookings.get()).exists).toEqual(true)
+          expect((await gusBookings.get()).exists).toEqual(true),
         ),
       ]);
 
@@ -388,6 +388,19 @@ describe("Cloud functions -> Data triggers ->", () => {
       await waitFor(async () => {
         const snap = await bookingCountsDocRef.get();
         expect(snap.data()![slot.id]).toEqual(1);
+      });
+
+      // Deleting a booking whose counter doesn't exist must not produce a
+      // negative count (regression: #965 - bulk deletions of legacy bookings
+      // used to write counters like -7 into slotBookingsCounts)
+      await bookingCountsDocRef.delete();
+      await gusBookings
+        .collection(BookingSubCollection.BookedSlots)
+        .doc(slot.id)
+        .delete();
+      await waitFor(async () => {
+        const snap = await bookingCountsDocRef.get();
+        expect(snap.data()![slot.id]).toEqual(0);
       });
     });
   });
@@ -468,7 +481,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           .doc(getSlotDocPath(organization, baseSlot.id))
           .set(baseSlot);
         const newSlotRef = adminDb.doc(
-          getSlotDocPath(organization, baseSlot.id)
+          getSlotDocPath(organization, baseSlot.id),
         );
         await newSlotRef.set(newSlot);
         await waitFor(async () => {
@@ -488,7 +501,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           expect(snap.exists).toEqual(true);
           expect(Boolean(snap.data()![testDate][newSlotId])).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -513,7 +526,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         // we're manually deleting attendance to test that it won't get created on slot update
         // the attendance entry for slot shouldn't be edited manually in production
         const attendanceDocRef = adminDb.doc(
-          getAttendanceDocPath(organization, baseSlot.id)
+          getAttendanceDocPath(organization, baseSlot.id),
         );
         await attendanceDocRef.delete();
         // wait for attendance entry to be deleted
@@ -526,7 +539,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         // check the no new entry for slot attendance was created (on update)
         const slotAttendance = await attendanceDocRef.get();
         expect(slotAttendance.exists).toEqual(false);
-      }
+      },
     );
 
     testWithEmulator(
@@ -551,7 +564,7 @@ describe("Cloud functions -> Data triggers ->", () => {
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
 
     testWithEmulator(
@@ -576,7 +589,7 @@ describe("Cloud functions -> Data triggers ->", () => {
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -615,7 +628,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(organizationPath).get();
           expect(snap.data()!.existingSecrets).toEqual(["anotherSecret"]);
         });
-      }
+      },
     );
 
     testWithEmulator(
@@ -639,7 +652,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(organizationPath).get();
           const data = snap.data() as OrganizationData;
           expect(data.existingSecrets).toEqual(
-            expect.arrayContaining(["smtpHost"])
+            expect.arrayContaining(["smtpHost"]),
           );
           expect(data.smtpConfigured).toBeFalsy();
         });
@@ -658,8 +671,8 @@ describe("Cloud functions -> Data triggers ->", () => {
           const data = snap.data() as OrganizationData;
           expect(
             Object.keys(secrets).every((key) =>
-              data.existingSecrets!.includes(key)
-            )
+              data.existingSecrets!.includes(key),
+            ),
           ).toEqual(true);
           expect(data.smtpConfigured).toEqual(true);
         });
@@ -675,7 +688,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(organizationPath).get();
           expect(snap.data()!.smtpConfigured).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -736,7 +749,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(publicOrgPath).get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -782,7 +795,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         await waitFor(async () => {
           const snap = await adminDb
             .doc(
-              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             )
             .get();
           expect(snap.data()).toEqual({
@@ -805,7 +818,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         await waitFor(async () => {
           const attendedSlotDoc = await adminDb
             .doc(
-              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             )
             .get();
           expect(attendedSlotDoc.data()).toEqual({
@@ -823,12 +836,12 @@ describe("Cloud functions -> Data triggers ->", () => {
         await waitFor(async () => {
           const snap = await adminDb
             .doc(
-              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             )
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
 
     testWithEmulator(
@@ -876,7 +889,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           waitFor(async () => {
             const snap = await adminDb
               .doc(
-                getBookingsDocPath(organization, controlledCustomer.secretKey)
+                getBookingsDocPath(organization, controlledCustomer.secretKey),
               )
               .get();
             expect(snap.exists).toEqual(true);
@@ -889,8 +902,8 @@ describe("Cloud functions -> Data triggers ->", () => {
             getBookedSlotDocPath(
               organization,
               testCustomer.secretKey,
-              baseSlot.id
-            )
+              baseSlot.id,
+            ),
           )
           .set({
             date: baseSlot.date,
@@ -935,8 +948,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getAttendedSlotDocPath(
                 organization,
                 controlledCustomer.secretKey,
-                baseSlot.id
-              )
+                baseSlot.id,
+              ),
             )
             .get();
           expect(snap.exists).toEqual(true);
@@ -949,13 +962,13 @@ describe("Cloud functions -> Data triggers ->", () => {
               getAttendedSlotDocPath(
                 organization,
                 testCustomer.secretKey,
-                baseSlot.id
-              )
+                baseSlot.id,
+              ),
             )
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
   });
   describe("createCustomerStats", () => {
@@ -1028,8 +1041,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotThisMonthIce.date}-9`
-              )
+                `${bookedSlotThisMonthIce.date}-9`,
+              ),
             )
             .set(bookedSlotThisMonthIce),
           await adminDb
@@ -1037,8 +1050,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotNextMonthIce.date}-9`
-              )
+                `${bookedSlotNextMonthIce.date}-9`,
+              ),
             )
             .set(bookedSlotNextMonthIce),
           await adminDb
@@ -1046,8 +1059,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotThisMonthOffIce.date}-10`
-              )
+                `${bookedSlotThisMonthOffIce.date}-10`,
+              ),
             )
             .set(bookedSlotThisMonthOffIce),
           await adminDb
@@ -1055,8 +1068,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotNextMonthOffIce.date}-10`
-              )
+                `${bookedSlotNextMonthOffIce.date}-10`,
+              ),
             )
             .set(bookedSlotNextMonthOffIce),
         ]);
@@ -1090,8 +1103,8 @@ describe("Cloud functions -> Data triggers ->", () => {
             getBookedSlotDocPath(
               organization,
               saul.secretKey,
-              `${bookedSlotThisMonthIce.date}-9`
-            )
+              `${bookedSlotThisMonthIce.date}-9`,
+            ),
           )
           .delete();
 
@@ -1115,7 +1128,7 @@ describe("Cloud functions -> Data triggers ->", () => {
             },
           });
         });
-      }
+      },
     );
   });
 });

--- a/packages/client/src/__tests__/dataTriggers.test.ts
+++ b/packages/client/src/__tests__/dataTriggers.test.ts
@@ -127,8 +127,8 @@ describe("Cloud functions -> Data triggers ->", () => {
                   getBookedSlotDocPath(
                     organization,
                     saul.secretKey,
-                    baseSlot.id
-                  )
+                    baseSlot.id,
+                  ),
                 )
                 .set(initialBooking);
 
@@ -144,7 +144,7 @@ describe("Cloud functions -> Data triggers ->", () => {
 
             // update (or delete) the booked slot
             const bookedSlotRef = adminDb.doc(
-              getBookedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getBookedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             );
             if (update) {
               await bookedSlotRef.set(update);
@@ -165,7 +165,7 @@ describe("Cloud functions -> Data triggers ->", () => {
               expect(snap.data()).toEqual(wantAttendanceFinal);
             });
           });
-        }
+        },
       );
     };
 
@@ -341,10 +341,10 @@ describe("Cloud functions -> Data triggers ->", () => {
       // Wait for the data triggers to run
       await Promise.all([
         waitFor(async () =>
-          expect((await saulBookings.get()).exists).toEqual(true)
+          expect((await saulBookings.get()).exists).toEqual(true),
         ),
         waitFor(async () =>
-          expect((await gusBookings.get()).exists).toEqual(true)
+          expect((await gusBookings.get()).exists).toEqual(true),
         ),
       ]);
 
@@ -467,9 +467,10 @@ describe("Cloud functions -> Data triggers ->", () => {
         await adminDb
           .doc(getSlotDocPath(organization, baseSlot.id))
           .set(baseSlot);
-        const newSlotRef = adminDb.doc(
-          getSlotDocPath(organization, baseSlot.id)
-        );
+        // (this used to - mistakenly - point to baseSlot's doc, which only
+        // passed because the old aggregation left stale entries behind on
+        // date change)
+        const newSlotRef = adminDb.doc(getSlotDocPath(organization, newSlotId));
         await newSlotRef.set(newSlot);
         await waitFor(async () => {
           const snap = await adminDb
@@ -477,7 +478,11 @@ describe("Cloud functions -> Data triggers ->", () => {
             .get();
           // wait until both slots are aggregated
           const data = snap.data()!;
-          expect(Boolean(data[testDate] && data[dayAfter])).toEqual(true);
+          expect(
+            Boolean(
+              data[testDate]?.[baseSlot.id] && data[dayAfter]?.[newSlotId],
+            ),
+          ).toEqual(true);
         });
         // test removing of the additional slot
         await newSlotRef.delete();
@@ -486,9 +491,81 @@ describe("Cloud functions -> Data triggers ->", () => {
             .doc(getSlotsByDayDocPath(organization, testMonth))
             .get();
           expect(snap.exists).toEqual(true);
-          expect(Boolean(snap.data()![testDate][newSlotId])).toEqual(false);
+          const data = snap.data()!;
+          // the deleted slot is removed from the aggregate...
+          expect(data[dayAfter]?.[newSlotId]).toBeUndefined();
+          // ...while the other slot is untouched
+          expect(Boolean(data[testDate]?.[baseSlot.id])).toEqual(true);
         });
-      }
+      },
+    );
+
+    testWithEmulator(
+      "should not leave a ghost slot (in slotsByDay or attendance) when a slot is created and deleted in quick succession (regression: #966)",
+      async () => {
+        const { organization } = await setUpOrganization();
+        const slotRef = adminDb.doc(getSlotDocPath(organization, baseSlot.id));
+
+        // Create and delete the slot back-to-back, without waiting for the
+        // create-event triggers to process. With unordered/at-least-once
+        // trigger delivery this used to resurrect the slot in 'slotsByDay'
+        // (and its 'attendance' doc) with no way for the admin to remove it.
+        await slotRef.set(baseSlot);
+        await slotRef.delete();
+
+        // Give both events' triggers time to fully process
+        await new Promise((resolve) => setTimeout(resolve, 4000));
+
+        const aggSnap = await adminDb
+          .doc(getSlotsByDayDocPath(organization, testMonth))
+          .get();
+        expect(aggSnap.data()?.[testDate]?.[baseSlot.id]).toBeUndefined();
+
+        const attendanceSnap = await adminDb
+          .doc(getAttendanceDocPath(organization, baseSlot.id))
+          .get();
+        expect(attendanceSnap.exists).toEqual(false);
+      },
+      { timeout: 15000 },
+    );
+
+    testWithEmulator(
+      "should move (not duplicate) the slotsByDay entry when a slot's date is edited",
+      async () => {
+        const { organization } = await setUpOrganization();
+        const slotRef = adminDb.doc(getSlotDocPath(organization, baseSlot.id));
+        await slotRef.set(baseSlot);
+
+        // wait for the initial aggregate entry
+        await waitFor(async () => {
+          const snap = await adminDb
+            .doc(getSlotsByDayDocPath(organization, testMonth))
+            .get();
+          expect(Boolean(snap.data()?.[testDate]?.[baseSlot.id])).toEqual(true);
+        });
+
+        // move the slot to a date in the next month
+        const movedDateLuxon = testDateLuxon.plus({ months: 1 });
+        const movedDate = luxon2ISODate(movedDateLuxon);
+        const movedMonth = movedDate.substring(0, 7);
+        const movedSlot = { ...baseSlot, date: movedDate };
+        await slotRef.set(movedSlot);
+
+        // the entry should appear under the new month...
+        await waitFor(async () => {
+          const snap = await adminDb
+            .doc(getSlotsByDayDocPath(organization, movedMonth))
+            .get();
+          expect(snap.data()?.[movedDate]?.[baseSlot.id]).toEqual(movedSlot);
+        });
+        // ...and disappear from the old one (previously it was left behind)
+        await waitFor(async () => {
+          const snap = await adminDb
+            .doc(getSlotsByDayDocPath(organization, testMonth))
+            .get();
+          expect(snap.data()?.[testDate]?.[baseSlot.id]).toBeUndefined();
+        });
+      },
     );
   });
 
@@ -513,7 +590,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         // we're manually deleting attendance to test that it won't get created on slot update
         // the attendance entry for slot shouldn't be edited manually in production
         const attendanceDocRef = adminDb.doc(
-          getAttendanceDocPath(organization, baseSlot.id)
+          getAttendanceDocPath(organization, baseSlot.id),
         );
         await attendanceDocRef.delete();
         // wait for attendance entry to be deleted
@@ -526,7 +603,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         // check the no new entry for slot attendance was created (on update)
         const slotAttendance = await attendanceDocRef.get();
         expect(slotAttendance.exists).toEqual(false);
-      }
+      },
     );
 
     testWithEmulator(
@@ -551,7 +628,7 @@ describe("Cloud functions -> Data triggers ->", () => {
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
 
     testWithEmulator(
@@ -576,7 +653,7 @@ describe("Cloud functions -> Data triggers ->", () => {
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -615,7 +692,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(organizationPath).get();
           expect(snap.data()!.existingSecrets).toEqual(["anotherSecret"]);
         });
-      }
+      },
     );
 
     testWithEmulator(
@@ -639,7 +716,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(organizationPath).get();
           const data = snap.data() as OrganizationData;
           expect(data.existingSecrets).toEqual(
-            expect.arrayContaining(["smtpHost"])
+            expect.arrayContaining(["smtpHost"]),
           );
           expect(data.smtpConfigured).toBeFalsy();
         });
@@ -658,8 +735,8 @@ describe("Cloud functions -> Data triggers ->", () => {
           const data = snap.data() as OrganizationData;
           expect(
             Object.keys(secrets).every((key) =>
-              data.existingSecrets!.includes(key)
-            )
+              data.existingSecrets!.includes(key),
+            ),
           ).toEqual(true);
           expect(data.smtpConfigured).toEqual(true);
         });
@@ -675,7 +752,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(organizationPath).get();
           expect(snap.data()!.smtpConfigured).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -736,7 +813,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           const snap = await adminDb.doc(publicOrgPath).get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
   });
 
@@ -782,7 +859,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         await waitFor(async () => {
           const snap = await adminDb
             .doc(
-              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             )
             .get();
           expect(snap.data()).toEqual({
@@ -805,7 +882,7 @@ describe("Cloud functions -> Data triggers ->", () => {
         await waitFor(async () => {
           const attendedSlotDoc = await adminDb
             .doc(
-              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             )
             .get();
           expect(attendedSlotDoc.data()).toEqual({
@@ -823,12 +900,12 @@ describe("Cloud functions -> Data triggers ->", () => {
         await waitFor(async () => {
           const snap = await adminDb
             .doc(
-              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id)
+              getAttendedSlotDocPath(organization, saul.secretKey, baseSlot.id),
             )
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
 
     testWithEmulator(
@@ -876,7 +953,7 @@ describe("Cloud functions -> Data triggers ->", () => {
           waitFor(async () => {
             const snap = await adminDb
               .doc(
-                getBookingsDocPath(organization, controlledCustomer.secretKey)
+                getBookingsDocPath(organization, controlledCustomer.secretKey),
               )
               .get();
             expect(snap.exists).toEqual(true);
@@ -889,8 +966,8 @@ describe("Cloud functions -> Data triggers ->", () => {
             getBookedSlotDocPath(
               organization,
               testCustomer.secretKey,
-              baseSlot.id
-            )
+              baseSlot.id,
+            ),
           )
           .set({
             date: baseSlot.date,
@@ -935,8 +1012,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getAttendedSlotDocPath(
                 organization,
                 controlledCustomer.secretKey,
-                baseSlot.id
-              )
+                baseSlot.id,
+              ),
             )
             .get();
           expect(snap.exists).toEqual(true);
@@ -949,13 +1026,13 @@ describe("Cloud functions -> Data triggers ->", () => {
               getAttendedSlotDocPath(
                 organization,
                 testCustomer.secretKey,
-                baseSlot.id
-              )
+                baseSlot.id,
+              ),
             )
             .get();
           expect(snap.exists).toEqual(false);
         });
-      }
+      },
     );
   });
   describe("createCustomerStats", () => {
@@ -1028,8 +1105,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotThisMonthIce.date}-9`
-              )
+                `${bookedSlotThisMonthIce.date}-9`,
+              ),
             )
             .set(bookedSlotThisMonthIce),
           await adminDb
@@ -1037,8 +1114,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotNextMonthIce.date}-9`
-              )
+                `${bookedSlotNextMonthIce.date}-9`,
+              ),
             )
             .set(bookedSlotNextMonthIce),
           await adminDb
@@ -1046,8 +1123,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotThisMonthOffIce.date}-10`
-              )
+                `${bookedSlotThisMonthOffIce.date}-10`,
+              ),
             )
             .set(bookedSlotThisMonthOffIce),
           await adminDb
@@ -1055,8 +1132,8 @@ describe("Cloud functions -> Data triggers ->", () => {
               getBookedSlotDocPath(
                 organization,
                 saul.secretKey,
-                `${bookedSlotNextMonthOffIce.date}-10`
-              )
+                `${bookedSlotNextMonthOffIce.date}-10`,
+              ),
             )
             .set(bookedSlotNextMonthOffIce),
         ]);
@@ -1090,8 +1167,8 @@ describe("Cloud functions -> Data triggers ->", () => {
             getBookedSlotDocPath(
               organization,
               saul.secretKey,
-              `${bookedSlotThisMonthIce.date}-9`
-            )
+              `${bookedSlotThisMonthIce.date}-9`,
+            ),
           )
           .delete();
 
@@ -1115,7 +1192,7 @@ describe("Cloud functions -> Data triggers ->", () => {
             },
           });
         });
-      }
+      },
     );
   });
 });

--- a/packages/client/src/__tests__/updateSMSStatus.test.ts
+++ b/packages/client/src/__tests__/updateSMSStatus.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment node
+ */
+
+import { v4 as uuid } from "uuid";
+import { describe, expect } from "vitest";
+
+import { Collection, DeliveryQueue } from "@eisbuk/shared";
+
+import { adminDb } from "@/__testSetup__/firestoreSetup";
+import { testWithEmulator } from "@/__testUtils__/envUtils";
+
+/**
+ * URL of the `updateSMSStatus` https endpoint in the functions emulator,
+ * the same way GatewayAPI would call it (id/organization as query params).
+ */
+const getUpdateSMSStatusUrl = (params?: { id: string; organization: string }) =>
+  `http://127.0.0.1:5002/eisbuk/europe-west6/updateSMSStatus${
+    params
+      ? `?id=${encodeURIComponent(params.id)}&organization=${encodeURIComponent(
+          params.organization,
+        )}`
+      : ""
+  }`;
+
+const getSMSProcessDocPath = (organization: string, id: string) =>
+  [Collection.DeliveryQueues, organization, DeliveryQueue.SMSQueue, id].join(
+    "/",
+  );
+
+describe("updateSMSStatus", () => {
+  testWithEmulator(
+    "should store the delivery status (sent as query params + body, like GatewayAPI does) to the SMS process document",
+    async () => {
+      const organization = uuid();
+      const id = uuid();
+
+      // Set up an SMS process document (as if an SMS had been sent out)
+      const processDocRef = adminDb.doc(getSMSProcessDocPath(organization, id));
+      await processDocRef.set({ payload: { to: "+385991111111" } });
+
+      const res = await fetch(getUpdateSMSStatusUrl({ id, organization }), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "DELIVERED" }),
+      });
+      expect(res.status).toEqual(200);
+
+      const processDoc = await processDocRef.get();
+      expect(processDoc.data()?.delivery?.meta?.status).toEqual("DELIVERED");
+    },
+  );
+
+  testWithEmulator(
+    "should respond 400 (and not write anything) when id/organization query params are missing",
+    async () => {
+      const res = await fetch(getUpdateSMSStatusUrl(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "DELIVERED" }),
+      });
+      expect(res.status).toEqual(400);
+
+      // Regression: the handler used to fall through after the 400 and write
+      // a junk document to 'deliveryQueues/undefined/SMSQueue/undefined'
+      const junkDoc = await adminDb
+        .doc(getSMSProcessDocPath("undefined", "undefined"))
+        .get();
+      expect(junkDoc.exists).toEqual(false);
+    },
+  );
+
+  testWithEmulator(
+    "should respond 400 when no status is received in the request body",
+    async () => {
+      const organization = uuid();
+      const id = uuid();
+
+      const res = await fetch(getUpdateSMSStatusUrl({ id, organization }), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toEqual(400);
+
+      const processDoc = await adminDb
+        .doc(getSMSProcessDocPath(organization, id))
+        .get();
+      expect(processDoc.exists).toEqual(false);
+    },
+  );
+});

--- a/packages/client/src/store/actions/__tests__/authOperations.test.ts
+++ b/packages/client/src/store/actions/__tests__/authOperations.test.ts
@@ -75,6 +75,31 @@ describe("Auth operations", () => {
       });
     });
 
+    test("should not hang the app if the auth-status callable rejects (regression: #960 / unhandled rejection)", async () => {
+      const { dispatch, getState } = getNewStore();
+      const testThunk = updateAuthUser(testUser);
+
+      // Simulate the callable failing (network blip / cold-start timeout / 5xx)
+      mockQueryAuthStatus.mockRejectedValueOnce(
+        new Error("internal: callable failed"),
+      );
+
+      // The thunk must resolve (not reject) ...
+      await expect(
+        runThunk(testThunk, dispatch, getState),
+      ).resolves.not.toThrow();
+
+      // ... and the auth state must be marked loaded so the UI stops hanging,
+      // with the user authenticated but not (wrongly) granted admin/secret access.
+      expect(getState().auth).toEqual({
+        isAdmin: false,
+        secretKeys: [],
+        isEmpty: false,
+        isLoaded: true,
+        userData: testUser,
+      });
+    });
+
     test("should reset the state (perform local logout) if no user is received", async () => {
       // set up tests with authenticated admin
       const { dispatch, getState } = getNewStore();

--- a/packages/client/src/store/actions/__tests__/bookingOperations.test.ts
+++ b/packages/client/src/store/actions/__tests__/bookingOperations.test.ts
@@ -139,14 +139,14 @@ describe("Booking operations", () => {
         });
         // get all `bookedSlots` for customer
         const bookedSlotsForCustomer = await getDocs(
-          collection(db, getBookedSlotsPath(organization, secretKey))
+          collection(db, getBookedSlotsPath(organization, secretKey)),
         );
         // the updated `bookedSlots` should contain 2 default entries and one new (testBooking)
         expect(bookedSlotsForCustomer.docs.length).toEqual(3);
         // check the updated booking
         const updatedBooking = (
           await getDoc(
-            doc(db, getBookedSlotDocPath(organization, secretKey, bookingId))
+            doc(db, getBookedSlotDocPath(organization, secretKey, bookingId)),
           )
         ).data();
         expect(updatedBooking).toEqual({
@@ -161,9 +161,9 @@ describe("Booking operations", () => {
               interval: intervals[0],
             }),
             variant: NotifVariant.Success,
-          })
+          }),
         );
-      }
+      },
     );
 
     // testWithEmulator(
@@ -183,7 +183,7 @@ describe("Booking operations", () => {
           date: baseSlot.date,
         });
         const mockDispatch = vi.fn();
-        await runThunk(testThunk, mockDispatch, () => ({} as any), {
+        await runThunk(testThunk, mockDispatch, () => ({}) as any, {
           getFirestore,
         });
         expect(mockDispatch).toHaveBeenCalledWith(
@@ -194,9 +194,9 @@ describe("Booking operations", () => {
             }),
             variant: NotifVariant.Error,
             error: testError,
-          })
+          }),
         );
-      }
+      },
     );
   });
 
@@ -240,7 +240,7 @@ describe("Booking operations", () => {
         });
         // get all `bookedSlots` for customer
         const bookedSlotsForCustomer = await getDocs(
-          collection(db, getBookedSlotsPath(organization, secretKey))
+          collection(db, getBookedSlotsPath(organization, secretKey)),
         );
         // the updated `bookedSlots` should contain 2 default entries (with testBooking removed)
         expect(bookedSlotsForCustomer.docs.length).toEqual(2);
@@ -252,9 +252,9 @@ describe("Booking operations", () => {
               interval: intervals[0],
             }),
             variant: NotifVariant.Success,
-          })
+          }),
         );
-      }
+      },
     );
 
     testWithEmulator(
@@ -273,7 +273,7 @@ describe("Booking operations", () => {
           date: baseSlot.date,
         });
         const mockDispatch = vi.fn();
-        await runThunk(testThunk, mockDispatch, () => ({} as any), {
+        await runThunk(testThunk, mockDispatch, () => ({}) as any, {
           getFirestore,
         });
         expect(mockDispatch).toHaveBeenCalledWith(
@@ -284,9 +284,9 @@ describe("Booking operations", () => {
             }),
             variant: NotifVariant.Error,
             error: testError,
-          })
+          }),
         );
-      }
+      },
     );
   });
 
@@ -341,8 +341,8 @@ describe("Booking operations", () => {
         const updatedBooking = await getDoc(
           doc(
             db,
-            getBookedSlotDocPath(organization, saul.secretKey, testSlot.id)
-          )
+            getBookedSlotDocPath(organization, saul.secretKey, testSlot.id),
+          ),
         );
         // the updated booking should contain the same data with 'bookingNotes' added
         expect(updatedBooking.data()).toEqual({
@@ -354,9 +354,9 @@ describe("Booking operations", () => {
           enqueueNotification({
             message: i18n.t(NotificationMessage.BookingNotesUpdated),
             variant: NotifVariant.Success,
-          })
+          }),
         );
-      }
+      },
     );
 
     testWithEmulator(
@@ -376,7 +376,7 @@ describe("Booking operations", () => {
           bookingNotes: "",
         });
         const mockDispatch = vi.fn();
-        await runThunk(testThunk, mockDispatch, () => ({} as any), {
+        await runThunk(testThunk, mockDispatch, () => ({}) as any, {
           getFirestore,
         });
         expect(mockDispatch).toHaveBeenCalledWith(
@@ -384,9 +384,9 @@ describe("Booking operations", () => {
             message: i18n.t(NotificationMessage.BookingNotesError),
             variant: NotifVariant.Error,
             error: testError,
-          })
+          }),
         );
-      }
+      },
     );
   });
 
@@ -416,17 +416,17 @@ describe("Booking operations", () => {
       // Check updates
       await waitFor(async () => {
         const bookingsSnap = await getDoc(
-          doc(db, getBookingsDocPath(organization, saul.secretKey))
+          doc(db, getBookingsDocPath(organization, saul.secretKey)),
         );
         expect(bookingsSnap.data()).toEqual(
-          sanitizeCustomer({ ...saul, name: "Jimmy" })
+          sanitizeCustomer({ ...saul, name: "Jimmy" }),
         );
       });
       expect(mockDispatch).toHaveBeenCalledWith(
         enqueueNotification({
           message: i18n.t(NotificationMessage.CustomerProfileUpdated),
           variant: NotifVariant.Success,
-        })
+        }),
       );
     });
 
@@ -441,7 +441,7 @@ describe("Booking operations", () => {
         // run the thunk
         const testThunk = customerSelfUpdate(saul);
         const mockDispatch = vi.fn();
-        await runThunk(testThunk, mockDispatch, () => ({} as any), {
+        await runThunk(testThunk, mockDispatch, () => ({}) as any, {
           getFunctions,
         });
         expect(mockDispatch).toHaveBeenCalledWith(
@@ -449,9 +449,9 @@ describe("Booking operations", () => {
             message: i18n.t(NotificationMessage.CustomerProfileError),
             variant: NotifVariant.Error,
             error: testError,
-          })
+          }),
         );
-      }
+      },
     );
   });
 
@@ -466,7 +466,7 @@ describe("Booking operations", () => {
           // Set up organization 'registrationCode'
           const docRef = doc(
             db,
-            [Collection.Organizations, organization].join("/")
+            [Collection.Organizations, organization].join("/"),
           );
           await setDoc(docRef, { registrationCode }, { merge: true });
         },
@@ -483,14 +483,14 @@ describe("Booking operations", () => {
       const { id, secretKey } = await runThunk(
         testThunk,
         mockDispatch,
-        store.getState
+        store.getState,
       );
       expect(id).toBeTruthy();
       expect(secretKey).toBeTruthy();
       // Check updates
       await waitFor(async () => {
         const bookingsSnap = await getDoc(
-          doc(db, getBookingsDocPath(organization, secretKey))
+          doc(db, getBookingsDocPath(organization, secretKey)),
         );
         expect(bookingsSnap.data()).toEqual({ ...saul, id, secretKey });
       });
@@ -498,7 +498,7 @@ describe("Booking operations", () => {
         enqueueNotification({
           message: i18n.t(NotificationMessage.SelfRegSuccess),
           variant: NotifVariant.Success,
-        })
+        }),
       );
     });
 
@@ -516,7 +516,7 @@ describe("Booking operations", () => {
           registrationCode: "",
         });
         const mockDispatch = vi.fn();
-        await runThunk(testThunk, mockDispatch, () => ({} as any), {
+        await runThunk(testThunk, mockDispatch, () => ({}) as any, {
           getFunctions,
         });
         expect(mockDispatch).toHaveBeenCalledWith(
@@ -524,9 +524,62 @@ describe("Booking operations", () => {
             message: i18n.t(NotificationMessage.SelfRegError),
             variant: NotifVariant.Error,
             error: testError,
-          })
+          }),
         );
-      }
+      },
+    );
+
+    testWithEmulator(
+      "should return codeOk: false when the backend explicitly rejects the registration code",
+      async () => {
+        const invalidCodeError = Object.assign(new Error("invalid code"), {
+          code: "functions/unauthenticated",
+        });
+        const getFunctions = () => {
+          throw invalidCodeError;
+        };
+        const testThunk = customerSelfRegister({
+          ...saul,
+          registrationCode: "wrong-code",
+        });
+        const mockDispatch = vi.fn();
+        const res = await runThunk(testThunk, mockDispatch, () => ({}) as any, {
+          getFunctions,
+        });
+        expect(res.codeOk).toEqual(false);
+      },
+    );
+
+    testWithEmulator(
+      "should not blame the registration code for unrelated failures (regression: #964)",
+      async () => {
+        // e.g. a flaky network / cold start - nothing to do with the code
+        const networkError = Object.assign(new Error("deadline exceeded"), {
+          code: "functions/deadline-exceeded",
+        });
+        const getFunctions = () => {
+          throw networkError;
+        };
+        const testThunk = customerSelfRegister({
+          ...saul,
+          registrationCode: "correct-code",
+        });
+        const mockDispatch = vi.fn();
+        const res = await runThunk(testThunk, mockDispatch, () => ({}) as any, {
+          getFunctions,
+        });
+        // No misleading "invalid registration code" field error...
+        expect(res.codeOk).toEqual(true);
+        // ...but the registration did fail (no secretKey to proceed with)
+        expect(res.secretKey).toEqual("");
+        expect(mockDispatch).toHaveBeenCalledWith(
+          enqueueNotification({
+            message: i18n.t(NotificationMessage.SelfRegError),
+            variant: NotifVariant.Error,
+            error: networkError,
+          }),
+        );
+      },
     );
   });
 
@@ -557,7 +610,7 @@ describe("Booking operations", () => {
         // Check updates
         await waitFor(async () => {
           const bookingsSnap = await getDoc(
-            doc(db, getBookingsDocPath(organization, saul.secretKey))
+            doc(db, getBookingsDocPath(organization, saul.secretKey)),
           );
           expect(bookingsSnap.data()?.privacyPolicyAccepted).toEqual({
             timestamp: expect.stringContaining(timestampDate),
@@ -567,9 +620,9 @@ describe("Booking operations", () => {
           enqueueNotification({
             message: i18n.t(NotificationMessage.SelectionSaved),
             variant: NotifVariant.Success,
-          })
+          }),
         );
-      }
+      },
     );
 
     testWithEmulator(
@@ -583,7 +636,7 @@ describe("Booking operations", () => {
         // run the thunk
         const testThunk = acceptPrivacyPolicy(saul);
         const mockDispatch = vi.fn();
-        await runThunk(testThunk, mockDispatch, () => ({} as any), {
+        await runThunk(testThunk, mockDispatch, () => ({}) as any, {
           getFunctions,
         });
         expect(mockDispatch).toHaveBeenCalledWith(
@@ -591,9 +644,9 @@ describe("Booking operations", () => {
             message: i18n.t(NotificationMessage.Error),
             variant: NotifVariant.Error,
             error: testError,
-          })
+          }),
         );
-      }
+      },
     );
   });
 });

--- a/packages/client/src/store/actions/authOperations.ts
+++ b/packages/client/src/store/actions/authOperations.ts
@@ -31,14 +31,14 @@ export const signOut = (): FirestoreThunk => async (dispatch) => {
       enqueueNotification({
         message: i18n.t(NotificationMessage.LogoutSuccess),
         variant: NotifVariant.Success,
-      })
+      }),
     );
   } catch (err) {
     dispatch(
       enqueueNotification({
         message: i18n.t(NotificationMessage.LogoutError),
         variant: NotifVariant.Error,
-      })
+      }),
     );
   }
 };
@@ -50,7 +50,7 @@ export const signOut = (): FirestoreThunk => async (dispatch) => {
  */
 export const checkAuthStatus = async (
   functions: Functions,
-  authString: string
+  authString: string,
 ): Promise<AuthStatus> => {
   const organization = getOrganization();
 
@@ -64,7 +64,7 @@ export const checkAuthStatus = async (
     CloudFunction.QueryAuthStatus,
     {
       organization,
-    }
+    },
   )();
 
   return res.data;
@@ -88,18 +88,46 @@ export const updateAuthUser =
 
     const { email, phoneNumber } = user;
 
-    const authStatus = await checkAuthStatus(
-      getFunctions(),
-      email || phoneNumber || ""
-    );
+    try {
+      const authStatus = await checkAuthStatus(
+        getFunctions(),
+        email || phoneNumber || "",
+      );
 
-    dispatch({
-      type: Action.UpdateAuthInfo,
-      payload: {
-        ...authStatus,
-        userData: user,
-        isEmpty: false,
-        isLoaded: true,
-      },
-    } as AuthReducerAction<Action.UpdateAuthInfo>);
+      dispatch({
+        type: Action.UpdateAuthInfo,
+        payload: {
+          ...authStatus,
+          userData: user,
+          isEmpty: false,
+          isLoaded: true,
+        },
+      } as AuthReducerAction<Action.UpdateAuthInfo>);
+    } catch (err) {
+      // The `queryAuthStatus` callable can fail (flaky mobile network, Gen-1
+      // cold-start `deadline-exceeded`, or a backend error). Previously this
+      // rejected unhandled and, crucially, never dispatched `UpdateAuthInfo`, so
+      // the store stayed `isLoaded: false` and the app hung on the loading/login
+      // screen until a manual refresh. Instead, surface the error and mark auth as
+      // loaded (authenticated, but admin/secretKeys unknown) so the UI renders and
+      // the user can retry; the next auth-state change re-runs this check.
+      dispatch(
+        enqueueNotification({
+          message: i18n.t(NotificationMessage.Error),
+          variant: NotifVariant.Error,
+          error: err as Error,
+        }),
+      );
+
+      dispatch({
+        type: Action.UpdateAuthInfo,
+        payload: {
+          isAdmin: false,
+          secretKeys: [],
+          userData: user,
+          isEmpty: false,
+          isLoaded: true,
+        },
+      } as AuthReducerAction<Action.UpdateAuthInfo>);
+    }
   };

--- a/packages/client/src/store/actions/bookingOperations.ts
+++ b/packages/client/src/store/actions/bookingOperations.ts
@@ -26,7 +26,7 @@ import {
 import { getOrganization } from "@/lib/getters";
 
 interface UpdateBooking<
-  P extends Record<string, any> = Record<string, unknown>
+  P extends Record<string, any> = Record<string, unknown>,
 > {
   (
     payload: {
@@ -34,7 +34,7 @@ interface UpdateBooking<
       secretKey: Customer["secretKey"];
       date: string;
       interval: string;
-    } & P
+    } & P,
   ): FirestoreThunk;
 }
 
@@ -51,7 +51,7 @@ export const bookInterval: UpdateBooking =
       // update booked interval to firestore
       await setDoc(
         doc(db, getBookedSlotDocPath(getOrganization(), secretKey, slotId)),
-        { interval, date }
+        { interval, date },
       );
 
       // show success message
@@ -62,7 +62,7 @@ export const bookInterval: UpdateBooking =
             interval,
           }),
           variant: NotifVariant.Success,
-        })
+        }),
       );
     } catch (err) {
       dispatch(
@@ -73,7 +73,7 @@ export const bookInterval: UpdateBooking =
           }),
           variant: NotifVariant.Error,
           error: err as Error,
-        })
+        }),
       );
     }
   };
@@ -89,7 +89,7 @@ export const cancelBooking: UpdateBooking =
 
       // remove the booking from firestore
       await deleteDoc(
-        doc(db, getBookedSlotDocPath(getOrganization(), secretKey, slotId))
+        doc(db, getBookedSlotDocPath(getOrganization(), secretKey, slotId)),
       );
 
       // show success message
@@ -100,7 +100,7 @@ export const cancelBooking: UpdateBooking =
             interval,
           }),
           variant: NotifVariant.Success,
-        })
+        }),
       );
     } catch (err) {
       dispatch(
@@ -111,7 +111,7 @@ export const cancelBooking: UpdateBooking =
           }),
           variant: NotifVariant.Error,
           error: err as Error,
-        })
+        }),
       );
     }
   };
@@ -128,7 +128,7 @@ export const updateBookingNotes: UpdateBooking<{ bookingNotes: string }> =
 
       const bookingDocRef = doc(
         db,
-        getBookedSlotDocPath(organization, secretKey, slotId)
+        getBookedSlotDocPath(organization, secretKey, slotId),
       );
 
       await setDoc(bookingDocRef, { ...booking, bookingNotes });
@@ -137,7 +137,7 @@ export const updateBookingNotes: UpdateBooking<{ bookingNotes: string }> =
         enqueueNotification({
           variant: NotifVariant.Success,
           message: i18n.t(NotificationMessage.BookingNotesUpdated),
-        })
+        }),
       );
     } catch (err) {
       dispatch(
@@ -145,7 +145,7 @@ export const updateBookingNotes: UpdateBooking<{ bookingNotes: string }> =
           variant: NotifVariant.Error,
           message: i18n.t(NotificationMessage.BookingNotesError),
           error: err as Error,
-        })
+        }),
       );
     }
   };
@@ -175,7 +175,7 @@ export const customerSelfUpdate: {
         enqueueNotification({
           variant: NotifVariant.Success,
           message: i18n.t(NotificationMessage.CustomerProfileUpdated),
-        })
+        }),
       );
     } catch (err) {
       dispatch(
@@ -183,13 +183,15 @@ export const customerSelfUpdate: {
           variant: NotifVariant.Error,
           message: i18n.t(NotificationMessage.CustomerProfileError),
           error: err as Error,
-        })
+        }),
       );
     }
   };
 
 export const customerSelfRegister: {
-  (paylod: CustomerBase & { registrationCode: string }): (
+  (
+    paylod: CustomerBase & { registrationCode: string },
+  ): (
     ...params: Parameters<FirestoreThunk>
   ) => Promise<{ id: string; secretKey: string; codeOk: boolean }>;
 } =
@@ -212,7 +214,7 @@ export const customerSelfRegister: {
       const res = await createFunctionCaller(
         getFunctions(),
         handler,
-        payload
+        payload,
       )();
       const { id, secretKey } = res.data;
 
@@ -220,7 +222,7 @@ export const customerSelfRegister: {
         enqueueNotification({
           variant: NotifVariant.Success,
           message: i18n.t(NotificationMessage.SelfRegSuccess),
-        })
+        }),
       );
       return {
         id,
@@ -233,9 +235,16 @@ export const customerSelfRegister: {
           variant: NotifVariant.Error,
           message: i18n.t(NotificationMessage.SelfRegError),
           error: err as Error,
-        })
+        }),
       );
-      return { id: "", secretKey: "", codeOk: false };
+      // Only report the registration code as wrong when the backend explicitly
+      // rejected it ('unauthenticated'). For any other failure (network,
+      // backend error, ...) returning codeOk: false would show a misleading
+      // "invalid registration code" field error and send the athlete chasing
+      // a code that is in fact correct.
+      const isInvalidCode =
+        (err as { code?: string })?.code === "functions/unauthenticated";
+      return { id: "", secretKey: "", codeOk: !isInvalidCode };
     }
   };
 
@@ -268,7 +277,7 @@ export const acceptPrivacyPolicy: {
         enqueueNotification({
           variant: NotifVariant.Success,
           message: i18n.t(NotificationMessage.SelectionSaved),
-        })
+        }),
       );
     } catch (err) {
       dispatch(
@@ -276,7 +285,7 @@ export const acceptPrivacyPolicy: {
           variant: NotifVariant.Error,
           message: i18n.t(NotificationMessage.Error),
           error: err as Error,
-        })
+        }),
       );
     }
   };

--- a/packages/client/src/store/selectors/attendance/__tests__/attendance.test.ts
+++ b/packages/client/src/store/selectors/attendance/__tests__/attendance.test.ts
@@ -12,7 +12,10 @@ import {
   getBookedIntervalsCustomers,
 } from "../slotAttendance";
 
-import { processAttendances } from "../attendanceVariance";
+import {
+  processAttendances,
+  getMonthAttendanceVariance,
+} from "../attendanceVariance";
 
 import { getNewStore } from "@/store/createStore";
 
@@ -44,6 +47,36 @@ describe("Selectors ->", () => {
     test("should get slots for current day (read from store) with customers attendance (sorted by booked interval) data for each slot", () => {
       const res = getSlotsWithAttendance(testStore.getState());
       expect(res).toEqual(expectedStruct);
+    });
+
+    test("should not crash when a slot has no attendance doc (regression: #832, missing/lagging attendance trigger)", () => {
+      const dateISO = testDateLuxon.toISODate();
+      const monthStr = dateISO.substring(0, 7);
+      const slot = {
+        ...baseSlot,
+        id: "slot-without-attendance",
+        date: dateISO,
+      };
+
+      const store = getNewStore({
+        firestore: {
+          data: {
+            // Slot exists for the current day...
+            slotsByDay: { [monthStr]: { [dateISO]: { [slot.id]: slot } } },
+            // ...but there's no attendance/{slotId} doc for it.
+            attendance: {},
+            customers: {},
+          },
+        },
+        app: {
+          calendarDay: testDateLuxon,
+        },
+      });
+
+      expect(() => getSlotsWithAttendance(store.getState())).not.toThrow();
+      const res = getSlotsWithAttendance(store.getState());
+      expect(res).toHaveLength(1);
+      expect(res[0].customers).toEqual([]);
     });
   });
 
@@ -232,6 +265,25 @@ describe("Selectors ->", () => {
         },
       ],
     ]);
+  });
+
+  test("'getMonthAttendanceVariance' should not crash when the month has no slotsByDay entry (regression: #832 / Object.values(undefined))", () => {
+    const store = getNewStore({
+      firestore: {
+        data: {
+          attendance: {},
+          customers: {},
+          // No entry for the viewed month (not loaded yet, or no slots).
+          slotsByDay: {},
+        },
+      },
+      app: {
+        calendarDay: testDateLuxon,
+      },
+    });
+
+    expect(() => getMonthAttendanceVariance(store.getState())).not.toThrow();
+    expect(getMonthAttendanceVariance(store.getState())).toEqual([]);
   });
 
   describe("Test 'getBookedIntervalsCustomers'", () => {

--- a/packages/client/src/store/selectors/attendance/attendanceVariance.ts
+++ b/packages/client/src/store/selectors/attendance/attendanceVariance.ts
@@ -37,7 +37,7 @@ export const processAttendances = (
   attendance: Attendance,
   slots: Slots,
   customers: Customers,
-  month: string,
+  month: string
 ) =>
   wrapIter(Object.entries(attendance))
     // Get only current month's attendance
@@ -46,8 +46,8 @@ export const processAttendances = (
     .flatMap(([slotId, { date, attendances }]) =>
       // { customerId => attendanceIntervals } pairs
       Object.entries(attendances).map(
-        valueMapper(mergeMapper({ date, slotType: slots[slotId].type })),
-      ),
+        valueMapper(mergeMapper({ date, slotType: slots[slotId].type }))
+      )
     )
     // { customerId => attendanceDurations } pairs
     .map(valueMapper(convertIntervalsToDurations))
@@ -66,7 +66,7 @@ export const processAttendances = (
     .map(keyMapper(joinCustomerName));
 
 export const getMonthAttendanceVariance = (
-  state: LocalStore,
+  state: LocalStore
 ): AthleteAttendanceMonth[] => {
   const { app, firestore } = state;
   const { calendarDay } = app;
@@ -75,12 +75,13 @@ export const getMonthAttendanceVariance = (
   const currentMonth = getMonthStr(calendarDay, 0);
   const slots = Object.fromEntries(
     flatMap(
-      // `slotsByDay` is defaulted to `{}` above, so it is always truthy; the month
-      // entry itself can be missing (month not loaded yet, or no slots that month),
-      // in which case `Object.values(undefined)` would throw.
-      Object.values(slotsByDay[currentMonth] || {}),
-      (slots) => Object.entries(slots),
-    ),
+      // The `= {}` destructuring default above only covers `undefined`, not `null`
+      // (which the store type allows); the month entry itself can also be missing
+      // (month not loaded yet, or no slots that month), in which case
+      // `Object.values(undefined)` would throw.
+      Object.values(slotsByDay?.[currentMonth] || {}),
+      (slots) => Object.entries(slots)
+    )
   );
 
   return processAttendances(attendance, slots, customers, currentMonth);
@@ -97,14 +98,12 @@ export const filterAttendanceByMonth =
 
 export const replaceCustomerIdWithName =
   (customerLookup: Customers) =>
-  (id: string): CustomerNameTuple => [
-    customerLookup[id].surname,
-    customerLookup[id].name,
-  ];
+  (id: string): CustomerNameTuple =>
+    [customerLookup[id].surname, customerLookup[id].name];
 
 const compareCustomerNames = (
   [[a]]: [CustomerNameTuple, any],
-  [[b]]: [CustomerNameTuple, any],
+  [[b]]: [CustomerNameTuple, any]
 ) => (a > b ? 1 : -1);
 
 const joinCustomerName = (customer: CustomerNameTuple) => customer.join(" ");
@@ -131,7 +130,7 @@ const datePairFromAttendance = <A extends { date: string }>({
 
 const aggregateAttendance = (
   acc: AttendanceBySlotType,
-  { slotType, booked, attended }: AttendanceDurationsWithType,
+  { slotType, booked, attended }: AttendanceDurationsWithType
 ) => ({
   ...acc,
   [slotType]: {
@@ -141,7 +140,7 @@ const aggregateAttendance = (
 });
 
 const aggregateAttendanceEntries = (
-  attendances: Iterable<AttendanceDurationsWithType>,
+  attendances: Iterable<AttendanceDurationsWithType>
 ): AttendanceBySlotType =>
   _reduce(attendances, aggregateAttendance, {
     [SlotType.Ice]: { booked: 0, attended: 0 },
@@ -149,7 +148,7 @@ const aggregateAttendanceEntries = (
   });
 
 const aggregateAttendanceByDate = (
-  attendances: Iterable<DateAttendancePair<AttendanceDurationsWithType>>,
+  attendances: Iterable<DateAttendancePair<AttendanceDurationsWithType>>
 ): AttendanceByDate =>
   wrapIter(attendances)
     // Group each pair by date:

--- a/packages/client/src/store/selectors/attendance/attendanceVariance.ts
+++ b/packages/client/src/store/selectors/attendance/attendanceVariance.ts
@@ -37,7 +37,7 @@ export const processAttendances = (
   attendance: Attendance,
   slots: Slots,
   customers: Customers,
-  month: string
+  month: string,
 ) =>
   wrapIter(Object.entries(attendance))
     // Get only current month's attendance
@@ -46,8 +46,8 @@ export const processAttendances = (
     .flatMap(([slotId, { date, attendances }]) =>
       // { customerId => attendanceIntervals } pairs
       Object.entries(attendances).map(
-        valueMapper(mergeMapper({ date, slotType: slots[slotId].type }))
-      )
+        valueMapper(mergeMapper({ date, slotType: slots[slotId].type })),
+      ),
     )
     // { customerId => attendanceDurations } pairs
     .map(valueMapper(convertIntervalsToDurations))
@@ -66,7 +66,7 @@ export const processAttendances = (
     .map(keyMapper(joinCustomerName));
 
 export const getMonthAttendanceVariance = (
-  state: LocalStore
+  state: LocalStore,
 ): AthleteAttendanceMonth[] => {
   const { app, firestore } = state;
   const { calendarDay } = app;
@@ -75,9 +75,12 @@ export const getMonthAttendanceVariance = (
   const currentMonth = getMonthStr(calendarDay, 0);
   const slots = Object.fromEntries(
     flatMap(
-      Object.values(slotsByDay ? slotsByDay[currentMonth] : {}),
-      (slots) => Object.entries(slots)
-    )
+      // `slotsByDay` is defaulted to `{}` above, so it is always truthy; the month
+      // entry itself can be missing (month not loaded yet, or no slots that month),
+      // in which case `Object.values(undefined)` would throw.
+      Object.values(slotsByDay[currentMonth] || {}),
+      (slots) => Object.entries(slots),
+    ),
   );
 
   return processAttendances(attendance, slots, customers, currentMonth);
@@ -94,12 +97,14 @@ export const filterAttendanceByMonth =
 
 export const replaceCustomerIdWithName =
   (customerLookup: Customers) =>
-  (id: string): CustomerNameTuple =>
-    [customerLookup[id].surname, customerLookup[id].name];
+  (id: string): CustomerNameTuple => [
+    customerLookup[id].surname,
+    customerLookup[id].name,
+  ];
 
 const compareCustomerNames = (
   [[a]]: [CustomerNameTuple, any],
-  [[b]]: [CustomerNameTuple, any]
+  [[b]]: [CustomerNameTuple, any],
 ) => (a > b ? 1 : -1);
 
 const joinCustomerName = (customer: CustomerNameTuple) => customer.join(" ");
@@ -126,7 +131,7 @@ const datePairFromAttendance = <A extends { date: string }>({
 
 const aggregateAttendance = (
   acc: AttendanceBySlotType,
-  { slotType, booked, attended }: AttendanceDurationsWithType
+  { slotType, booked, attended }: AttendanceDurationsWithType,
 ) => ({
   ...acc,
   [slotType]: {
@@ -136,7 +141,7 @@ const aggregateAttendance = (
 });
 
 const aggregateAttendanceEntries = (
-  attendances: Iterable<AttendanceDurationsWithType>
+  attendances: Iterable<AttendanceDurationsWithType>,
 ): AttendanceBySlotType =>
   _reduce(attendances, aggregateAttendance, {
     [SlotType.Ice]: { booked: 0, attended: 0 },
@@ -144,7 +149,7 @@ const aggregateAttendanceEntries = (
   });
 
 const aggregateAttendanceByDate = (
-  attendances: Iterable<DateAttendancePair<AttendanceDurationsWithType>>
+  attendances: Iterable<DateAttendancePair<AttendanceDurationsWithType>>,
 ): AttendanceByDate =>
   wrapIter(attendances)
     // Group each pair by date:

--- a/packages/client/src/store/selectors/attendance/slotAttendance.ts
+++ b/packages/client/src/store/selectors/attendance/slotAttendance.ts
@@ -20,7 +20,7 @@ import { getCustomerById } from "../customers";
  * @returns
  */
 export const getSlotsWithAttendance = (
-  state: LocalStore
+  state: LocalStore,
 ): Omit<AttendanceCardProps, "allCustomers">[] => {
   const slotsByDay = getSlotsByMonth(state);
   const {
@@ -56,9 +56,12 @@ export const getSlotsWithAttendance = (
     .map(({ id }) => id);
 
   return slotIds.map((slotId) => {
-    const slotsAttendance = attendance[slotId]?.attendances;
+    // A slot can be missing its `attendance/{slotId}` doc (trigger lag/miss, or
+    // initial load), in which case `attendances` is undefined and `Object.keys`
+    // would throw. Fall back to an empty record.
+    const slotsAttendance = attendance[slotId]?.attendances ?? {};
     const customers: AttendanceCardProps["customers"] = Object.keys(
-      slotsAttendance
+      slotsAttendance,
     )
       .map((customerId) => ({
         ...allCustomers[customerId],
@@ -113,7 +116,7 @@ export const getBookedIntervalsCustomers =
           ],
         };
       },
-      {}
+      {},
     );
     return customersWhoBooked;
   };

--- a/packages/client/src/store/selectors/bookings/__tests__/bookings.test.ts
+++ b/packages/client/src/store/selectors/bookings/__tests__/bookings.test.ts
@@ -192,9 +192,9 @@ describe("Selectors ->", () => {
             slotsByDay: { [currentMonthString]: slotsByDay },
           });
           expect(
-            getMonthEmptyForBooking(saul.secretKey)(store.getState())
+            getMonthEmptyForBooking(saul.secretKey)(store.getState()),
           ).toEqual(wantRes);
-        })
+        }),
       );
 
     runTableTests([
@@ -279,7 +279,7 @@ describe("Selectors ->", () => {
             interval: bookedIntervalKey,
             bookingNotes,
           },
-        })
+        }),
       );
       expect(getBookingsForCalendar(store.getState())).toEqual([
         {
@@ -289,6 +289,86 @@ describe("Selectors ->", () => {
           bookingNotes,
         },
       ]);
+    });
+
+    test("should skip bookings whose slot no longer exists on that day, without crashing (regression: #816 / ghost slots #966)", () => {
+      const monthStr = "2022-01";
+      const day = "2022-01-01";
+
+      // A real slot that still exists for the day
+      const liveSlot = {
+        ...baseSlot,
+        id: "live-slot",
+        categories: [Category.Competitive],
+        date: day,
+      };
+
+      const store = setupBookingsTest({
+        category: Category.Competitive,
+        date: DateTime.fromISO(day),
+        slotsByDay: {
+          [monthStr]: {
+            [day]: { [liveSlot.id]: liveSlot },
+          },
+        },
+      });
+
+      const intervalKey = Object.keys(baseSlot.intervals)[0];
+
+      // Two bookings: one for the live slot and one for a slot that has been
+      // deleted (its id is absent from slotsByDay even though the day exists).
+      // The dangling one used to crash on `bookedSlot.intervals[...]`.
+      store.dispatch(
+        updateLocalDocuments(BookingSubCollection.BookedSlots, {
+          [liveSlot.id]: { date: day, interval: intervalKey },
+          "deleted-slot": { date: day, interval: intervalKey },
+        }),
+      );
+
+      const res = getBookingsForCalendar(store.getState());
+      expect(res).toHaveLength(1);
+      expect(res[0].id).toEqual(liveSlot.id);
+    });
+
+    test("getBookedAndAttendedSlotsForCalendar should skip booked/attended slots whose slot no longer exists, without crashing", () => {
+      const monthStr = "2022-01";
+      const day = "2022-01-01";
+
+      const liveSlot = {
+        ...baseSlot,
+        id: "live-slot",
+        categories: [Category.Competitive],
+        date: day,
+      };
+
+      const store = setupBookingsTest({
+        category: Category.Competitive,
+        date: DateTime.fromISO(day),
+        slotsByDay: {
+          [monthStr]: {
+            [day]: { [liveSlot.id]: liveSlot },
+          },
+        },
+      });
+
+      const intervalKey = Object.keys(baseSlot.intervals)[0];
+
+      store.dispatch(
+        updateLocalDocuments(BookingSubCollection.BookedSlots, {
+          [liveSlot.id]: { date: day, interval: intervalKey },
+          "deleted-booked": { date: day, interval: intervalKey },
+        }),
+      );
+      store.dispatch(
+        updateLocalDocuments(BookingSubCollection.AttendedSlots, {
+          "deleted-attended": { date: day, interval: intervalKey },
+        }),
+      );
+
+      const ids = getBookedAndAttendedSlotsForCalendar(store.getState()).map(
+        ({ id }) => id,
+      );
+      expect(ids).toEqual([liveSlot.id]);
     });
 
     test("should sort the slots (by date, and by time intraday)", () => {
@@ -374,7 +454,7 @@ describe("Selectors ->", () => {
             // Regerdless of this not being the last interval, this slot should appear last as the date sorting takes precenence
             interval: "09:00-10:00",
           },
-        })
+        }),
       );
       // Second slot should be attended, not booked to verify that the final result sorts all results, regerdless of the booked state
       store.dispatch(
@@ -384,12 +464,12 @@ describe("Selectors ->", () => {
             // Second interval (we want this slot to appear 2nd - be merged with the booked slots, and then sorted)
             interval: "10:00-11:00",
           },
-        })
+        }),
       );
 
       // It's enough to just check that the ids appear in the desired order
       const ids = getBookedAndAttendedSlotsForCalendar(store.getState()).map(
-        ({ id }) => id
+        ({ id }) => id,
       );
       expect(ids).toEqual(["slot-1", "slot-2", "slot-3", "slot-4"]);
     });

--- a/packages/client/src/store/selectors/bookings/slots.ts
+++ b/packages/client/src/store/selectors/bookings/slots.ts
@@ -22,7 +22,7 @@ import { isEmpty } from "@/utils/helpers";
  * @returns record of subscribed slots
  */
 export const getBookedSlots = (
-  state: LocalStore
+  state: LocalStore,
 ): Record<string, CustomerBookingEntry> =>
   state.firestore.data?.bookedSlots || {};
 /**
@@ -31,7 +31,7 @@ export const getBookedSlots = (
  * @returns record of subscribed slots
  */
 export const getAttendedSlots = (
-  state: LocalStore
+  state: LocalStore,
 ): Record<string, Omit<CustomerBookingEntry, "bookingNotes">> =>
   state.firestore.data?.attendedSlots || {};
 
@@ -49,7 +49,7 @@ export const getSlotsForBooking =
 
     // Sort dates so that the final output is sorted
     const daysToRender = Object.keys(slotsMonth).sort((a, b) =>
-      a < b ? -1 : 1
+      a < b ? -1 : 1,
     );
     if (!daysToRender.length || !customerData) {
       return [];
@@ -68,7 +68,7 @@ export const getSlotsForBooking =
           // If slot booked add interval to the return structure
           bookedSlots[slot.id]
             ? { ...slot, interval: bookedSlots[slot.id].interval }
-            : slot
+            : slot,
         ),
     }));
   };
@@ -108,11 +108,11 @@ export const getSlotsForCustomer =
       .map(valueMapper((slots) => Object.entries(slots)))
       // FlatMap: [date, [slotId, SlotInterface][]] -> [date, slotId, SlotInterface]
       .flatMap(([date, slots]) =>
-        slots.map(([id, slot]) => [date, id, slot] as const)
+        slots.map(([id, slot]) => [date, id, slot] as const),
       )
       // Filter out slots not matching customer's category
       .filter(([, , slot]) =>
-        categories.some((c) => slot.categories.includes(c))
+        categories.some((c) => slot.categories.includes(c)),
       )
       // Filter out slots booked at full capacity (or without any capacity set)
       .filter(
@@ -124,12 +124,12 @@ export const getSlotsForCustomer =
           !bookingCountsForAMonth[slotId] ||
           !slot.capacity ||
           slot.capacity > bookingCountsForAMonth[slotId] ||
-          Boolean(bookedSlots[slotId])
+          Boolean(bookedSlots[slotId]),
       )
       // GroupEntries by date: [date, [slotId, SlotInterface][]]
       ._group(
         ([date, id, slot]) =>
-          [date, [id, slot]] as [string, [string, SlotInterface]]
+          [date, [id, slot]] as [string, [string, SlotInterface]],
       )
       // Map the value: [date, [slotId, SlotInterface][]] -> [date, SlotsById]
       .map(valueMapper((slots) => Object.fromEntries(slots)));
@@ -162,8 +162,11 @@ export const getBookingsForCalendar = (state: LocalStore): BookingsList => {
     .filter(([, { date }]) => Boolean(slotsForAMonth[date]))
     .reduce(
       (acc, [slotId, { date, interval: bookedInterval, bookingNotes }]) => {
-        // If this returns undefined, our slot isn't in date range
+        // The slot may no longer exist on that day (slot deleted, or its date/
+        // intervals changed after the athlete booked it). Skip dangling bookings
+        // instead of crashing on `bookedSlot.intervals`.
         const bookedSlot = slotsForAMonth[date][slotId];
+        if (!bookedSlot) return acc;
         const interval = bookedSlot.intervals[bookedInterval];
         return [
           ...acc,
@@ -175,7 +178,7 @@ export const getBookingsForCalendar = (state: LocalStore): BookingsList => {
           } as BookingsEntry,
         ];
       },
-      [] as BookingsList
+      [] as BookingsList,
     )
     .sort((a, b) => (a.date < b.date ? -1 : 1));
 };
@@ -190,7 +193,7 @@ type CalendarSlotEntry = SlotInterface & {
 type CalendarSlotList = CalendarSlotEntry[];
 
 export const getBookedAndAttendedSlotsForCalendar = (
-  state: LocalStore
+  state: LocalStore,
 ): CalendarSlotList => {
   // Current month in view is determined by `currentDate` in Redux store
   const monthString = getCalendarDay(state).toISO().substring(0, 7);
@@ -211,6 +214,8 @@ export const getBookedAndAttendedSlotsForCalendar = (
       }
 
       const attendedSlot = dayOfAttendedSlot[slotId];
+      // Skip if the slot no longer exists on that day (deleted/changed slot)
+      if (!attendedSlot) return acc;
       const interval = attendedSlot.intervals[attendedInterval];
       const completeAttendanceEntry = {
         ...attendedSlot,
@@ -219,7 +224,7 @@ export const getBookedAndAttendedSlotsForCalendar = (
       };
       return [...acc, completeAttendanceEntry];
     },
-    [] as CalendarSlotList
+    [] as CalendarSlotList,
   );
   const bookedSlotsObj = Object.entries(bookedSlots).reduce(
     (acc, [slotId, { date, interval: bookedInterval, bookingNotes }]) => {
@@ -230,6 +235,8 @@ export const getBookedAndAttendedSlotsForCalendar = (
       }
 
       const bookedSlot = dayOfBookedSlot[slotId];
+      // Skip if the slot no longer exists on that day (deleted/changed slot)
+      if (!bookedSlot) return acc;
       const interval = bookedSlot.intervals[bookedInterval];
       const completeBookingEntry = {
         ...bookedSlot,
@@ -239,7 +246,7 @@ export const getBookedAndAttendedSlotsForCalendar = (
       };
       return [...acc, completeBookingEntry];
     },
-    [] as CalendarSlotList
+    [] as CalendarSlotList,
   );
   return [...attendedSlotsObj, ...bookedSlotsObj].sort(compareCalendarSlots);
 };
@@ -248,7 +255,7 @@ const compareCalendarSlots = (a: CalendarSlotEntry, b: CalendarSlotEntry) =>
   a.date < b.date
     ? -1
     : a.date > b.date
-    ? 1
-    : a.interval.startTime < b.interval.startTime
-    ? -1
-    : 1;
+      ? 1
+      : a.interval.startTime < b.interval.startTime
+        ? -1
+        : 1;

--- a/packages/functions/src/constants.ts
+++ b/packages/functions/src/constants.ts
@@ -1,5 +1,7 @@
 import * as Sentry from "@sentry/serverless";
 
+import { scrubPII } from "@eisbuk/shared";
+
 export const __functionsZone__ = "europe-west6";
 export const __projectId__ = process.env.PROJECT_ID;
 export const __smsUrl__ = "https://gatewayapi.com/rest/mtsms";
@@ -15,5 +17,16 @@ if (__enableSentry__) {
     dsn: __sentryDSN__,
     release: __sentryRelease__,
     tracesSampleRate: 1.0,
+    // Strip athletes' personal data (callable request bodies, trigger context,
+    // caller IP) before events leave the process. Default server-side scrubbing
+    // only catches key names like 'password', so customer fields (name,
+    // surname, birthday, email, phone - many belonging to minors) would
+    // otherwise be persisted in the error tracker verbatim.
+    beforeSend: (event) => {
+      if (event.request) event.request = scrubPII(event.request);
+      if (event.user) event.user = scrubPII(event.user);
+      if (event.extra) event.extra = scrubPII(event.extra);
+      return event;
+    },
   });
 }

--- a/packages/functions/src/dataTriggers.ts
+++ b/packages/functions/src/dataTriggers.ts
@@ -38,13 +38,13 @@ export const addIdToSlot = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`,
   )
   .onCreate(
     wrapFirestoreOnCreateHandler("addIdToSlot", async ({ ref }, context) => {
       const { slotId } = context.params as Record<string, string>;
       ref.update({ id: slotId });
-    })
+    }),
   );
 
 /**
@@ -61,7 +61,7 @@ export const addCustomerIdAndSecretKey = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Customers}/{customerId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Customers}/{customerId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -98,7 +98,7 @@ export const addCustomerIdAndSecretKey = functions
               id: customerId,
               secretKey,
             } as Pick<Customer, "id" | "secretKey">,
-            { merge: true }
+            { merge: true },
           );
         }
 
@@ -111,12 +111,12 @@ export const addCustomerIdAndSecretKey = functions
         // create/update booking entry
         batch.set(
           orgRef.collection(OrgSubCollection.Bookings).doc(secretKey),
-          customer
+          customer,
         );
 
         await batch.commit();
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -132,7 +132,7 @@ export const triggerAttendanceEntryForSlot = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -148,24 +148,37 @@ export const triggerAttendanceEntryForSlot = functions
         const isCreate = !change.before.exists;
         const isDelete = !change.after.exists;
 
-        const attendanceEntryRef = db
+        const orgRef = db
           .collection(Collection.Organizations)
-          .doc(organization)
+          .doc(organization);
+        const attendanceEntryRef = orgRef
           .collection(OrgSubCollection.Attendance)
           .doc(slotId);
+        const slotRef = orgRef.collection(OrgSubCollection.Slots).doc(slotId);
 
         switch (true) {
           case isCreate:
-            // check if attendance entry already exists (in case we're dumping/restoring the data)
-            const { exists } = await attendanceEntryRef.get();
-            if (exists) {
-              return;
-            }
-            // add empty entry for slot's attendance
-            await attendanceEntryRef.set({
-              date: change.after.data()!.date,
-              attendances: {},
-            } as SlotAttendnace);
+            // Firestore triggers are at-least-once and unordered: when a slot is
+            // created and deleted in quick succession, this create event can be
+            // processed *after* the delete event, which would resurrect the
+            // attendance entry as an orphan. Re-read the slot inside a
+            // transaction and only create the entry if the slot still exists.
+            await db.runTransaction(async (tx) => {
+              const slotSnap = await tx.get(slotRef);
+              if (!slotSnap.exists) {
+                return;
+              }
+              // check if attendance entry already exists (in case we're dumping/restoring the data)
+              const attendanceSnap = await tx.get(attendanceEntryRef);
+              if (attendanceSnap.exists) {
+                return;
+              }
+              // add empty entry for slot's attendance
+              tx.set(attendanceEntryRef, {
+                date: slotSnap.data()!.date,
+                attendances: {},
+              } as SlotAttendnace);
+            });
             break;
           case isDelete:
             // delete attendance entry for slot
@@ -175,8 +188,8 @@ export const triggerAttendanceEntryForSlot = functions
             // exit if slot was just updated
             return;
         }
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -191,7 +204,7 @@ export const aggregateSlots = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler("aggregateSlots", async (change, context) => {
@@ -202,78 +215,103 @@ export const aggregateSlots = functions
 
       const db = admin.firestore();
 
-      let date: string;
-      let newSlot: SlotInterface | FirebaseFirestore.FieldValue;
-
-      const isCreate = !change.before.exists;
-      const isDelete = !change.after.exists;
-
       const deleteSentinel = admin.firestore.FieldValue.delete();
 
-      switch (true) {
-        case isDelete:
-          // if deleting, we're just setting slot value as delete sentinel and getting the date from before
-          const beforeData = change.before.data() as SlotInterface;
-          date = beforeData.date;
-          newSlot = deleteSentinel;
-          break;
-        case isCreate:
-          // if creating, we're only using the new (after data) and adding generated id
-          const afterData = change.after.data()! as Omit<SlotInterface, "id">;
-          newSlot = { ...afterData, id };
-          date = newSlot.date;
-          break;
-        default:
-          // if not change or create: is update
-          const { intervals: newIntervals, ...updatedData } =
-            change.after.data() as Omit<SlotInterface, "id">;
-          const { intervals: oldIntervals } = change.before.data() as Omit<
-            SlotInterface,
-            "id"
-          >;
+      const orgRef = db.collection(Collection.Organizations).doc(organization);
+      const slotRef = orgRef.collection(OrgSubCollection.Slots).doc(id);
+      const getMonthRef = (date: string) =>
+        orgRef
+          .collection(OrgSubCollection.SlotsByDay)
+          .doc(date.substring(0, 7));
 
-          // we're using {merge: true} flag for setting the document so
-          // we need to process intervals in order to make sure the old intervals get deleted
-          // and only the updated values remain (prevent merging of the old values with the new)
-          const deletedIntervals = Object.keys(oldIntervals).reduce(
-            (acc, intervalString) => ({
-              ...acc,
-              [intervalString]: deleteSentinel,
-            }),
-            {} as Record<string, typeof deleteSentinel>
+      const beforeData = change.before.data() as SlotInterface | undefined;
+      const eventDate = (change.after.data() || change.before.data())!
+        .date as string;
+
+      // Firestore triggers are at-least-once and unordered: when a slot is
+      // created (or updated) and deleted within a short period, this handler can
+      // process the create event *after* the delete event, overwriting the
+      // delete sentinel and resurrecting the slot in the (publicly readable)
+      // aggregate - a "ghost" slot athletes see but can never book, and which
+      // the admin can't remove (deleting the already-absent slot doc fires no
+      // trigger). Instead of trusting the event snapshot, re-read the slot
+      // inside a transaction and write the aggregate from current truth.
+      await db.runTransaction(async (tx) => {
+        const currentSlot = await tx.get(slotRef);
+
+        if (!currentSlot.exists) {
+          // Slot is gone (delete event, or a stale create/update event arriving
+          // after deletion): remove the aggregate entry wherever the event saw it
+          tx.set(
+            getMonthRef(eventDate),
+            { [eventDate]: { [id]: deleteSentinel } },
+            { merge: true },
           );
-          const updatedIntervals = Object.keys(newIntervals).reduce(
-            (acc, intervalString) => ({
-              ...acc,
-              [intervalString]: newIntervals[intervalString],
-            }),
-            {} as Record<string, SlotInterval>
+          // If the event also saw an older date (date-edit), clear that location too
+          if (beforeData && beforeData.date !== eventDate) {
+            tx.set(
+              getMonthRef(beforeData.date),
+              { [beforeData.date]: { [id]: deleteSentinel } },
+              { merge: true },
+            );
+          }
+          return;
+        }
+
+        const { intervals: newIntervals, ...updatedData } =
+          currentSlot.data() as Omit<SlotInterface, "id">;
+        const date = updatedData.date;
+
+        // we're using {merge: true} flag for setting the document so
+        // we need to process intervals in order to make sure the old intervals get deleted
+        // and only the updated values remain (prevent merging of the old values with the new)
+        const deletedIntervals = Object.keys(
+          beforeData?.intervals || {},
+        ).reduce(
+          (acc, intervalString) => ({
+            ...acc,
+            [intervalString]: deleteSentinel,
+          }),
+          {} as Record<string, typeof deleteSentinel>,
+        );
+        const updatedIntervals = Object.keys(newIntervals).reduce(
+          (acc, intervalString) => ({
+            ...acc,
+            [intervalString]: newIntervals[intervalString],
+          }),
+          {} as Record<string, SlotInterval>,
+        );
+
+        // we're merging old intervals as delete sentinels and new intervals as they are
+        // this way old intervals get deleted and in case some interval should stay (wasn't changed/deleted),
+        // the delete sentinel gets overwritten with the new value
+        const intervals = {
+          ...deletedIntervals,
+          ...updatedIntervals,
+        } as Record<string, SlotInterval>;
+
+        const newSlot = { ...updatedData, intervals, id } as SlotInterface;
+
+        // If the slot's date was edited, remove the aggregate entry from the old
+        // date/month (previously the old entry was left behind, duplicating the
+        // slot across months)
+        if (beforeData && beforeData.date !== date) {
+          tx.set(
+            getMonthRef(beforeData.date),
+            { [beforeData.date]: { [id]: deleteSentinel } },
+            { merge: true },
           );
+        }
 
-          // we're merging old intervals as delete sentinels and new intervals as they are
-          // this way old intervals get deleted and in case some interval should stay (wasn't changed/deleted),
-          // the delete sentinel gets overwritten with the new value
-          const intervals = {
-            ...deletedIntervals,
-            ...updatedIntervals,
-          } as Record<string, SlotInterval>;
-
-          newSlot = { ...updatedData, intervals, id };
-          date = newSlot.date;
-      }
-
-      const monthStr = date.substring(0, 7);
-
-      const monthSlotsRef = db
-        .collection(Collection.Organizations)
-        .doc(organization)
-        .collection(OrgSubCollection.SlotsByDay)
-        .doc(monthStr);
-
-      await monthSlotsRef.set({ [date]: { [id]: newSlot } }, { merge: true });
+        tx.set(
+          getMonthRef(date),
+          { [date]: { [id]: newSlot } },
+          { merge: true },
+        );
+      });
 
       return change.after;
-    })
+    }),
   );
 
 export const countSlotsBookings = functions
@@ -282,7 +320,7 @@ export const countSlotsBookings = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -316,8 +354,8 @@ export const countSlotsBookings = functions
         data[bookingId] = slotsBookings + delta;
 
         await bookingCountsDocRef.set(data, { merge: true });
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -332,7 +370,7 @@ export const createAttendanceForBooking = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -385,8 +423,8 @@ export const createAttendanceForBooking = functions
         await attendanceRef.set(updatedEntry, {
           mergeFields: [`attendances.${customerId}`],
         });
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -435,14 +473,14 @@ export const registerCreatedOrgSecret = functions
         const smtpConfig = ["smtpHost", "smtpPort", "smtpUser", "smtpPass"];
 
         const smtpConfigured = smtpConfig.every((element) =>
-          updatedSecrets.includes(element)
+          updatedSecrets.includes(element),
         );
         await organizationRef.set(
           { existingSecrets: updatedSecrets, smtpConfigured },
-          { merge: true }
+          { merge: true },
         );
-      }
-    )
+      },
+    ),
   );
 
 export const createPublicOrgInfo = functions
@@ -479,11 +517,11 @@ export const createPublicOrgInfo = functions
         ].reduce(
           (acc, curr) =>
             orgData[curr] ? { ...acc, [curr]: orgData[curr] } : acc,
-          {}
+          {},
         );
         await publicOrgInfoDocRef.set(updates, { merge: true });
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -499,7 +537,7 @@ export const createAttendedSlotOnAttendance = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Attendance}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Attendance}/{slotId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -589,12 +627,12 @@ export const createAttendedSlotOnAttendance = functions
             // Finally, if interval doesn't exist, we're deleting the attended slot
             batch.delete(attendedSlotRef);
             return;
-          })
+          }),
         );
 
         await batch.commit();
-      }
-    )
+      },
+    ),
   );
 
 export const createCustomerStats = functions
@@ -603,7 +641,7 @@ export const createCustomerStats = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -659,6 +697,6 @@ export const createCustomerStats = functions
           .collection(OrgSubCollection.Customers)
           .doc(customerId)
           .set({ bookingStats: stats }, { merge: true });
-      }
-    )
+      },
+    ),
   );

--- a/packages/functions/src/dataTriggers.ts
+++ b/packages/functions/src/dataTriggers.ts
@@ -38,13 +38,13 @@ export const addIdToSlot = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`,
   )
   .onCreate(
     wrapFirestoreOnCreateHandler("addIdToSlot", async ({ ref }, context) => {
       const { slotId } = context.params as Record<string, string>;
       ref.update({ id: slotId });
-    })
+    }),
   );
 
 /**
@@ -61,7 +61,7 @@ export const addCustomerIdAndSecretKey = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Customers}/{customerId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Customers}/{customerId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -98,7 +98,7 @@ export const addCustomerIdAndSecretKey = functions
               id: customerId,
               secretKey,
             } as Pick<Customer, "id" | "secretKey">,
-            { merge: true }
+            { merge: true },
           );
         }
 
@@ -111,12 +111,12 @@ export const addCustomerIdAndSecretKey = functions
         // create/update booking entry
         batch.set(
           orgRef.collection(OrgSubCollection.Bookings).doc(secretKey),
-          customer
+          customer,
         );
 
         await batch.commit();
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -132,7 +132,7 @@ export const triggerAttendanceEntryForSlot = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -175,8 +175,8 @@ export const triggerAttendanceEntryForSlot = functions
             // exit if slot was just updated
             return;
         }
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -191,7 +191,7 @@ export const aggregateSlots = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Slots}/{slotId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler("aggregateSlots", async (change, context) => {
@@ -240,14 +240,14 @@ export const aggregateSlots = functions
               ...acc,
               [intervalString]: deleteSentinel,
             }),
-            {} as Record<string, typeof deleteSentinel>
+            {} as Record<string, typeof deleteSentinel>,
           );
           const updatedIntervals = Object.keys(newIntervals).reduce(
             (acc, intervalString) => ({
               ...acc,
               [intervalString]: newIntervals[intervalString],
             }),
-            {} as Record<string, SlotInterval>
+            {} as Record<string, SlotInterval>,
           );
 
           // we're merging old intervals as delete sentinels and new intervals as they are
@@ -273,7 +273,7 @@ export const aggregateSlots = functions
       await monthSlotsRef.set({ [date]: { [id]: newSlot } }, { merge: true });
 
       return change.after;
-    })
+    }),
   );
 
 export const countSlotsBookings = functions
@@ -282,7 +282,7 @@ export const countSlotsBookings = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -309,15 +309,28 @@ export const countSlotsBookings = functions
           .collection(OrgSubCollection.SlotBookingsCounts)
           .doc(date.substring(0, 7));
 
-        const doc = await bookingCountsDocRef.get();
-        const data = doc.data() || ({} as SlotBookingsCounts);
+        // Use a transaction: the previous non-transactional read-modify-write
+        // lost updates when two bookings for the same month changed
+        // concurrently, permanently corrupting the counters that drive the
+        // "slot is full" filtering in the athlete booking view.
+        await db.runTransaction(async (tx) => {
+          const doc = await tx.get(bookingCountsDocRef);
+          const data = doc.data() || ({} as SlotBookingsCounts);
 
-        const slotsBookings = data[bookingId] || 0;
-        data[bookingId] = slotsBookings + delta;
+          const slotsBookings = data[bookingId] || 0;
+          // Floor at 0: decrements for bookings whose counter was never
+          // created (e.g. bulk deletions of legacy bookings) used to write
+          // negative counts.
+          const updatedCount = Math.max(0, slotsBookings + delta);
 
-        await bookingCountsDocRef.set(data, { merge: true });
-      }
-    )
+          tx.set(
+            bookingCountsDocRef,
+            { [bookingId]: updatedCount },
+            { merge: true },
+          );
+        });
+      },
+    ),
   );
 
 /**
@@ -332,7 +345,7 @@ export const createAttendanceForBooking = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -385,8 +398,8 @@ export const createAttendanceForBooking = functions
         await attendanceRef.set(updatedEntry, {
           mergeFields: [`attendances.${customerId}`],
         });
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -435,14 +448,14 @@ export const registerCreatedOrgSecret = functions
         const smtpConfig = ["smtpHost", "smtpPort", "smtpUser", "smtpPass"];
 
         const smtpConfigured = smtpConfig.every((element) =>
-          updatedSecrets.includes(element)
+          updatedSecrets.includes(element),
         );
         await organizationRef.set(
           { existingSecrets: updatedSecrets, smtpConfigured },
-          { merge: true }
+          { merge: true },
         );
-      }
-    )
+      },
+    ),
   );
 
 export const createPublicOrgInfo = functions
@@ -479,11 +492,11 @@ export const createPublicOrgInfo = functions
         ].reduce(
           (acc, curr) =>
             orgData[curr] ? { ...acc, [curr]: orgData[curr] } : acc,
-          {}
+          {},
         );
         await publicOrgInfoDocRef.set(updates, { merge: true });
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -499,7 +512,7 @@ export const createAttendedSlotOnAttendance = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Attendance}/{slotId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Attendance}/{slotId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -589,12 +602,12 @@ export const createAttendedSlotOnAttendance = functions
             // Finally, if interval doesn't exist, we're deleting the attended slot
             batch.delete(attendedSlotRef);
             return;
-          })
+          }),
         );
 
         await batch.commit();
-      }
-    )
+      },
+    ),
   );
 
 export const createCustomerStats = functions
@@ -603,7 +616,7 @@ export const createCustomerStats = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`
+    `${Collection.Organizations}/{organization}/${OrgSubCollection.Bookings}/{secretKey}/${BookingSubCollection.BookedSlots}/{bookingId}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler(
@@ -659,6 +672,6 @@ export const createCustomerStats = functions
           .collection(OrgSubCollection.Customers)
           .doc(customerId)
           .set({ bookingStats: stats }, { merge: true });
-      }
-    )
+      },
+    ),
   );

--- a/packages/functions/src/https.ts
+++ b/packages/functions/src/https.ts
@@ -51,7 +51,7 @@ export const finalizeBookings = functions
       if (!customerInStore.exists) {
         throw new functions.https.HttpsError(
           "not-found",
-          BookingsErrors.CustomerNotFound
+          BookingsErrors.CustomerNotFound,
         );
       }
 
@@ -61,13 +61,13 @@ export const finalizeBookings = functions
       if (secretKey !== existingSecretKey) {
         throw new functions.https.HttpsError(
           "invalid-argument",
-          BookingsErrors.SecretKeyMismatch
+          BookingsErrors.SecretKeyMismatch,
         );
       }
 
       // remove `extendedDate`
       await customerRef.set({ extendedDate: null }, { merge: true });
-    })
+    }),
   );
 
 /**
@@ -104,7 +104,7 @@ export const customerSelfUpdate = functions
         if (!customerInStore.exists) {
           throw new functions.https.HttpsError(
             "not-found",
-            BookingsErrors.CustomerNotFound
+            BookingsErrors.CustomerNotFound,
           );
         }
 
@@ -114,13 +114,35 @@ export const customerSelfUpdate = functions
         if (customer.secretKey !== existingSecretKey) {
           throw new functions.https.HttpsError(
             "invalid-argument",
-            BookingsErrors.SecretKeyMismatch
+            BookingsErrors.SecretKeyMismatch,
           );
         }
 
-        await customerRef.set({ ...customer }, { merge: true });
-      }
-    )
+        // Only persist the fields a customer is allowed to self-edit
+        // (CustomerBase). Admin SDK writes bypass firestore rules, so without
+        // this whitelist an athlete could write arbitrary fields (categories,
+        // extendedDate, deleted, ...) to their own customer document.
+        const selfEditableFields = [
+          "name",
+          "surname",
+          "email",
+          "phone",
+          "birthday",
+          "certificateExpiration",
+          "photoURL",
+          "privacyPolicyAccepted",
+        ] as const;
+        const updates = selfEditableFields.reduce(
+          (acc, field) =>
+            customer[field] !== undefined
+              ? { ...acc, [field]: customer[field] }
+              : acc,
+          {} as Partial<CustomerBase>,
+        );
+
+        await customerRef.set(updates, { merge: true });
+      },
+    ),
   );
 
 /**
@@ -173,7 +195,7 @@ export const customerSelfRegister = functions
             HTTPSErrors.SelfRegInvalidCode,
             {
               registrationCode,
-            }
+            },
           );
         }
 
@@ -210,8 +232,8 @@ To verify the athlete, add them to a category/categories on their respective pro
         }
 
         return fullCustomer;
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -255,7 +277,7 @@ export const acceptPrivacyPolicy = functions
       if (!customerInStore.exists) {
         throw new functions.https.HttpsError(
           "not-found",
-          BookingsErrors.CustomerNotFound
+          BookingsErrors.CustomerNotFound,
         );
       }
 
@@ -265,14 +287,14 @@ export const acceptPrivacyPolicy = functions
       if (secretKey !== existingSecretKey) {
         throw new functions.https.HttpsError(
           "invalid-argument",
-          BookingsErrors.SecretKeyMismatch
+          BookingsErrors.SecretKeyMismatch,
         );
       }
 
       // Store the accepted privacy policy timestamp to the customer structure
       await customerRef.set(
         { privacyPolicyAccepted: { timestamp } },
-        { merge: true }
+        { merge: true },
       );
-    })
+    }),
   );

--- a/packages/functions/src/https.ts
+++ b/packages/functions/src/https.ts
@@ -51,7 +51,7 @@ export const finalizeBookings = functions
       if (!customerInStore.exists) {
         throw new functions.https.HttpsError(
           "not-found",
-          BookingsErrors.CustomerNotFound
+          BookingsErrors.CustomerNotFound,
         );
       }
 
@@ -61,13 +61,13 @@ export const finalizeBookings = functions
       if (secretKey !== existingSecretKey) {
         throw new functions.https.HttpsError(
           "invalid-argument",
-          BookingsErrors.SecretKeyMismatch
+          BookingsErrors.SecretKeyMismatch,
         );
       }
 
       // remove `extendedDate`
       await customerRef.set({ extendedDate: null }, { merge: true });
-    })
+    }),
   );
 
 /**
@@ -104,7 +104,7 @@ export const customerSelfUpdate = functions
         if (!customerInStore.exists) {
           throw new functions.https.HttpsError(
             "not-found",
-            BookingsErrors.CustomerNotFound
+            BookingsErrors.CustomerNotFound,
           );
         }
 
@@ -114,13 +114,13 @@ export const customerSelfUpdate = functions
         if (customer.secretKey !== existingSecretKey) {
           throw new functions.https.HttpsError(
             "invalid-argument",
-            BookingsErrors.SecretKeyMismatch
+            BookingsErrors.SecretKeyMismatch,
           );
         }
 
         await customerRef.set({ ...customer }, { merge: true });
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -166,14 +166,19 @@ export const customerSelfRegister = functions
         const orgDoc = await orgRef.get();
         const orgData = orgDoc.data() as OrganizationData;
 
-        functions.logger.log({ orgData });
+        // Log only non-sensitive flags: this is an unauthenticated endpoint and
+        // the full org doc contains the registration code, admin emails, etc.
+        functions.logger.log({
+          smtpConfigured: Boolean(orgData.smtpConfigured),
+          hasRegistrationCode: Boolean(orgData.registrationCode),
+        });
         if (!checkExpected(registrationCode, orgData.registrationCode || "")) {
           throw new EisbukHttpsError(
             "unauthenticated",
             HTTPSErrors.SelfRegInvalidCode,
             {
               registrationCode,
-            }
+            },
           );
         }
 
@@ -210,8 +215,8 @@ To verify the athlete, add them to a category/categories on their respective pro
         }
 
         return fullCustomer;
-      }
-    )
+      },
+    ),
   );
 
 /**
@@ -255,7 +260,7 @@ export const acceptPrivacyPolicy = functions
       if (!customerInStore.exists) {
         throw new functions.https.HttpsError(
           "not-found",
-          BookingsErrors.CustomerNotFound
+          BookingsErrors.CustomerNotFound,
         );
       }
 
@@ -265,14 +270,14 @@ export const acceptPrivacyPolicy = functions
       if (secretKey !== existingSecretKey) {
         throw new functions.https.HttpsError(
           "invalid-argument",
-          BookingsErrors.SecretKeyMismatch
+          BookingsErrors.SecretKeyMismatch,
         );
       }
 
       // Store the accepted privacy policy timestamp to the customer structure
       await customerRef.set(
         { privacyPolicyAccepted: { timestamp } },
-        { merge: true }
+        { merge: true },
       );
-    })
+    }),
   );

--- a/packages/functions/src/sendSMS/deliver.ts
+++ b/packages/functions/src/sendSMS/deliver.ts
@@ -41,12 +41,15 @@ export const deliverSMS = functions
   })
   .region(__functionsZone__)
   .firestore.document(
-    `${Collection.DeliveryQueues}/{organization}/${DeliveryQueue.SMSQueue}/{sms}`
+    `${Collection.DeliveryQueues}/{organization}/${DeliveryQueue.SMSQueue}/{sms}`,
   )
   .onWrite(
     wrapFirestoreOnWriteHandler("deliverSMS", (change, { params }) =>
       processDelivery(change, async ({ success, error }) => {
-        const { organization } = params as { organization: string };
+        const { organization, sms: smsId } = params as {
+          organization: string;
+          sms: string;
+        };
 
         // Get current SMS payload
         const {
@@ -74,7 +77,7 @@ export const deliverSMS = functions
         const { proto, ...options } = createSMSReqOptions(
           "POST",
           __smsUrl__,
-          authToken
+          authToken,
         );
 
         // Construct and validate SMS data
@@ -82,7 +85,7 @@ export const deliverSMS = functions
           message,
           sender: smsFrom,
           recipients: [{ msisdn: to }],
-          callback_url: getSMSCallbackUrl(),
+          callback_url: getSMSCallbackUrl(organization, smsId),
         });
         if (errs) {
           return error(errs);
@@ -106,6 +109,6 @@ export const deliverSMS = functions
             "Error occurred while trying to send SMS, check the function logs for more info.",
           ]);
         }
-      })
-    )
+      }),
+    ),
   );

--- a/packages/functions/src/sendSMS/https.ts
+++ b/packages/functions/src/sendSMS/https.ts
@@ -33,7 +33,7 @@ export const sendSMS = functions
         ClientMessageMethod.SMS,
         Exclude<ClientMessageType, ClientMessageType.SendCalendarFile>
       >,
-      { auth }
+      { auth },
     ) => {
       const { organization } = payload;
 
@@ -68,7 +68,7 @@ export const sendSMS = functions
       const deliveryDoc = admin
         .firestore()
         .collection(
-          `${Collection.DeliveryQueues}/${organization}/${DeliveryQueue.SMSQueue}`
+          `${Collection.DeliveryQueues}/${organization}/${DeliveryQueue.SMSQueue}`,
         )
         .doc();
       await deliveryDoc.set({ payload: smsPayload });
@@ -79,7 +79,7 @@ export const sendSMS = functions
         success: true,
         deliveryDocumentPath: deliveryDoc.path,
       };
-    }
+    },
   );
 
 /**
@@ -92,21 +92,28 @@ export const updateSMSStatus = functions
   .region(__functionsZone__)
   .https.onRequest(async (req, res) => {
     functions.logger.log(
-      "Received a SMS delivery status update from GatewayAPI, processing..."
+      "Received a SMS delivery status update from GatewayAPI, processing...",
     );
 
     // This id is the id of the firestore document for a process delivery
-    // rather than the GatewayAPI assigned SMS id
-    const params = (req.params as { id: string; organization: string }) || {};
-    const { id, organization } = params;
+    // rather than the GatewayAPI assigned SMS id.
+    // The values are sent as query string params (see `getSMSCallbackUrl`),
+    // so they're found on `req.query` (`req.params` only carries route params,
+    // which this endpoint doesn't have).
+    const { id, organization } =
+      (req.query as {
+        id?: string;
+        organization?: string;
+      }) || {};
     if (!id || !organization) {
       functions.logger.log("GatewayAPI request missing query params", {
-        params,
+        query: req.query,
       });
       // This is an error on GatewayAPI side
       // Return 'Bad Request' so that the request is retried
       res.writeHead(400);
       res.end();
+      return;
     }
 
     const { status } = (req.body as SMSStatusPayload) || {};
@@ -115,19 +122,20 @@ export const updateSMSStatus = functions
       functions.logger.log("No status received with GatewayAPI update");
       res.writeHead(400);
       res.end();
+      return;
     }
 
     // Store the status in the appropriate process document
     await admin
       .firestore()
       .doc(
-        `${Collection.DeliveryQueues}/${organization}/${DeliveryQueue.SMSQueue}/${id}`
+        `${Collection.DeliveryQueues}/${organization}/${DeliveryQueue.SMSQueue}/${id}`,
       )
       .set(
         { delivery: { meta: { status } } },
         {
           merge: true,
-        }
+        },
       );
 
     res.writeHead(200);

--- a/packages/functions/src/sendSMS/utils.ts
+++ b/packages/functions/src/sendSMS/utils.ts
@@ -23,7 +23,7 @@ import {
  * Validate client email payload accepts an email payload and applies the correct validation for an email type.
  */
 export const validateSMSPayload = <T extends SMSMessageType>(
-  payload: ClientMessagePayload<ClientMessageMethod.SMS, T>
+  payload: ClientMessagePayload<ClientMessageMethod.SMS, T>,
 ) => {
   // Check that the type has been provided and is a supported email type
   if (
@@ -50,7 +50,7 @@ export const validateSMSPayload = <T extends SMSMessageType>(
   const [res, errors] = validateJSON(
     validationSchemaLookup[payload.type] as ValidationSchemaLookup[T],
     payload,
-    "Constructing the email gave following errors (check the email payload and organization preferences):"
+    "Constructing the email gave following errors (check the email payload and organization preferences):",
   );
 
   if (errors !== null) {
@@ -70,7 +70,7 @@ export const validateSMSPayload = <T extends SMSMessageType>(
 export const createSMSReqOptions = (
   method: "GET" | "POST",
   url: string,
-  token: string
+  token: string,
 ): http.RequestOptions & { proto: "http" | "https" } => {
   let proto: "http" | "https" = "https";
   let hostname = "";
@@ -110,7 +110,14 @@ export const createSMSReqOptions = (
 };
 
 /**
- * Creates an URL of and endpoint for `updateSMSSStatus` for GatewayAPI status update.
+ * Creates an URL of and endpoint for `updateSMSStatus` for GatewayAPI status update.
+ * The `id` (SMS process document id) and `organization` are sent as query params,
+ * read back by `updateSMSStatus` to locate the process document to update.
  */
-export const getSMSCallbackUrl = (): string =>
-  `https://${__functionsZone__}-${__projectId__}.cloudfunctions.net/sendSMS`;
+export const getSMSCallbackUrl = (
+  organization: string,
+  smsId: string,
+): string =>
+  `https://${__functionsZone__}-${__projectId__}.cloudfunctions.net/updateSMSStatus?id=${encodeURIComponent(
+    smsId,
+  )}&organization=${encodeURIComponent(organization)}`;

--- a/packages/shared/src/enums/errorMessages.ts
+++ b/packages/shared/src/enums/errorMessages.ts
@@ -1,7 +1,7 @@
 // #region cloudFunctions
 export enum HTTPSErrors {
   NoPayload = "No request payload provided",
-  Unauth = "Unathorized",
+  Unauth = "Unauthorized",
   TimedOut = "Function timed out",
   MissingParameter = "One or more required parameters are missing from the payload",
   EmailInvalidType = "Email type missing or invalid",
@@ -10,7 +10,7 @@ export enum HTTPSErrors {
   NoSecrets = "No secrets document found, make sure to create a secrets document for an organziation at: '/secrets/{ organization }'",
   NoSMTPConfigured = "No smtp configuration found, make sure to create a secrets document for an organziation at: '/secrets/{ organization }' with your smtp configuration",
   NoEmailConfigured = "No emailFrom found, make sure to add an emailFrom to your organziation settings",
-  SelfRegInvalidCode = "Unathorized: Invalid registration code code",
+  SelfRegInvalidCode = "Unauthorized: Invalid registration code",
 }
 
 export enum SendSMSErrors {

--- a/packages/shared/src/utils/__tests__/scrub.test.ts
+++ b/packages/shared/src/utils/__tests__/scrub.test.ts
@@ -1,0 +1,71 @@
+import { describe, test, expect } from "vitest";
+
+import { scrubPII } from "../scrub";
+
+describe("scrubPII", () => {
+  test("should replace values of PII keys at any depth with '[Filtered]'", () => {
+    const event = {
+      request: {
+        url: "https://europe-west6-project.cloudfunctions.net/customerSelfRegister",
+        data: {
+          data: {
+            organization: "test-org",
+            registrationCode: "super-secret",
+            customer: {
+              name: "Ayla",
+              surname: "Marucelli",
+              birthday: "2013-02-02",
+              email: "parent@example.com",
+              phone: "+393331111111",
+            },
+          },
+        },
+      },
+      user: { ip_address: "203.0.113.7", country: "IT" },
+    };
+
+    const scrubbed = scrubPII(event);
+
+    expect(scrubbed.request.data.data.registrationCode).toEqual("[Filtered]");
+    expect(scrubbed.request.data.data.customer).toEqual({
+      name: "[Filtered]",
+      surname: "[Filtered]",
+      birthday: "[Filtered]",
+      email: "[Filtered]",
+      phone: "[Filtered]",
+    });
+    expect(scrubbed.user.ip_address).toEqual("[Filtered]");
+    // Non-sensitive data is left intact
+    expect(scrubbed.request.url).toEqual(event.request.url);
+    expect(scrubbed.request.data.data.organization).toEqual("test-org");
+    expect(scrubbed.user.country).toEqual("IT");
+    // The input is not mutated
+    expect(event.request.data.data.customer.name).toEqual("Ayla");
+  });
+
+  test("should handle arrays, null values and custom key lists", () => {
+    const input = {
+      list: [{ email: "a@b.c", keep: 1 }, null, "plain"],
+      nothing: null,
+    };
+    expect(scrubPII(input)).toEqual({
+      list: [{ email: "[Filtered]", keep: 1 }, null, "plain"],
+      nothing: null,
+    });
+
+    expect(scrubPII({ foo: "x", bar: "y" }, ["foo"])).toEqual({
+      foo: "[Filtered]",
+      bar: "y",
+    });
+  });
+
+  test("should not choke on circular references or class instances", () => {
+    const circular: Record<string, any> = { email: "a@b.c" };
+    circular.self = circular;
+    expect(() => scrubPII(circular)).not.toThrow();
+    expect(scrubPII(circular).email).toEqual("[Filtered]");
+
+    const date = new Date(0);
+    expect(scrubPII({ created: date }).created).toBe(date);
+  });
+});

--- a/packages/shared/src/utils/__tests__/sort.test.ts
+++ b/packages/shared/src/utils/__tests__/sort.test.ts
@@ -17,7 +17,7 @@ interface ComparePeriodsTest {
 
 const comparePeriodsTableTests = (
   compareFn: (x: string, y: string) => number,
-  tests: ComparePeriodsTest[]
+  tests: ComparePeriodsTest[],
 ) => {
   tests.forEach(({ name, input, want }) => {
     test(name, () => {
@@ -47,7 +47,7 @@ interface CompareCustomerBookingsTest {
 }
 
 const compareCustomerBookingsTableTests = (
-  tests: CompareCustomerBookingsTest[]
+  tests: CompareCustomerBookingsTest[],
 ) => {
   tests.forEach(({ name, input, want }) => {
     test(name, () => {
@@ -152,6 +152,20 @@ describe("Sort utils tests", () => {
         ],
       },
     ]);
+
+    test("should not crash on entries with a missing name/surname (regression: deleted/not-yet-loaded customer)", () => {
+      // An attendance doc referencing a deleted customer yields an entry with no
+      // name/surname; this used to throw on `surname.toLowerCase()`.
+      const input = [
+        { name: "Bfoo", surname: "Bbar" },
+        {} as Pick<Customer, "name" | "surname">,
+        { name: "Afoo", surname: "Abar" },
+      ];
+      expect(() => [...input].sort(compareCustomerNames)).not.toThrow();
+      const sorted = [...input].sort(compareCustomerNames);
+      // The undefined-surname entry sorts first (treated as empty string)
+      expect(sorted.map((x) => x.surname)).toEqual([undefined, "Abar", "Bbar"]);
+    });
   });
 
   compareCustomerBookingsTableTests([

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from "./slots";
 
 export * from "./generators";
 export * from "./sort";
+export * from "./scrub";

--- a/packages/shared/src/utils/scrub.ts
+++ b/packages/shared/src/utils/scrub.ts
@@ -1,0 +1,73 @@
+/**
+ * Default list of keys considered personal/sensitive data wherever they appear
+ * in a structure: customer identity fields, contact data, secrets and message
+ * payloads (which embed customer data in free text).
+ */
+export const defaultPIIKeys = [
+  "name",
+  "surname",
+  "email",
+  "phone",
+  "birthday",
+  "certificateExpiration",
+  "photoURL",
+  "secretKey",
+  "registrationCode",
+  "password",
+  "smtpPass",
+  "smtpUser",
+  "smsAuthToken",
+  "authToken",
+  "ip_address",
+  // Email/SMS payload fields (interpolated with customer data)
+  "html",
+  "subject",
+  "to",
+  "bcc",
+  "cc",
+  "message",
+  "attachments",
+];
+
+/**
+ * Returns a deep copy of `value` with the values of all properties whose key
+ * is in `keys` (at any depth) replaced by "[Filtered]". Used to scrub personal
+ * data out of structures before handing them to third parties (e.g. Sentry
+ * error reports - athletes' data shouldn't end up in the error tracker).
+ *
+ * Non-plain values (class instances, functions) are passed through untouched,
+ * and circular references are left in place rather than followed.
+ */
+export const scrubPII = <T>(value: T, keys: string[] = defaultPIIKeys): T => {
+  const keySet = new Set(keys);
+  const seen = new WeakSet<object>();
+
+  const scrub = (node: any): any => {
+    if (node === null || typeof node !== "object") {
+      return node;
+    }
+    if (seen.has(node)) {
+      return node;
+    }
+    seen.add(node);
+
+    if (Array.isArray(node)) {
+      return node.map(scrub);
+    }
+
+    // Leave non-plain objects (Dates, class instances, ...) untouched
+    if (Object.getPrototypeOf(node) !== Object.prototype) {
+      return node;
+    }
+
+    return Object.entries(node).reduce(
+      (acc, [key, val]) => {
+        acc[key] = keySet.has(key) ? "[Filtered]" : scrub(val);
+        return acc;
+      },
+      {} as Record<string, any>,
+    );
+  };
+
+  return scrub(value);
+};

--- a/packages/shared/src/utils/sort.ts
+++ b/packages/shared/src/utils/sort.ts
@@ -23,7 +23,7 @@ export function composeCompare<T>(
 
 export function asc<C extends string | number>(): (a: C, b: C) => number;
 export function asc<C extends string | number, T>(
-  transform: (x: T) => C
+  transform: (x: T) => C,
 ): (a: T, b: T) => number;
 /** */
 export function asc<C extends string | number, T>(transform?: (x: T) => C) {
@@ -38,7 +38,7 @@ export function asc<C extends string | number, T>(transform?: (x: T) => C) {
 
 export function desc<C extends string | number>(): (a: C, b: C) => number;
 export function desc<C extends string | number, T>(
-  transform: (x: T) => C
+  transform: (x: T) => C,
 ): (a: T, b: T) => number;
 /** */
 export function desc<C extends string | number, T>(transform?: (x: T) => C) {
@@ -92,7 +92,7 @@ export const comparePeriodsEarliestFirst = composeCompare<
   // Compare (asc) by start time first
   asc(getStartTime),
   // If start times are equal, compare (desc) by end time - longer periods take precedence
-  desc(getIntervalDuration)
+  desc(getIntervalDuration),
 );
 
 /**
@@ -106,7 +106,7 @@ export const comparePeriodsLongestFirst = composeCompare<string | SlotInterval>(
   // If start times are equal, compare (desc) by end time - longer periods take precedence
   desc(getIntervalDuration),
   // Compare (asc) by start time first
-  asc(getStartTime)
+  asc(getStartTime),
 );
 
 /**
@@ -119,8 +119,11 @@ export const comparePeriodsLongestFirst = composeCompare<string | SlotInterval>(
 export const compareCustomerNames = composeCompare<
   Pick<Customer, "name" | "surname">
 >(
-  asc((x) => x.surname.toLowerCase()),
-  asc((x) => x.name.toLowerCase())
+  // Guard against entries with a missing name/surname (e.g. an attendance doc
+  // referencing a customer that was deleted/not yet loaded), which would
+  // otherwise throw on `.toLowerCase()`.
+  asc((x) => (x.surname || "").toLowerCase()),
+  asc((x) => (x.name || "").toLowerCase()),
 );
 
 /**
@@ -137,5 +140,5 @@ export const compareCustomerBookings = composeCompare<
 >(
   (a, b) =>
     comparePeriodsEarliestFirst(a.bookedInterval || "", b.bookedInterval || ""),
-  compareCustomerNames
+  compareCustomerNames,
 );

--- a/packages/ui/src/utils/__tests__/helpers.test.ts
+++ b/packages/ui/src/utils/__tests__/helpers.test.ts
@@ -47,5 +47,22 @@ describe("Test helpers", () => {
         "de P. J. N. M. de los R. C. de la S. T. R. y Picasso",
       ]);
     });
+
+    test("should not crash on missing name/surname (regression: dirty customer data crashing the avatar menu)", () => {
+      expect(() =>
+        shortName(
+          undefined as unknown as string,
+          undefined as unknown as string,
+        ),
+      ).not.toThrow();
+      expect(shortName(undefined as unknown as string, "Doe")).toEqual([
+        "",
+        "Doe",
+      ]);
+      expect(shortName("John", undefined as unknown as string)).toEqual([
+        "John",
+        "",
+      ]);
+    });
   });
 });

--- a/packages/ui/src/utils/helpers.ts
+++ b/packages/ui/src/utils/helpers.ts
@@ -1,6 +1,8 @@
-export const shortName = (name: string, surname: string) => {
-  const nameWords = name.trim().split(" ");
-  const surnameWords = surname.trim().split(" ");
+export const shortName = (name = "", surname = "") => {
+  // Guard against customers with a missing name/surname (e.g. dirty/legacy data)
+  // so the avatar menu doesn't crash on `.trim()` of undefined.
+  const nameWords = (name || "").trim().split(" ");
+  const surnameWords = (surname || "").trim().split(" ");
 
   const n = nameWords
     .map((word, i) => (i === 0 ? word : `${word[0]}.`))
@@ -11,8 +13,8 @@ export const shortName = (name: string, surname: string) => {
       i === o.length - 1
         ? word
         : surnameParticles.includes(word.toLowerCase())
-        ? word
-        : `${word[0]}.`
+          ? word
+          : `${word[0]}.`,
     )
     .join(" ");
 


### PR DESCRIPTION
Integration branch combining the 8 reviewed fix PRs (#970–#977) for tonight's production deploy. Each was green individually; this branch merges all 8, resolves the two expected conflicts, and has been verified green as a combined tree.

## Conflicts resolved (mechanical, different functions in shared files)
- `https.ts`: kept #973's `customerSelfUpdate` field whitelist alongside #975's `customerSelfRegister` hygiene.
- `dataTriggers.ts` (+ test): kept #974's `aggregateSlots`/attendance transaction rewrite alongside #977's atomic `countSlotsBookings`.

## Verified locally (CI harness, node 18 + emulator)
- `rush build` (typecheck all packages): pass
- client selectors/helpers (#970): 24 pass
- `cloudFunctions` (#973): 29 pass
- `dataTriggers` (#974+#977) + `updateSMSStatus` (#972): 23 pass, 2 skipped

Merging this closes #970–#977 as merged. Deploy to production happens by fast-forwarding the `production` branch (scheduled 20:00 Rome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)